### PR TITLE
persist vic-adm_*.tar.gz to enable 'systemctl restart kov'

### DIFF
--- a/installer/packer/scripts/kov/configure_kov.sh
+++ b/installer/packer/scripts/kov/configure_kov.sh
@@ -38,6 +38,7 @@ flag=${conf_dir}/cert_gen_type
 
 data_dir=/data/kov
 cfg=${data_dir}/kov.cfg
+kov_tag_file=${data_dir}/kov.tag
 
 cert_dir=${data_dir}/cert
 ca_download_dir=${data_dir}/ca_download
@@ -67,9 +68,12 @@ function bundle_kov {
   cp $admin_key $admin_cert $ca_cert $FILES_DIR/$CERT_FILES_DIR
   cd $FILES_DIR
   set +f
+  [ -f ${KOV_BINARY_NAME}_*.tar.gz ] || cp_kov_tar
   kov_target=$(ls ${KOV_BINARY_NAME}_*.tar.gz)
   kov_tag="${kov_target#${KOV_BINARY_NAME}_}"
   kov_tag="${kov_tag%.tar.gz}"
+  echo "Saving kov tag ${kov_tag} to ${kov_tag_file}"
+  echo ${kov_tag} > ${kov_tag_file}
   tar xzvf ${kov_target}
   for dir in bin/*; do
     target=$(ls ${dir})
@@ -78,6 +82,12 @@ function bundle_kov {
   done
   rm -rf bin ${CERT_FILES_DIR} ${KOV_ENV_FILE} ${KOV_BINARY_NAME}_${kov_tag}.tar.gz
   set -f
+}
+
+function cp_kov_tar {
+  kov_tag=$(cat ${kov_tag_file})
+  [[ x$kov_tag == "x" ]] && ( echo "KOV tag not set, failing"; exit 1 )
+  cp ${data_dir}/${KOV_BINARY_NAME}_${kov_tag}.tar.gz ${FILES_DIR}
 }
 
 function genCert {

--- a/installer/packer/scripts/provision_fileserver.sh
+++ b/installer/packer/scripts/provision_fileserver.sh
@@ -55,6 +55,12 @@ mv ${VIC_ENGINE_FILE} ${FILES_DIR}
 
 KOV_BUCKET="kov-releases"
 KOV_BINARY_NAME="vic-adm"
+
+# fileserver service is after data.mount
+KOV_DATA_DIR="/data/kov"
+# make sure this directory exists
+mkdir -p ${KOV_DATA_DIR}
+
 if [ ${BUILD_KOV_CLI_REVISION} = "dev" ]; then
     KOV_BUCKET="kov-builds"
 fi
@@ -62,4 +68,5 @@ fi
 KOV_CLI_URL="https://storage.googleapis.com/${KOV_BUCKET}/${KOV_BINARY_NAME}_${BUILD_KOV_CLI_REVISION}.tar.gz"
 echo "Downloading KOV ${KOV_CLI_URL}"
 curl -LO ${KOV_CLI_URL}
+cp ${KOV_BINARY_NAME}_${BUILD_KOV_CLI_REVISION}.tar.gz ${KOV_DATA_DIR}
 mv ${KOV_BINARY_NAME}_${BUILD_KOV_CLI_REVISION}.tar.gz ${FILES_DIR}


### PR DESCRIPTION
fixes: https://github.com/vmware/kov/issues/337

because new certificate and key may be generated, so we have to persist vic-adm_*.tar.gz in this case to enable the restart of kov.

manual deployment verified 