### PR TITLE
Removed quotes from configs file for Windows UI deployment.

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
@@ -15,8 +15,8 @@ You install the vSphere Client plug-ins for vSphere Integrated Containers by usi
 
 1. On the Windows system on which you have downloaded and unpacked vSphere Integrated Containers Engine, open the `\vic\ui\vCenterForWindows\configs` file in a text editor.
 3. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>SET target_vcenter_ip=<i>vcenter_server_address</i></pre>
-4. Enter the URL on which the vSphere Integrated Containers appliance publishes the client plug-in bundle. <pre>SET vic_ui_host_url="https://<i>vic_appliance_address</i>:<i>port</i>"</pre>
-6. Provide the SHA-1 thumbprint of the Web server.<pre>SET vic_ui_host_thumbprint="<i>thumbprint</i>"</pre>**NOTE**: Use colon delimitation in the thumbprint. Do not use space delimitation. 
+4. Enter the URL on which the vSphere Integrated Containers appliance publishes the client plug-in bundle. <pre>SET vic_ui_host_url=https://<i>vic_appliance_address</i>:<i>port</i></pre>
+6. Provide the SHA-1 thumbprint of the Web server.<pre>SET vic_ui_host_thumbprint=<i>thumbprint</i></pre>**NOTE**: Use colon delimitation in the thumbprint. Do not use space delimitation. 
 7. Specify the version of the plug-in to install.
   - To install the plug-in for the HTML5 vSphere Client, leave the vCenter Server version set to `6.5`.
   - To install the plug-in for the Flex-based vSphere Web Client, set the vCenter Server version to `6.0`.<pre>SET target_vc_version=6.0</pre>**NOTE**: When installing the Flex-based plug-in, you must set the version to `6.0` even if you are running vCenter Server 6.5.


### PR DESCRIPTION
Removed erroneous quotation marks from the `configs` file settings for deployment of the client plug-ins for vCenter Server on Windows.

@jooskim can you please confirm that you use quotes for VCSA but not for Windows?