### PR TITLE
Disable ci for ova builds

### DIFF
--- a/.drone.ova.yml
+++ b/.drone.ova.yml
@@ -10,7 +10,7 @@
 # The secrets file is in our local git repo.  Ask mhagen for access.
 ---
 clone:
-  path: github.com/vmware/vic
+  path: github.com/vmware/vic-product
   tags: true
 
 build:
@@ -29,4 +29,5 @@ build:
       BUILD_ADMIRAL_REVISION: v1.1.0
       BUILD_VICENGINE_REVISION: 1.1.0
     commands:
-      - make ova-release
+      - echo 'TODO: Enable ova-relase'
+#      - make ova-release

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -30,10 +30,9 @@ PHOTON_ISO := https://storage.googleapis.com/vic-product-ova-build-deps/photon-1
 PHOTON_ISO_SHA1SUM := c4c6cb94c261b162e7dac60fdffa96ddb5836d66
 
 BIN ?= bin
-GVT ?= $(GOPATH)/bin/gvt$(BIN_ARCH)
 
 export GOPATH ?= $(shell echo $(CURDIR) | sed -e 's,/src/.*,,')
-
+GVT ?= $(GOPATH)/bin/gvt$(BIN_ARCH)
 
 .PHONY: ova-release ova-debug vagrant-local
 

--- a/installer/Makefile
+++ b/installer/Makefile
@@ -23,6 +23,7 @@ RM ?= rm
 CP ?= cp
 
 VER :=$(shell git describe --abbrev=0 --tags)
+REV :=$(shell git rev-parse --short=8 HEAD)
 
 BASE_DIR := $(dir $(abspath $(lastword $(MAKEFILE_LIST))))
 


### PR DESCRIPTION
Disabled drone builds for the ci temporarily. 
Fixed gopath order in Makefile.