### PR TITLE
[skip ci]Add harbor registry to the default VCH

### DIFF
--- a/installer/engine_installer/engine_installer.go
+++ b/installer/engine_installer/engine_installer.go
@@ -145,10 +145,10 @@ func (ei *EngineInstaller) buildCreateCommand(binaryPath string) {
 	createCommand = append(createCommand, []string{"--bridge-network", ei.BridgeNetwork}...)
 	createCommand = append(createCommand, []string{"--compute-resource", ei.ComputeResource}...)
 	createCommand = append(createCommand, []string{"--image-store", ei.ImageStore}...)
-	createCommand = append(createCommand, []string{"--thumbprint", ei.Thumbprint}...)
 	if ip, err := ip.FirstIPv4(ip.Eth0Interface); err == nil {
-            createCommand = append(createCommand, fmt.Sprintf("--insecure-registry %s:443", ip.String()))
+            createCommand = append(createCommand, []string{"--insecure-registry", fmt.Sprintf("%s:443", ip.String())}...)
         }
+	createCommand = append(createCommand, []string{"--thumbprint", ei.Thumbprint}...)
 
 	ei.CreateCommand = createCommand
 }

--- a/installer/engine_installer/engine_installer.go
+++ b/installer/engine_installer/engine_installer.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/vmware/vic-product/installer/lib"
 	"github.com/vmware/vic/pkg/trace"
+	"github.com/vmware/vic-product/installer/pkg/ip"
 )
 
 // EngineInstallerConfigOptions contains resource options for selection by user in exec.html
@@ -145,6 +146,9 @@ func (ei *EngineInstaller) buildCreateCommand(binaryPath string) {
 	createCommand = append(createCommand, []string{"--compute-resource", ei.ComputeResource}...)
 	createCommand = append(createCommand, []string{"--image-store", ei.ImageStore}...)
 	createCommand = append(createCommand, []string{"--thumbprint", ei.Thumbprint}...)
+	if ip, err := ip.FirstIPv4(ip.Eth0Interface); err == nil {
+            createCommand = append(createCommand, fmt.Sprintf("--insecure-registry %s:443", ip.String()))
+        }
 
 	ei.CreateCommand = createCommand
 }


### PR DESCRIPTION
Add the harbor registry as an insecure registry to the default VCH so that customers that want to play around with the default VCH can actually use the already installed and running harbor instance.