### PR TITLE
Updated plug-in installation topics

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
@@ -1,6 +1,6 @@
 # Install the Client Plug-Ins on vCenter Server for Windows #
 
-You install the vSphere Client plug-ins for vSphere Integrated Containers by logging in to the Windows system on which vCenter Server runs and running a script. The script uploads files from the file server in the vSphere Integrated Containers appliance to vCenter Server.
+You install the vSphere Client plug-ins for vSphere Integrated Containers by logging in to the Windows system on which vCenter Server runs and running a script. The script registers an extension with vCenter Server, and instructs vCenter Server to download the plug-in files from the file server in the vSphere Integrated Containers appliance.
 
 - You can install the the Flex-based vSphere Web Client plug-in on vCenter Server 6.0 or 6.5.
 - You can install the the HTML5 vSphere Client plug-in on vCenter Server 6.5.
@@ -16,7 +16,7 @@ You install the vSphere Client plug-ins for vSphere Integrated Containers by log
 
 **Procedure**
 
-1. Open a command prompt and run the following command to obtain the SHA-1 thumprint of the file server that is running in the vSphere Integrated Containers appliance.<pre>echo | "%VMWARE_OPENSSL_BIN%" s_client -connect <i>vic_appliance_address</i>:9443 | "%VMWARE_OPENSSL_BIN%" x509 -fingerprint -sha1 -noout</pre>
+1. Open a command prompt as Administrator and run the following command to obtain the SHA-1 thumprint of the file server that is running in the vSphere Integrated Containers appliance.<pre>echo | "%VMWARE_OPENSSL_BIN%" s_client -connect <i>vic_appliance_address</i>:9443 | "%VMWARE_OPENSSL_BIN%" x509 -fingerprint -sha1 -noout</pre>
 2. Open the `\vic\ui\vCenterForWindows\configs` file in a text editor.<pre>notepad %USERPROFILE%\Desktop\vic\ui\vCenterForWindows\configs</pre>
 3. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>SET target_vcenter_ip=<i>vcenter_server_address</i></pre>
 4. Enter the URL of the vSphere Integrated Containers appliance file server. <pre>SET vic_ui_host_url=https://<i>vic_appliance_address</i>:9443/</pre>
@@ -28,14 +28,9 @@ You install the vSphere Client plug-ins for vSphere Integrated Containers by log
 7. To install the plug-in for the Flex-based vSphere Web Client, reopen the `configs` file and set the target version to `6.0`.<pre>SET target_vc_version=6.0</pre>
 6. Save and close the `configs` file.
 7. Run the installer again, entering the user name and password for the vCenter Server administrator account when prompted.<pre>%USERPROFILE%\Desktop\vic\ui\vCenterForWindows\install.bat</pre>
-9. When the installation finishes, stop and restart the vSphere Web Client service.
-
-   - vCenter Server 6.5: 
-   <pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vsphere-client</pre>
-   <pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --start vsphere-client</pre>
-   - vCenter Server 6.0:<pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vspherewebclientsvc</pre>
+9. When the installation finishes, stop and restart the vSphere Web Client service.<pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vspherewebclientsvc</pre>
    <pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --start vspherewebclientsvc</pre>
 
 **What to Do Next**
 
-To verify the deployment of the plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md) and [Find VCH Information in the vSphere Clients](vch_portlet_ui.md).
+To verify the deployment of the plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md), [Find VCH Information in the vSphere Clients](vch_portlet_ui.md), and [Find Container Information in the vSphere Clients](container_portlet_ui.md).

--- a/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
@@ -1,15 +1,16 @@
 # Install the Client Plug-Ins on vCenter Server for Windows #
 
-You install the vSphere Client plug-ins for vSphere Integrated Containers by using the file server that runs in the vSphere Integrated Containers appliance.
+You install the vSphere Client plug-ins for vSphere Integrated Containers by logging in to the Windows system on which vCenter Server runs and running a script. The script uploads files from the file server in the vSphere Integrated Containers appliance to vCenter Server.
 
 - You can install the the Flex-based vSphere Web Client plug-in on vCenter Server 6.0 or 6.5.
 - You can install the the HTML5 vSphere Client plug-in on vCenter Server 6.5.
 
 **Prerequisites**
 
