### PR TITLE
It looks like non-root users are now supported.

### DIFF
--- a/docs/user_doc/vic_app_dev/container_limitations.md
+++ b/docs/user_doc/vic_app_dev/container_limitations.md
@@ -31,7 +31,6 @@ For limitations of using vSphere Integrated Containers with volumes, see [Using 
 ## Limitations of vSphere Integrated Containers Engine
 vSphere Integrated Containers Engine includes these limitations:
 
-- Container VMs only support root user.
 - If you do not configure a `PATH` environment variable, or if you create a container from an image that does not supply a `PATH`, vSphere Integrated Containers Engine provides a default `PATH`.
 - You can resolve the symbolic names of a container from within another container, except in the following cases:
 	- Aliases


### PR DESCRIPTION
While going through the list of known issues from 0.9 for the 1.1 release notes, I saw that https://github.com/vmware/vic/issues/1279 is now closed and non-root users are supported. 

@emlin can you please confirm?