### PR TITLE
PSC: copy Harbor token to volume mount

### DIFF
--- a/installer/packer/scripts/psc/get_token.sh
+++ b/installer/packer/scripts/psc/get_token.sh
@@ -29,3 +29,8 @@ version=$(grep "version" /etc/vmware/psc/admiral/psc-config.properties | awk -F=
 # Put the engine token in guestinfo
 /etc/vmware/set_guestinfo.sh -f /etc/vmware/psc/engine/tokens.properties "engine.token"
 
+# Copy harbor token to container mount path
+mkdir -p /data/harbor/psc
+cp /etc/vmware/psc/harbor/tokens.properties /data/harbor/psc/tokens.properties
+# Create path for activating harbor_startup.service to avoid its dependency on /data
+mkdir -p /etc/vmware/psc/harbor/harbor_startup

--- a/installer/packer/scripts/systemd/harbor/harbor_startup.path
+++ b/installer/packer/scripts/systemd/harbor/harbor_startup.path
@@ -3,7 +3,7 @@ Description=Harbor PSC token dependency
 Documentation=https://github.com/vmware/vic-product/installer
 
 [Path]
-PathExists=/etc/vmware/psc/harbor/tokens.properties
+PathExists=/etc/vmware/psc/harbor/harbor_startup
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
This change copies Harbor's `tokens.properties` file to
`/data/harbor/psc`. This is needed to support Harbor's standalone
use-case where the user may not have access to `/etc` while
attempting to mount the token file's path as a volume in the
Harbor container.

To avoid a systemd dependency cycle with the `harbor_startup.path`
unit, this change creates a marker path after the token file has
been copied and uses that path to activate `harbor_startup.service`.