+- The vCenter Server instance on which to install the plug-in runs on Windows. If you are running a vCenter Server appliance instance, see [Install the Client Plug-Ins on a vCenter Server Appliance](plugins_vcsa.md).
 - You deployed the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
 - Log in to the Windows system on which vCenter Server is running. You must perform all of the steps in this procedure on this Windows system.
-- Go to https://<i>vic_appliance_address</i>:9443 in a Web browser, and download the vSphere Integrated Containers Engine package, `vic_1.1.x.tar.gz`, and unpack it on the Desktop. 
+- Go to https://<i>vic_appliance_address</i>:9443 in a Web browser, download the vSphere Integrated Containers Engine package, `vic_1.1.x.tar.gz`, and unpack it on the Desktop. 
 
 **NOTE**: If the vSphere Integrated Containers appliance uses a different port for the file server, replace 9443 with the appropriate port in the prerequisites above and in the procedure below.
 
@@ -19,19 +20,22 @@ You install the vSphere Client plug-ins for vSphere Integrated Containers by usi
 2. Open the `\vic\ui\vCenterForWindows\configs` file in a text editor.<pre>notepad %USERPROFILE%\Desktop\vic\ui\vCenterForWindows\configs</pre>
 3. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>SET target_vcenter_ip=<i>vcenter_server_address</i></pre>
 4. Enter the URL of the vSphere Integrated Containers appliance file server. <pre>SET vic_ui_host_url=https://<i>vic_appliance_address</i>:9443/</pre>
-6. Copy and paste the SHA-1 thumbprint of the file server into the `\vic\ui\vCenterForWindows\configs` file.<pre>SET vic_ui_host_thumbprint=<i>thumbprint</i></pre>**NOTE**: Use colon delimitation in the thumbprint. Do not use space delimitation. 
+6. Copy the SHA-1 thumbprint of the file server that you obtained in step 1 and paste it into the `configs` file.<pre>SET vic_ui_host_thumbprint=<i>thumbprint</i></pre>**NOTE**: Use colon delimitation in the thumbprint. Do not use space delimitation. 
 7. Save the `configs` file.
-8. Run the installer, entering the user name and password for the vCenter Server administrator account when prompted.<pre>%USERPROFILE%\Desktop\vic\ui\vCenterForWindows\install.bat</pre>
-7. To also install the plug-in for the Flex-based vSphere Web Client, reopen the `\vic\ui\vCenterForWindows\configs` file and set the target version to `6.0`.<pre>SET target_vc_version=6.0</pre>
+8. Run the installer, entering the user name and password for the vCenter Server administrator account when prompted.<pre>%USERPROFILE%\Desktop\vic\ui\vCenterForWindows\install.bat</pre>This first run of the script installs the HTML5 client.
+9. When the installation finishes, stop and restart the HTML5 vSphere Client service.<pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vsphere-ui</pre>
+<pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --start vsphere-ui</pre>
+7. To install the plug-in for the Flex-based vSphere Web Client, reopen the `configs` file and set the target version to `6.0`.<pre>SET target_vc_version=6.0</pre>
 6. Save and close the `configs` file.
 7. Run the installer again, entering the user name and password for the vCenter Server administrator account when prompted.<pre>%USERPROFILE%\Desktop\vic\ui\vCenterForWindows\install.bat</pre>
-10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.
+9. When the installation finishes, stop and restart the vSphere Web Client service.
+
+   - vCenter Server 6.5: 
+   <pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vsphere-client</pre>
+   <pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --start vsphere-client</pre>
+   - vCenter Server 6.0:<pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vspherewebclientsvc</pre>
+   <pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --start vspherewebclientsvc</pre>
 
 **What to Do Next**
 
