### PR TITLE
Register all VIC components with PSC during init

### DIFF
--- a/installer/packer/scripts/package_provisioning.sh
+++ b/installer/packer/scripts/package_provisioning.sh
@@ -28,8 +28,10 @@ tdnf remove -y cloud-init
 mkdir /etc/vmware
 mkdir "/usr/lib/systemd/system/getty@tty2.service.d"
 
-# Create directory for PSC token
+# Create directories for PSC token
 mkdir -p /etc/vmware/psc/admiral
+mkdir -p /etc/vmware/psc/harbor
+mkdir -p /etc/vmware/psc/engine
 
 # Create Data Dir
 mkdir /data

--- a/installer/packer/scripts/systemd/harbor/harbor_startup.path
+++ b/installer/packer/scripts/systemd/harbor/harbor_startup.path
@@ -3,7 +3,7 @@ Description=Harbor PSC token dependency
 Documentation=https://github.com/vmware/vic-product/installer
 
 [Path]
-PathExists=/etc/vmware/psc/admiral/psc-config.properties
+PathExists=/etc/vmware/psc/harbor/psc-config.properties
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change runs the PSC binary's register command for admiral,
harbor and engine to create separate config and keystore files
for each component.

Issue: vmware/vic#5551