### PR TITLE
Changed "printable" to "download" for PDF links.

### DIFF
--- a/docs/user_doc/SUMMARY.md
+++ b/docs/user_doc/SUMMARY.md
@@ -132,4 +132,4 @@
 
 
 * [Send Doc Feedback](vic_vsphere_admin/feedback.md)
-* [Printable PDFs](pdf.md)
+* [Download PDF](pdf.md)

--- a/docs/user_doc/pdf.md
+++ b/docs/user_doc/pdf.md
@@ -1,4 +1,4 @@
-# Printable PDF Documentation #
+# Download PDF Documentation #
 
 - <a href="./pdf/vic_11_vsphere_admin.pdf" target="_blank">vSphere Integrated Containers for vSphere Administrators</a>
 - <a href="./pdf/vic_11_dev_ops.pdf" target="_blank">vSphere Integrated Containers for Dev Ops Administrators</a>


### PR DESCRIPTION
In relation to https://github.com/vmware/vic/issues/5459, changed "Printable PDFs" to "Download PDF", to be more tree-friendly.