-Verify the deployment of the plug-in.
-
-- If you installed the HTML5 plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md).
-- If you installed the Flex plug-in, see [Find VCH Information in the vSphere Clients](vch_portlet_ui.md).
-
-If the vSphere Integrated Containers plug-in does not appear, restart the vSphere Client service. For instructions about how to restart the vSphere Client service, see [vSphere Integrated Containers Plug-In Does Not Appear](ts_ui_not_appearing.md).
+To verify the deployment of the plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md) and [Find VCH Information in the vSphere Clients](vch_portlet_ui.md).

--- a/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
@@ -1,6 +1,6 @@
 # Install the Client Plug-Ins on vCenter Server for Windows #
 
-You install the vSphere Client plug-ins for vSphere Integrated Containers by using the Web server that runs in the vSphere Integrated Containers appliance.
+You install the vSphere Client plug-ins for vSphere Integrated Containers by using the file server that runs in the vSphere Integrated Containers appliance.
 
 - You can install the the Flex-based vSphere Web Client plug-in on vCenter Server 6.0 or 6.5.
 - You can install the the HTML5 vSphere Client plug-in on vCenter Server 6.5.
@@ -8,21 +8,23 @@ You install the vSphere Client plug-ins for vSphere Integrated Containers by usi
 **Prerequisites**
 
 - You deployed the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
-- Open a Web browser on a Windows system, go to https://<i>vic_appliance_address</i>:9443, and download and unpack the vSphere Integrated Containers Engine package. You must use a Windows system to run the script to install the plug-in on a vCenter Server instance that runs on Windows. For example, download the package to the Windows system on which vCenter Server is running. If the vSphere Integrated Containers appliance uses a different port for the vSphere Integrated Containers Engine file server, replace 9443 with the appropriate port.
-- Copy the thumbprint of the Communications Server certificate from https://<i>vic_appliance_address</i>:<i>port</i>. For information about how to view the certificate thumbprint, see the documentation for your type of browser.
+- Log in to the Windows system on which vCenter Server is running. You must perform all of the steps in this procedure on this Windows system.
+- Go to https://<i>vic_appliance_address</i>:9443 in a Web browser, and download the vSphere Integrated Containers Engine package, `vic_1.1.x.tar.gz`, and unpack it on the Desktop. 
+
+**NOTE**: If the vSphere Integrated Containers appliance uses a different port for the file server, replace 9443 with the appropriate port in the prerequisites above and in the procedure below.
 
 **Procedure**
 
-1. On the Windows system on which you have downloaded and unpacked vSphere Integrated Containers Engine, open the `\vic\ui\vCenterForWindows\configs` file in a text editor.
+1. Open a command prompt and run the following command to obtain the SHA-1 thumprint of the file server that is running in the vSphere Integrated Containers appliance.<pre>echo | "%VMWARE_OPENSSL_BIN%" s_client -connect <i>vic_appliance_address</i>:9443 | "%VMWARE_OPENSSL_BIN%" x509 -fingerprint -sha1 -noout</pre>
+2. Open the `\vic\ui\vCenterForWindows\configs` file in a text editor.<pre>notepad %USERPROFILE%\Desktop\vic\ui\vCenterForWindows\configs</pre>
 3. Enter the IPv4 address or FQDN of the vCenter Server instance on which to install the plug-in.<pre>SET target_vcenter_ip=<i>vcenter_server_address</i></pre>
