### PR TITLE
Updated "edit this file" link to point to 1.1 branch.

### DIFF
--- a/docs/user_doc/book.json
+++ b/docs/user_doc/book.json
@@ -5,7 +5,7 @@
         "plugins": ["expandable-chapters", "edit-link"],
         "pluginsConfig": {
             "edit-link": {
-                "base": "https://github.com/vmware/vic-product/tree/master/docs/user_doc",
+                "base": "https://github.com/vmware/vic-product/blob/1.1-docs/docs/user_doc/",
                 "label": "Edit this Page"
             }
         },


### PR DESCRIPTION
Fixes https://github.com/vmware/vic-product/issues/305.

If you click the EDIT THIS PAGE link in any page in the HTML 1.1 docs, you are taken to the corresponding Markdown file in the `1.1-docs` branch of `vic-product`, rather than to `master`. This will prevent anyone from making 1.1-specific update in the 1.2 docs-in-progress.