### PR TITLE
Run PSC register command during OVA init

### DIFF
--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -119,7 +119,7 @@ func main() {
 
 	// attach root index route
 	mux.Handle("/", http.HandlerFunc(indexHandler))
-	
+
 	// start the web server
 	t := &tls.Config{}
 	t.Certificates = []tls.Certificate{c.cert}
@@ -171,7 +171,8 @@ func renderTemplate(resp http.ResponseWriter, filename string, data interface{})
 	}
 }
 
-// error messages from each services is concatenated, return "" if no errors.
+// startInitializationServices performs some OVA init tasks - tagging the OVA VM
+// registering Admiral with PSC. Errors, if any, are concatenated and returned.
 func startInitializationServices() string {
 	var errorMsg []string
 
@@ -179,6 +180,11 @@ func startInitializationServices() string {
 	if err := tagvm.Run(ctx, admin.Validator.Session); err != nil {
 		log.Debug(errors.ErrorStack(err))
 		errorMsg = append(errorMsg, "Failed to locate productVM, trusted content is not available")
+	}
+
+	if err := registerWithPSC(ctx); err != nil {
+		log.Debug(errors.ErrorStack(err))
+		errorMsg = append(errorMsg, "Failed to register with PSC: %s", err.Error())
 	}
 
 	return strings.Join(errorMsg, "\n")

--- a/installer/fileserver/tasks.go
+++ b/installer/fileserver/tasks.go
@@ -1,0 +1,103 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"strings"
+
+	log "github.com/sirupsen/logrus"
+
+	"github.com/vmware/vic-product/installer/lib"
+	"github.com/vmware/vic-product/installer/pkg/ip"
+	"github.com/vmware/vic/pkg/vsphere/optmanager"
+)
+
+const (
+	pscBinaryPath    = "/etc/vmware/admiral/admiral-auth-psc-1.2.0-SNAPSHOT-command.jar"
+	vcHostnameOption = "config.vpxd.hostnameUrl"
+	pscConfDir       = "/etc/vmware/psc"
+)
+
+// registerWithPSC runs the PSC register command to register VIC services with
+// the platforms services controller. The command generates a config file and
+// certificates to use while getting and renewing tokens.
+func registerWithPSC(ctx context.Context) error {
+	var err error
+
+	session := admin.Validator.Session
+	version := session.ServiceContent.About.Version
+	versionFields := strings.Split(version, ".")
+	if len(versionFields) > 2 {
+		// Set version in required format (x.y)
+		version = versionFields[0] + "." + versionFields[1]
+	}
+
+	// Obtain the admin user's domain
+	domain := "vsphere.local"
+	userFields := strings.SplitN(admin.User, "@", 2)
+	if len(userFields) == 2 {
+		domain = userFields[1]
+	}
+
+	// Obtain the hostname of the vCenter host
+	vcHostname, err := optmanager.QueryOptionValue(ctx, session, vcHostnameOption)
+	if err != nil {
+		return err
+	}
+
+	// Obtain the OVA VM's IP
+	vmIP, err := ip.FirstIPv4(ip.Eth0Interface)
+	if err != nil {
+		return err
+	}
+
+	// Fetch the OVF env to get the Admiral port
+	ovf, err := lib.UnmarshaledOvfEnv()
+	if err != nil {
+		return err
+	}
+	admiralPort := ovf.Properties["management_portal.port"]
+
+	log.Infof("version: %s", version)
+	log.Infof("tenant: %s", domain)
+	log.Infof("vcHostName: %s", vcHostname)
+	log.Infof("vmIP: %s", vmIP.String())
+	log.Infof("admiralPort: %s", admiralPort)
+
+	cmdName := "java"
+	cmdArgs := []string{
+		"-jar",
+		pscBinaryPath,
+		"--command=register",
+		"--clientName=admiral",
+		"--version=" + version,
+		"--tenant=" + domain,
+		"--domainController=" + vcHostname,
+		"--username=" + admin.User,
+		"--password=" + admin.Password,
+		"--admiralUrl=" + fmt.Sprintf("https://%s:%s", vmIP.String(), admiralPort),
+		"--configDir=" + pscConfDir,
+	}
+	cmd := exec.Command(cmdName, cmdArgs...)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		log.Infof("Error running PSC register command: %s", string(output))
+		return err
+	}
+
+	return nil
+}