-4. Enter the URL on which the vSphere Integrated Containers appliance publishes the client plug-in bundle. <pre>SET vic_ui_host_url=https://<i>vic_appliance_address</i>:<i>port</i></pre>
-6. Provide the SHA-1 thumbprint of the Web server.<pre>SET vic_ui_host_thumbprint=<i>thumbprint</i></pre>**NOTE**: Use colon delimitation in the thumbprint. Do not use space delimitation. 
-7. Specify the version of the plug-in to install.
-  - To install the plug-in for the HTML5 vSphere Client, leave the vCenter Server version set to `6.5`.
-  - To install the plug-in for the Flex-based vSphere Web Client, set the vCenter Server version to `6.0`.<pre>SET target_vc_version=6.0</pre>**NOTE**: When installing the Flex-based plug-in, you must set the version to `6.0` even if you are running vCenter Server 6.5.
+4. Enter the URL of the vSphere Integrated Containers appliance file server. <pre>SET vic_ui_host_url=https://<i>vic_appliance_address</i>:9443/</pre>
+6. Copy and paste the SHA-1 thumbprint of the file server into the `\vic\ui\vCenterForWindows\configs` file.<pre>SET vic_ui_host_thumbprint=<i>thumbprint</i></pre>**NOTE**: Use colon delimitation in the thumbprint. Do not use space delimitation. 
+7. Save the `configs` file.
+8. Run the installer, entering the user name and password for the vCenter Server administrator account when prompted.<pre>%USERPROFILE%\Desktop\vic\ui\vCenterForWindows\install.bat</pre>
+7. To also install the plug-in for the Flex-based vSphere Web Client, reopen the `\vic\ui\vCenterForWindows\configs` file and set the target version to `6.0`.<pre>SET target_vc_version=6.0</pre>
 6. Save and close the `configs` file.
-7. Open a Windows command prompt, navigate to `\vic\ui\vCenterForWindows`, and run the installer.<pre>install.bat</pre>
-9. Enter the user name and password for the vCenter Server administrator account.
+7. Run the installer again, entering the user name and password for the vCenter Server administrator account when prompted.<pre>%USERPROFILE%\Desktop\vic\ui\vCenterForWindows\install.bat</pre>
 10. When installation finishes, if you are logged into the vSphere Web Client, log out then log back in again.
 
 **What to Do Next**

--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -1,53 +1,37 @@
 # Install the Client Plug-Ins on a vCenter Server Appliance #
 
-You install the vSphere Client plug-ins for vSphere Integrated Containers by using the Web server that runs in the vSphere Integrated Containers appliance.
+You install the vSphere Client plug-ins for vSphere Integrated Containers by logging into the vCenter Server appliance and running a script. The script uploads files from the file server in the vSphere Integrated Containers appliance to vCenter Server.
 
 - You can install the the Flex-based vSphere Web Client plug-in on vCenter Server 6.0 or 6.5.
 - You can install the the HTML5 vSphere Client plug-in on vCenter Server 6.5.
 
 **Prerequisites**
 
+- You are installing the plug-ins on a vCenter Server appliance instance. If you are running vCenter Server on Windows, see [Install the Client Plug-Ins on vCenter Server for Windows](plugins_vc_windows.md).
 - Go to the vCenter Server Appliance Management Interface (VAMI) at https://<i>vcsa_address</i>:5480, click **Access**, and make sure that Bash Shell is enabled.
 - You deployed the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
-- Go to https://<i>vic_appliance_address</i>:9443 and download and unpack the vSphere Integrated Containers Engine package. If the vSphere Integrated Containers appliance uses a different port for the vSphere Integrated Containers Engine file server, replace 9443 with the appropriate port.
-- Copy the thumbprint of the Communications Server certificate from https://<i>vic_appliance_address</i>:<i>port</i>. For information about how to view the certificate thumbprint, see the documentation for your type of browser.
+
+**NOTE**: If the vSphere Integrated Containers appliance uses a different port for the file server, replace 9443 with the appropriate port in the procedure below.
+
 
 **Procedure**
 
