### PR TITLE
Update install-configure-admiral.md

### DIFF
--- a/docs/setup/alpha/install-configure-admiral.md
+++ b/docs/setup/alpha/install-configure-admiral.md
@@ -16,7 +16,7 @@ This is the command we are using to instantiate Admiral:
 root@lab-vic01:~/harbor/Deploy# docker run -d -p 8282:8282 --volume /data/admiral:/var/admiral --name admiral vmware/admiral
 676c060aa2595b7d3c4758887e4cce66adfe3b7f5f56d26eb71567f0595db534
 ```
-Admiral is now running on the Linux VM and is exposed on port 8282. This is the complete URL you need to point your browser to: http://10.140.50.77:8282/uic/ (where 10.140.50.77 is the IP the Linux host it's running on). 
+Admiral is now running on the Linux VM and is exposed on port 8282. This is the complete URL you need to point your browser to: http://10.140.50.77:8282 (where 10.140.50.77 is the IP the Linux host it's running on). 
 
 Congratulations! You have just deployed Admiral successfully! 
 


### PR DESCRIPTION
The Admiral UI no longer requires /uic and is now available in the root path.