### PR TITLE
Added instruction to use colon-delimitation in thumbprint everywhere.

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/common_vic_options.md
+++ b/docs/user_doc/vic_vsphere_admin/common_vic_options.md
@@ -49,7 +49,9 @@ Short name: None
 
 The thumbprint of the vCenter Server or ESXi host certificate. Specify this option if your vSphere environment uses untrusted, self-signed certificates. Alternatively, specifying the `--force` option allows you to omit the `--thumbprint` option. If your vSphere environment uses trusted certificates that are signed by a known Certificate Authority (CA), you do not need to specify the `--thumbprint` option.
 
-To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine` without the specifying the `--thumbprint` or `--force` options. The operation fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run `vic-machine` again, including the `thumbprint` option. If you obtain the thumbprint by other means, use upper-case letters and colon delimitation rather than space delimitation when you specify `--thumbprint`.
+To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine` without the specifying the `--thumbprint` or `--force` options. The operation fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run `vic-machine` again, including the `thumbprint` option. 
+
+**NOTE**: If you obtain the thumbprint by other means, use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
 
 <pre>--thumbprint <i>certificate_thumbprint</i></pre>
 

--- a/docs/user_doc/vic_vsphere_admin/inspect_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/inspect_vch.md
@@ -20,7 +20,9 @@ You have deployed a VCH.
   - If multiple compute resources exist in the datacenter, you must specify the `--compute-resource` or `--id` option.
   - If your vSphere environment uses untrusted, self-signed certificates, you must also specify the thumbprint of the vCenter Server instance or ESXi host in the `--thumbprint` option. To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine` without the specifying the `--thumbprint` option. The inspection of the VCH fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run `vic-machine` again, including the `--thumbprint` option.
 
-     <pre>$ vic-machine-<i>operating_system</i> inspect
+     **NOTE**: If you obtain the thumbprint by other means, use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
+
+  <pre>$ vic-machine-<i>operating_system</i> inspect
     --target <i>vcenter_server_username</i>:<i>password</i>@<i>vcenter_server_address</i>
     --thumbprint <i>certificate_thumbprint</i>
     --name <i>vch_name</i></pre>

--- a/docs/user_doc/vic_vsphere_admin/list_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/list_vch.md
@@ -22,7 +22,9 @@ You have deployed a VCH. If you have not deployed a VCH, `vic-machine ls` return
    - You must specify the username and optionally the password, either in the `--target` option or separately in the `--user` and `--password` options. 
    - If your vSphere environment uses untrusted, self-signed certificates, you must also specify the thumbprint of the vCenter Server instance or ESXi host in the `--thumbprint` option. To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine` without the specifying the `--thumbprint` option. The listing of the VCHs fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run `vic-machine` again, including the `--thumbprint` option.
 
-    <pre>$ vic-machine-<i>operating_system</i> ls
+    **NOTE**: If you obtain the thumbprint by other means, use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
+
+  <pre>$ vic-machine-<i>operating_system</i> ls
 --target <i>esxi_host_address</i>
 --user root
 --password <i>esxi_host_password</i>

--- a/docs/user_doc/vic_vsphere_admin/open_ports_on_hosts.md
+++ b/docs/user_doc/vic_vsphere_admin/open_ports_on_hosts.md
@@ -44,5 +44,7 @@ The `vic-machine update firewall` command in these examples specifies the follow
 - The address of the vCenter Server instance and datacenter, or the ESXi host, on which to deploy the VCH in the `--target` option.  
 - The user name and password for the vCenter Server instance or ESXi host in the `--user` and `--password` options. 
 - In the case of a vCenter Server cluster, the name of the cluster in the `--compute-resource` option.
-- The thumbprint of the vCenter Server or ESXi host certificate in the `--thumbprint` option, if they use untrusted, self-signed certificates.
+- The thumbprint of the vCenter Server or ESXi host certificate in the `--thumbprint` option, if they use untrusted, self-signed certificates. 
+
+     **NOTE**: Use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
 - The `--allow` option to open the port.