-1. On the system on which you have downloaded and unpacked vSphere Integrated Containers Engine, open the appropriate configuration file in a text editor.
+1. Connect as root user to the vCenter Server Appliance by using SSH.<pre>ssh root@<i>vcsa_address</i></pre>
+4. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>curl -k https://<i>vic_appliance_address</i>:9443/vic_1.1.1.tar.gz -o vic_1.1.1.tar.gz</pre>
+5. Unpack the vSphere Integrated Containers binaries.<pre>tar -zxf vic_1.1.1.tar.gz</pre>
+5. Use `sed` to set the vCenter Server address in the `/vic/ui/VCSA/configs` file.<pre>sed -i 's#^\(VCENTER_IP=\).*$#\1"<i>vic_appliance_address</i>"#' ~/vic/ui/*/configs</pre>
+6. Use `sed` to set the address of the vSphere Integrated Containers appliance file server in the `/vic/ui/VCSA/configs` file.<pre>sed -i 's#^\(VIC_UI_HOST_URL=\).*$#\1"https://<i>vic_appliance_address</i>:9443"#' ~/vic/ui/*/configs</pre>
+7. Obtain the thumbprint of the vSphere Integrated Containers appliance file server certificate.<pre>echo | openssl s_client -connect <i>vic_appliance_address</i>:9443 | openssl x509 -fingerprint -sha1 -noout</pre>
+8.  Use `sed` to set the certificate thumbprint in the `/vic/ui/VCSA/configs` file, replacing <i>thumbprint</i> with the output of the command from the preceding step.<pre>sed -i 's#^\(VIC_UI_HOST_THUMBPRINT=\).*$#\1"<i>thumbprint</i>"#' ~/vic/ui/*/configs</pre>
+9. Navigate to `/vic/ui/VCSA`, and run the installer script, entering the user name and password for the vCenter Server administrator account when prompted.<pre>cd vic/ui/VCSA</pre><pre>./install.sh</pre>This first run of the script installs the HTML5 client.
+10. When the installation finishes, stop and restart the HTML5 vSphere Client service.<pre>service-control --stop vsphere-ui</pre><pre>service-control --start vsphere-ui</pre>
+10. To install the plug-in for the Flex-based vSphere Web Client, use `sed` to set the target version to `flex`.<pre>sed -i 's#^\(PLUGIN_TYPE=\).*$#\1"flex"#' ~/vic/ui/*/configs</pre>
+11. Run the installer script, entering the user name and password for the vCenter Server administrator account when prompted.<pre>cd vic/ui/VCSA</pre><pre>./install.sh</pre>
+10. When the installation finishes, stop and restart the Flex-based vSphere Web Client service.
 
-  - For the HTML5 plug-in, open `/vic/ui/HTML5Client/configs`.
-  - For the Flex plug-in, open `/vic/ui/VCSA/configs`.
-4. Enter the IPv4 address or FQDN of the vCenter Server Appliance on which to install the plug-in. <pre>VCENTER_IP="<i>vcenter_server_address</i>"</pre>
-5. Enter the URL on which the vSphere Integrated Containers appliance publishes the client plug-in bundle. <pre>SET VIC_UI_HOST_URL="https://<i>vic_appliance_address</i>:<i>port</i>"</pre>
-6. Provide the SHA-1 thumbprint of the Web server.<pre>VIC_UI_HOST_THUMBPRINT="<i>thumbprint</i>"</pre>**NOTE**: Use colon delimitation in the thumbprint. Do not use space delimitation.
-6. Save and close the `configs` file.
-7. (Optional) If you unpacked vSphere Integrated Containers Engine on a Windows system, open  the `/vic/ui/HTML5Client/install.sh` file in a text editor and point `PLUGIN_MANAGER_BIN` to the Windows UI executable.
-
-   Before:
-     <pre>if [[ $(echo $OS | grep -i "darwin") ]] ; then
-       PLUGIN_MANAGER_BIN="../../vic-ui-darwin"
-     else
-       PLUGIN_MANAGER_BIN="../../vic-ui-linux"</pre>
-   After:
-      <pre>if [[ $(echo $OS | grep -i "darwin") ]] ; then
-       PLUGIN_MANAGER_BIN="../../vic-ui-darwin"
-      else
-       PLUGIN_MANAGER_BIN="../../vic-ui-windows"</pre>
-
-7. Open a command prompt, navigate to `/vic/ui/VCSA`, and run the installer.
-   <pre>./install.sh</pre>
-
-    Make sure that `install.sh` is executable by running `chmod` before you run it.
-  
-9. Enter the user name and password for the vCenter Server administrator account.
-10. When installation finishes, if you are logged into the vSphere Client or vSphere Web Client, log out then log back in again.
+   - vCenter Server 6.5: <pre>service-control --stop vsphere-client</pre><pre>service-control --start vsphere-client</pre>
+   - vCenter Server 6.0: <pre>service-control --stop vspherewebclientsvc</pre><pre>service-control --start vspherewebclientsvc</pre>
 
 **What to Do Next**
 