--- a/installer/lib/login.go
+++ b/installer/lib/login.go
@@ -1,3 +1,17 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package lib
 
 import (
@@ -6,16 +20,16 @@ import (
 
 	log "github.com/sirupsen/logrus"
 
-	"github.com/vmware/vic/pkg/trace"
-	"github.com/vmware/vic/lib/install/validate"
 	"github.com/vmware/vic/lib/install/data"
+	"github.com/vmware/vic/lib/install/validate"
+	"github.com/vmware/vic/pkg/trace"
 )
 
 type LoginInfo struct {
-	Target          string `json:"target"`
-	User            string `json:"user"`
-	Password        string `json:"password"`
-	Validator       *validate.Validator
+	Target    string `json:"target"`
+	User      string `json:"user"`
+	Password  string `json:"password"`
+	Validator *validate.Validator
 }
 
 // Verify login based on info given, return non nil error if validation fails.
@@ -28,7 +42,7 @@ func (info *LoginInfo) VerifyLogin() error {
 	u.User = url.UserPassword(info.User, info.Password)
 	u.Host = info.Target
 	u.Path = ""
-	log.Infof("server URL: %v\n", u)
+	log.Infof("server URL: %v\n", u.Host)
 
 	input := data.NewData()
 

--- a/installer/lib/ovfenv.go
+++ b/installer/lib/ovfenv.go
@@ -1,0 +1,97 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package lib
+
+import (
+	"encoding/xml"
+	"strings"
+
+	"github.com/vmware/vmw-guestinfo/rpcvmx"
+)
+
+// EnvFetchError is returned when the ovf env cannot be fetched via RPC.
+type EnvFetchError struct {
+	msg string
+}
+
+func (e EnvFetchError) Error() string {
+	return e.msg
+}
+
+// UnmarshalError is returned when the ovf env cannot be unmarshaled.
+type UnmarshalError struct {
+	msg string
+}
+
+func (e UnmarshalError) Error() string {
+	return e.msg
+}
+
+// Environment stores guestinfo data.
+type Environment struct {
+	Properties map[string]string
+}
+
+// UnmarshaledOvfEnv returns the unmarshaled OVA environment fetched via RPC.
+func UnmarshaledOvfEnv() (Environment, error) {
+	config := rpcvmx.NewConfig()
+	// Fetch OVF Environment via RPC
+	ovfEnv, err := config.String("guestinfo.ovfEnv", "")
+	if err != nil {
+		return Environment{}, EnvFetchError{
+			msg: "unable to fetch ovf environment",
+		}
+	}
+
+	// TODO: fix this when proper support for namespaces is added to golang.
+	// ref: golang/go/issues/14407 and golang/go/issues/14407
+	ovfEnv = strings.Replace(ovfEnv, "oe:key", "key", -1)
+	ovfEnv = strings.Replace(ovfEnv, "oe:value", "value", -1)
+
+	var ovf Environment
+	err = xml.Unmarshal([]byte(ovfEnv), &ovf)
+	if err != nil {
+		return Environment{}, UnmarshalError{
+			msg: "unable to unmarshal ovf environment",
+		}
+	}
+
+	return ovf, nil
+}
+
+func (e *Environment) UnmarshalXML(d *xml.Decoder, start xml.StartElement) error {
+	type property struct {
+		Key   string `xml:"key,attr"`
+		Value string `xml:"value,attr"`
+	}
+
+	type propertySection struct {
+		Property []property `xml:"Property"`
+	}
+
+	var environment struct {
+		XMLName         xml.Name        `xml:"Environment"`
+		PropertySection propertySection `xml:"PropertySection"`
+	}
+	err := d.DecodeElement(&environment, &start)
+	if err == nil {
+		e.Properties = make(map[string]string)
+		for _, v := range environment.PropertySection.Property {
+			e.Properties[v.Key] = v.Value
+		}
+	}
+	return err
+
+}

--- a/installer/packer/scripts/package_provisioning.sh
+++ b/installer/packer/scripts/package_provisioning.sh
@@ -30,7 +30,6 @@ mkdir "/usr/lib/systemd/system/getty@tty2.service.d"
 
 # Create directory for PSC token
 mkdir -p /etc/vmware/psc/admiral
-mkdir -p /etc/vmware/psc/harbor
 
 # Create Data Dir
 mkdir /data

--- a/installer/packer/scripts/provision_admiral.sh
+++ b/installer/packer/scripts/provision_admiral.sh
@@ -14,7 +14,8 @@
 # limitations under the License.
 set -euf -o pipefail
 
-mkdir /etc/vmware/admiral
+conf_dir=/etc/vmware/admiral
+mkdir $conf_dir
 
 BUILD_ADMIRAL_REVISION="${BUILD_ADMIRAL_REVISION:-dev}"
 
@@ -36,3 +37,6 @@ echo "Pulled Admiral image"
 echo "stopping Docker .."
 systemctl stop docker
 echo "Docker stopped"
+
+# Get the PSC binary for use during initialization
+curl -o $conf_dir/admiral-auth-psc-1.2.0-SNAPSHOT-command.jar https://storage.googleapis.com/vic-product-ova-build-deps/admiral-auth-psc-1.2.0-SNAPSHOT-command.jar

--- a/installer/packer/scripts/systemd/harbor/harbor_startup.path
+++ b/installer/packer/scripts/systemd/harbor/harbor_startup.path
@@ -3,7 +3,7 @@ Description=Harbor PSC token dependency
 Documentation=https://github.com/vmware/vic-product/installer
 
 [Path]
-PathExists=/etc/vmware/psc/harbor/psc-config.properties
+PathExists=/etc/vmware/psc/admiral/psc-config.properties
 
 [Install]
 WantedBy=multi-user.target

--- a/installer/pkg/ip/ip.go
+++ b/installer/pkg/ip/ip.go
@@ -1,0 +1,50 @@
+// Copyright 2017 VMware, Inc. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package ip
+
+import (
+	"fmt"
+	"net"
+)
+
+const Eth0Interface = "eth0"
+
+// FirstIPv4 returns the IPv4 address of the input interface.
+func FirstIPv4(iFace string) (net.IP, error) {
+	iface, err := net.InterfaceByName(iFace)
+	if err != nil {
+		return nil, err
+	}
+	addrs, err := iface.Addrs()
+	if err != nil {
+		return nil, err
+	}
+
+	for _, addr := range addrs {
+		var ip net.IP
+		switch v := addr.(type) {
+		case *net.IPNet:
+			ip = v.IP
+		case *net.IPAddr:
+			ip = v.IP
+		}
+
+		if !ip.IsLoopback() && ip.To4() != nil {
+			return ip, nil
+		}
+	}
+
+	return nil, fmt.Errorf("no IP addrs found")
+}


### PR DESCRIPTION
This change runs the PSC `register` command during the OVA init step to generate the PSC-related files in `/etc/vmware/psc`. Issue vmware/vic#5551

Tested on top of https://github.com/vmware/vic-product/pull/410 - Admiral and Harbor start correctly after the token config file has been generated.