--- a/docs/user_doc/vic_vsphere_admin/remove_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/remove_vch.md
@@ -22,7 +22,9 @@ You have deployed a VCH that you no longer require.
   - If multiple compute resources exist in the datacenter, you must specify the `--compute-resource` or `--id` option.
   - If your vSphere environment uses untrusted, self-signed certificates, you must also specify the thumbprint of the vCenter Server instance or ESXi host in the `--thumbprint` option. To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine` without the specifying the `--thumbprint` or `--force` options. The deletion of the VCH fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run `vic-machine` again, including the `--thumbprint` option.
 
-   <pre>$ vic-machine-<i>operating_system</i> delete
+    **NOTE**: If you obtain the thumbprint by other means, use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
+
+  <pre>$ vic-machine-<i>operating_system</i> delete
 --target <i>vcenter_server_username</i>:<i>password</i>@<i>vcenter_server_address</i>
 --thumbprint <i>certificate_thumbprint</i>
 --name <i>vch_name</i></pre>

--- a/docs/user_doc/vic_vsphere_admin/ts_thumbprint_error.md
+++ b/docs/user_doc/vic_vsphere_admin/ts_thumbprint_error.md
@@ -26,3 +26,5 @@ If the CA should not be generally trusted, or the certificate is self-signed:
     **WARNING:** A thumbprint mismatch could mean the server you have connected to is not the intended target and might have be spoofed.
     2. Validate that the change in server certificate is legitimate
     3. Re-run `vic-machine create`, specifying the new thumbprint in the `--thumbprint` option.
+
+       **NOTE**: Use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.

--- a/docs/user_doc/vic_vsphere_admin/upgrade_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/upgrade_vch.md
@@ -31,6 +31,8 @@ For descriptions of the options that `vic-machine upgrade` includes in addition 
   - If multiple compute resources exist in the datacenter, you must specify the `--compute-resource` or `--id` option. 
   - If your vSphere environment uses untrusted, self-signed certificates, you must also specify the thumbprint of the vCenter Server instance or ESXi host in the `--thumbprint` option. To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine` without the specifying the `--thumbprint` or `--force` options. The upgrade of the VCH fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run `vic-machine` again, including the `--thumbprint` option.
 
+     **NOTE**: If you obtain the thumbprint by other means, use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
+
      <pre>$ vic-machine-<i>operating_system</i> upgrade
 --target <i>vcenter_server_username</i>:<i>password</i>@<i>vcenter_server_address</i>
 --thumbprint <i>certificate_thumbprint</i>

--- a/docs/user_doc/vic_vsphere_admin/vch_installer_options.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_installer_options.md
@@ -110,7 +110,9 @@ The thumbprint of the vCenter Server or ESXi host certificate. Specify this opti
 
 **NOTE** If your vSphere environment uses untrusted, self-signed certificates, you can run `vic-machine create` without the `--thumbprint` option by using the `--force` option. However, running `vic-machine create` with the `--force` option rather than providing the certificate thumbprint is not recommended, because it permits man-in-the-middle attacks to go undetected.
 
-To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine create` without the specifying the `--thumbprint` or `--force` options. The deployment of the VCH fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run vic-machine create again, including the `--thumbprint` option. If you obtain the thumbprint by other means, use upper-case letters and colon delimitation rather than space delimitation when you specify `--thumbprint`.
+To obtain the thumbprint of the vCenter Server or ESXi host certificate, run `vic-machine create` without the specifying the `--thumbprint` or `--force` options. The deployment of the VCH fails, but the resulting error message includes the required certificate thumbprint. You can copy the thumbprint from the error message and run vic-machine create again, including the `--thumbprint` option. 
+
+**NOTE**: If you obtain the thumbprint by other means, use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
 
 <pre>--thumbprint <i>certificate_thumbprint</i></pre>
 

--- a/docs/user_doc/vic_vsphere_admin/vch_shell_access.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_shell_access.md
@@ -18,7 +18,7 @@ You deployed a VCH.
       
        The credentials that you provide must have the following privilege on the endpoint VM:<pre>Virtual machine.Guest Operations.Guest Operation Program Execution</pre>
     - Specify the ID or name of the VCH to debug.
-    - Potentially provide the thumbprint of the vCenter Server or ESXi host certificate.
+    - Potentially provide the thumbprint of the vCenter Server or ESXi host certificate. Use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
     - Provide a password for the root user on the VCH endpoint VM by specifying the `--rootpw` option. Wrap the password in single quotes (Linux or Mac OS) or double quotes (Windows) if it includes shell characters such as `$`, `!` or `%`.
 
     <pre>$ vic-machine-<i>operating_system</i> debug

--- a/docs/user_doc/vic_vsphere_admin/vch_ssh_access.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_ssh_access.md
@@ -19,7 +19,7 @@ You deployed a VCH.
       
        The credentials that you provide must have the following privilege on the endpoint VM:<pre>Virtual machine.Guest Operations.Guest Operation Program Execution</pre>
    - Specify the ID or name of the VCH to debug.
-   - Potentially provide the thumbprint of the vCenter Server or ESXi host certificate.
+   - Potentially provide the thumbprint of the vCenter Server or ESXi host certificate. Use upper-case letters and colon delimitation in the thumbprint. Do not use space delimitation.
    - Specify the `--rootpw` option. Wrap the password in single quotes (Linux or Mac OS) or double quotes (Windows) if it includes shell characters such as `$`, `!` or `%`.
    - Authorize SSH access by specifying `--enable-ssh`.
    - Optionally, specify the `--authorized-key` option to upload a public key file to `/root/.ssh/authorized_keys` folder in the endpoint VM. Include the name of the `*.pub` file in the path.


### PR DESCRIPTION
Per title, following comment from @alextopuzov that this was not mentioned consistently.