-Verify the deployment of the plug-in.
-
-- If you installed the HTML5 plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md).
-- If you installed the Flex plug-in, see [Find VCH Information in the vSphere Clients](vch_portlet_ui.md).
-
-If the vSphere Integrated Containers plug-in does not appear, restart the vSphere Client service. For instructions about how to restart the vSphere Client service, see [vSphere Integrated Containers Plug-In Does Not Appear](ts_ui_not_appearing.md).
+To verify the deployment of the plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md) and [Find VCH Information in the vSphere Clients](vch_portlet_ui.md).

--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -1,7 +1,6 @@
 # Install the Client Plug-Ins on a vCenter Server Appliance #
 
-You install the vSphere Client plug-ins for vSphere Integrated Containers by logging into the vCenter Server appliance and running a script. The script uploads files from the file server in the vSphere Integrated Containers appliance to vCenter Server.
-
+You install the vSphere Client plug-ins for vSphere Integrated Containers by logging into the vCenter Server appliance and running a script.  The script registers an extension with vCenter Server, and instructs vCenter Server to download the plug-in files from the file server in the vSphere Integrated Containers appliance.
 - You can install the the Flex-based vSphere Web Client plug-in on vCenter Server 6.0 or 6.5.
 - You can install the the HTML5 vSphere Client plug-in on vCenter Server 6.5.
 
@@ -19,19 +18,24 @@ You install the vSphere Client plug-ins for vSphere Integrated Containers by log
 1. Connect as root user to the vCenter Server Appliance by using SSH.<pre>ssh root@<i>vcsa_address</i></pre>
 4. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>curl -k https://<i>vic_appliance_address</i>:9443/vic_1.1.1.tar.gz -o vic_1.1.1.tar.gz</pre>
 5. Unpack the vSphere Integrated Containers binaries.<pre>tar -zxf vic_1.1.1.tar.gz</pre>
-5. Use `sed` to set the vCenter Server address in the `/vic/ui/VCSA/configs` file.<pre>sed -i 's#^\(VCENTER_IP=\).*$#\1"<i>vic_appliance_address</i>"#' ~/vic/ui/*/configs</pre>
-6. Use `sed` to set the address of the vSphere Integrated Containers appliance file server in the `/vic/ui/VCSA/configs` file.<pre>sed -i 's#^\(VIC_UI_HOST_URL=\).*$#\1"https://<i>vic_appliance_address</i>:9443"#' ~/vic/ui/*/configs</pre>
+5. Use a text editor to set the vCenter Server address in the `/vic/ui/VCSA/configs` file.<pre>VCENTER_IP="<i>vcsa_address</i>"</pre>
+
+   Alternatively, you can use a utility such as `sed` to update the `configs` file:<pre>sed -i 's#^\(VCENTER_IP=\).*$#\1"<i>vcsa_address</i>"#' ~/vic/ui/*/configs</pre>
+6. Set the address of the vSphere Integrated Containers appliance file server in the `/vic/ui/VCSA/configs` file.<pre>VIC_UI_HOST_URL="https://<i>vic_appliance_address</i>:9443/"</pre>
+
+   Alternatively, you can use `sed`:<pre>sed -i 's#^\(VIC_UI_HOST_URL=\).*$#\1"https://<i>vic_appliance_address</i>:9443"#' ~/vic/ui/*/configs</pre>
 7. Obtain the thumbprint of the vSphere Integrated Containers appliance file server certificate.<pre>echo | openssl s_client -connect <i>vic_appliance_address</i>:9443 | openssl x509 -fingerprint -sha1 -noout</pre>
-8.  Use `sed` to set the certificate thumbprint in the `/vic/ui/VCSA/configs` file, replacing <i>thumbprint</i> with the output of the command from the preceding step.<pre>sed -i 's#^\(VIC_UI_HOST_THUMBPRINT=\).*$#\1"<i>thumbprint</i>"#' ~/vic/ui/*/configs</pre>
+8.  Set the certificate thumbprint in the `/vic/ui/VCSA/configs` file, replacing <i>thumbprint</i> with the output of the command from the preceding step.<pre>VIC_UI_HOST_THUMBPRINT="<i>thumbprint</i>"</pre>
+
+   Alternatively, you can use `sed`:<pre>sed -i 's#^\(VIC_UI_HOST_THUMBPRINT=\).*$#\1"<i>thumbprint</i>"#' ~/vic/ui/*/configs</pre>
 9. Navigate to `/vic/ui/VCSA`, and run the installer script, entering the user name and password for the vCenter Server administrator account when prompted.<pre>cd vic/ui/VCSA</pre><pre>./install.sh</pre>This first run of the script installs the HTML5 client.
 10. When the installation finishes, stop and restart the HTML5 vSphere Client service.<pre>service-control --stop vsphere-ui</pre><pre>service-control --start vsphere-ui</pre>
-10. To install the plug-in for the Flex-based vSphere Web Client, use `sed` to set the target version to `flex`.<pre>sed -i 's#^\(PLUGIN_TYPE=\).*$#\1"flex"#' ~/vic/ui/*/configs</pre>
-11. Run the installer script, entering the user name and password for the vCenter Server administrator account when prompted.<pre>cd vic/ui/VCSA</pre><pre>./install.sh</pre>
-10. When the installation finishes, stop and restart the Flex-based vSphere Web Client service.
+10. To install the plug-in for the Flex-based vSphere Web Client, edit `/vic/ui/VCSA/configs` again and set the plug-in type to `flex`.<pre>PLUGIN_TYPE="flex"</pre>
 
-   - vCenter Server 6.5: <pre>service-control --stop vsphere-client</pre><pre>service-control --start vsphere-client</pre>
-   - vCenter Server 6.0: <pre>service-control --stop vspherewebclientsvc</pre><pre>service-control --start vspherewebclientsvc</pre>
+   Alternatively, you can use `sed`:<pre>sed -i 's#^\(PLUGIN_TYPE=\).*$#\1"flex"#' ~/vic/ui/*/configs</pre>
+11. Run the installer script, entering the user name and password for the vCenter Server administrator account when prompted.<pre>cd vic/ui/VCSA</pre><pre>./install.sh</pre>
+10. When the installation finishes, stop and restart the Flex-based vSphere Web Client service.<pre>service-control --stop vsphere-client</pre><pre>service-control --start vsphere-client</pre>
 
 **What to Do Next**
 
-To verify the deployment of the plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md) and [Find VCH Information in the vSphere Clients](vch_portlet_ui.md).
+To verify the deployment of the plug-in, see [Access the vSphere Integrated Containers View in the HTML5 vSphere Client](access_h5_ui.md), [Find VCH Information in the vSphere Clients](vch_portlet_ui.md), and [Find Container Information in the vSphere Clients](container_portlet_ui.md).

--- a/docs/user_doc/vic_vsphere_admin/ts_ui_not_appearing.md
+++ b/docs/user_doc/vic_vsphere_admin/ts_ui_not_appearing.md
@@ -4,41 +4,37 @@ After you have installed either of the HTML5 or Flex-based plug-ins for vSphere 
 
 ## Problem ##
 
-The UI plug-in installer reported success, but the plug-in does not appear in the client. Logging out of the client and logging back in again does not resolve the issue.
+The UI plug-in installer reported success, but the plug-ins do not appear in the client. Logging out of the client and logging back in again does not resolve the issue.
 
 ## Cause ##
 
-- If a previous attempt at installing the vSphere Integrated Containers plug-in failed, the failed installation state is retained in the client cache.
-- You installed a new version of the vSphere Integrated Containers plug-in that has the same version number as the previous version, for example a hot patch.
+- If a previous attempt at installing the vSphere Integrated Containers plug-ins failed, the failed installation state is retained in the client cache.
+- You installed a new version of the vSphere Integrated Containers plug-ins that has the same version number as the previous version, for example a hot patch.
 
 ## Solution ##
 
 Restart the client service.
 
-### Restart the HTML5 or Flex Client on vSphere 6.5 on Windows ###
+### Restart the HTML5 Client on vCenter Server on Windows ###
 
-1. Log into the Flex-based vSphere Web Client.
-2. Go to **Home** > **System Configuration** > **Services**.
-3. Select the service for either the HTML5 or Flex client:
+1. Log into the Windows system on which vCenter Server is running.
+2. Open a command prompt as Administrator.
+3. Use the `service-control` command-line utility to stop and then restart the vSphere Client service.<pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vsphere-ui</pre><pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --start vsphere-ui</pre>
 
-   - HTML5: **VMware vSphere Client**.
-   - Flex: **VMware vSphere Web Client**
-3. Click the **Restart** button.
+### Restart the Flex Client on vCenter Server on Windows ###
 
-### Restart the Flex Client on vCenter Server 6.0 on Windows ###
+1. Log into the Windows system on which vCenter Server is running.
+2. Open a command prompt as Administrator.
+3. Use the `service-control` command-line utility to stop and then restart the vSphere Client service.<pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --stop vspherewebclientsvc</pre><pre>"C:\Program Files\VMware\vCenter Server\bin\service-control" --start vspherewebclientsvc</pre>
 
-1. Open Server Manager on the Windows system on which vCenter Server is running.
-2. Select **Configuration** > **Services**.
-3. Select **VMware vSphere Web Client** and click **Restart**.
+### Restart the HTML5 Client on a vCenter Server Appliance ###
+
+1. Use SSH to log in to the vCenter Server Appliance as `root`.
+2. Use the `service-control` command-line utility to stop the vSphere Client service.<pre>service-control --stop vsphere-ui</pre>
+3. Restart the vSphere Client service.<pre>service-control --start vsphere-ui</pre>
 
 ### Restart the Flex Client on a vCenter Server Appliance ###
 
 1. Use SSH to log in to the vCenter Server Appliance as `root`.
-2. Stop the vSphere Web Client service by running one of the following commands.
-   - vCenter Server 6.0: <pre>service vsphere-client stop</pre>
-   - vCenter Server 6.5: <pre>service-control --stop vsphere-client</pre>
-3. Restart the vSphere Web Client service by running one of the following commands.
-   - vCenter Server 6.0:<pre>service vsphere-client start</pre>
-   - vCenter Server 6.5: <pre>service-control --start vsphere-client</pre>
-
-
+2. Use the `service-control` command-line utility to stop the vSphere Web Client service.<pre>service vsphere-client stop</pre>
+3. Restart the vSphere Web Client service.<pre>service-control --start vsphere-client</pre>


### PR DESCRIPTION
Fixes https://github.com/vmware/vic-product/issues/180. 

I have completely rewritten the procedures for installing the client plug-ins based on @jooskim 's reworking of the process and on feedback from @dbarkelew  and @vmwarelab. 

Note that while I have tested these procedures to the point at which registration of the extensions succeeds and the extensions appear in the MOB for the VC (both Windows VC and VCSA), I am still unable to see the plug-ins in either client. The files are simply not uploading to either my VCSA or my Windows-based VC. 

But, pending me getting my hands on the final build for 1.1.1, can I please ask the 3 of you to review the steps as I have documented them so far? @mhagen-vmware can you also please run through the steps to see if you can get them to work? 

Thanks all!