### PR TITLE
Updated all download instructions to mention the Getting Started page.

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/contents_of_vic_binaries.md
+++ b/docs/user_doc/vic_vsphere_admin/contents_of_vic_binaries.md
@@ -1,19 +1,21 @@
 # Contents of the vSphere Integrated Containers Engine Binaries 
 
-You download vSphere Integrated Containers Engine binaries from https://<i>vic_appliance_address</i>:9443. When you unpack the vSphere Integrated Containers Engine binary bundle, you obtain following files:
+After you deploy the vSphere Integrated Containers appliance, you download the vSphere Integrated Containers Engine bundle from https://<i>vic_appliance_address</i>:9443.
+
+When you unpack the vSphere Integrated Containers Engine bundle, you obtain following files:
 
 | **File** | **Description** |
 | --- | --- |
-|`appliance.iso` | The Photon based boot image for the virtual container host (VCH) endpoint VM|
+|`appliance.iso` | The Photon based boot image for the virtual container host (VCH) endpoint VM. |
 |`bootstrap.iso` | The Photon based boot image for the container VMs.|
-|`ui/` | A folder that contains the files and scripts for the installation of the vSphere Client plug-in.| 
-|`vic-machine-darwin` | The OSX command line utility for the deployment and management of VCHs.| 
-|`vic-machine-linux` | The Linux command line utility for the deployment and management of VCHs.| 
+|`ui/` | A folder that contains the files and scripts for the installation of the vSphere Client plug-in. | 
+|`vic-machine-darwin` | The OSX command line utility for the deployment and management of VCHs. | 
+|`vic-machine-linux` | The Linux command line utility for the deployment and management of VCHs. | 
 |`vic-machine-windows.exe` | The Windows command line utility for the deployment and management of VCHs.| 
-|`vic-ui-darwin` | The OSX executable for the deployment of the vSphere Client plug-in. <br><br> **NOTE**: Do not run this executable directly.<sup>(1)</sup>| 
-|`vic-ui-linux` | The Linux executable for the deployment of the vSphere Client plug-in.  <br><br> **NOTE**: Do not run this executable directly.<sup>(1)</sup>| 
-|`vic-ui-windows.exe` | The Windows executable for the deployment of the vSphere Client plug-in.  <br><br> **NOTE**: Do not run this executable directly.<sup>(1)</sup>| 
-|`README`|Contains a link to the vSphere Integrated Containers Engine repository on GitHub.|
-|`LICENSE`|The license file.|
+|`vic-ui-darwin` | The OSX executable for the deployment of the vSphere Client plug-in. **NOTE**: Do not run this executable directly.<sup>(1)</sup>| 
+|`vic-ui-linux` | The Linux executable for the deployment of the vSphere Client plug-in. **NOTE**: Do not run this executable directly.<sup>(1)</sup> | 
+|`vic-ui-windows.exe` | The Windows executable for the deployment of the vSphere Client plug-in. **NOTE**: Do not run this executable directly.<sup>(1)</sup> | 
+|`README`|Contains a link to the vSphere Integrated Containers Engine repository on GitHub. |
+|`LICENSE`|The license file. |
 
 <sup>(1)</sup> For information about how to install the vSphere Client plug-in, see [Installing the vSphere Client Plug-Ins](install_vic_plugin.md).

--- a/docs/user_doc/vic_vsphere_admin/deploy_demo_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_demo_vch.md
@@ -17,11 +17,11 @@ The demo VCH has the minimum configuration that deployment to vCenter Server req
 
 **Procedure**
 
-1. Go to https://<i>vic_appliance_address</i>:1337 in your browser and trust the certificate. 
-2. Enter the IP address and administrator credentials of the vCenter Server instance on which the vSphere Integrated Containers appliance is running and click **Logon**. 
+1. In a Web browser, go to https://<i>vic_appliance_address</i>:9443, scroll down to Infrastructure Deployment Tools, click the link **Go to the web installer to deploy a demo VCH**, and trust the certificate. 
+2. Enter the IP address and administrator credentials of the vCenter Server instance on which the vSphere Integrated Containers appliance is running and click **Login**. 
 4. Use the drop-down menus to select the appropriate resources for each of the required resources.
 
-   <table border="1">
+     <table border="1">
   <tr>
     <th scope="col">Option</th>
     <th scope="col">Description</th>
@@ -46,7 +46,7 @@ The demo VCH has the minimum configuration that deployment to vCenter Server req
 5. (Optional) Modify the name of the VCH to create.
 6. Leave **Thumbprint** empty and click **Execute**. 
 
-   The deployment of the VCH fails, but the certificate thumbprint of the target vCenter Server appears under **Execution Output**.
+     The deployment of the VCH fails, but the certificate thumbprint of the target vCenter Server appears under **Execution Output**.
 7. Copy and paste the certificate thumbprint into **Thumbprint** and click **Execute** again.
 
     You can monitor the progress of the VCH deployment under **Execution Output**. Stay on the Installer page until the command finishes. Logs might stop streaming if you switch to other tabs or windows. 

--- a/docs/user_doc/vic_vsphere_admin/deploy_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vch.md
@@ -2,7 +2,9 @@
 
 # Deploy Virtual Container Hosts with `vic-machine` #
 
-After you deploy the vSphere Integrated Containers appliance, you can download the vSphere Integrated Containers Engine binaries, `vic_1.2.x-version.tar.gz`, from https://<i>vic_appliance_address</i>:9443. The vSphere Integrated Containers Engine binaries include the `vic-machine` utility, that you use to deploy virtual container hosts (VCHs). 
+After you deploy the vSphere Integrated Containers appliance, go to https://<i>vic_appliance_address</i>:9443 in a Web browser, scroll down to Infrastructure Deployment Tools, click the link to **download the vSphere Integrated Containers Engine bundle**, and unpack it on your working machine.
+
+The vSphere Integrated Containers Engine binaries include the `vic-machine` utility, that you use to deploy virtual container hosts (VCHs). 
 
 * [Contents of the vSphere Integrated Containers Engine Binaries](contents_of_vic_binaries.md)
 * [Environment Prerequisites for VCH Deployment](vic_installation_prereqs.md)

--- a/docs/user_doc/vic_vsphere_admin/deploy_vch_esxi.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vch_esxi.md
@@ -3,8 +3,9 @@
 This topic provides instructions for deploying a virtual container host (VCH) to an ESXi host that is not managed by vCenter Server. This is the most straightforward way to deploy a VCH, and is ideal for testing.
 
 **Prerequisites**
+
 * Deploy the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
-* Download the vSphere Integrated Containers Engine bundle, `vic_1.2.x-version.tar.gz`, from https://<i>vic_appliance_address</i>:9443 and unpack it on your working machine. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
+* In a Web browser, go to https://<i>vic_appliance_address</i>:9443, scroll down to Infrastructure Deployment Tools, click the link to **download the vSphere Integrated Containers Engine bundle**, and unpack it on your working machine. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
 * Create or obtain an ESXi host with the following configuration:
   * One datastore
   * The VM Network is present

--- a/docs/user_doc/vic_vsphere_admin/deploy_vch_registry.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vch_registry.md
@@ -7,7 +7,7 @@ If you did not provide a custom server certificate and private key for the regis
 **Prerequisites**
 
 - You selected the option to deploy vSphere Integrated Containers Registry when you deployed the vSphere Integrated Containers appliance.
-- You downloaded the vSphere Integrated Containers Engine bundle from the appliance.
+- You downloaded the vSphere Integrated Containers Engine bundle from https://<i>vic_appliance_address</i>:9443.
 
 **Procedure**
 

--- a/docs/user_doc/vic_vsphere_admin/deploy_vch_vcenter.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vch_vcenter.md
@@ -5,8 +5,9 @@ This topic provides instructions for deploying a virtual container host (VCH) in
 The vCenter Server instance to which you deploy the VCH must match the specifications listed in the prerequisites.
 
 **Prerequisites**
+
 * Deploy the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
-* Download the vSphere Integrated Containers Engine bundle, `vic_1.2.x-version.tar.gz`, from https://<i>vic_appliance_address</i>:9443 and unpack it on your working machine. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
+* In a Web browser, go to https://<i>vic_appliance_address</i>:9443, scroll down to Infrastructure Deployment Tools, click the link to **download the vSphere Integrated Containers Engine bundle**, and unpack it on your working machine. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
 * Create or obtain a vCenter Server instance with the following configuration:
   * One datacenter
   * One cluster with two ESXi hosts and DRS enabled. You can use nested ESXi hosts for this example.

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -43,8 +43,6 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
     - If you do not want to enable vSphere Integrated Containers Registry, uncheck the **Deploy Registry** check box.
     - In the **Registry Port** text box, optionally change the port on which to publish the vSphere Integrated Containers Registry service.
     - In the **Notary Port** text box, optionally change the port on which to publish the Docker Notary service for vSphere Integrated Containers Registry.
-    - In the **Registry Admin Password** text box, set a password for the vSphere Integrated Containers Registry admin account.
-    - In the **Database Password** text box, set a password for the root user of the MySQL database that vSphere Integrated Containers Registry uses.
     - Optionally check the **Garbage Collection** check box to enable garbage collection on the registry when the appliance reboots. 
     - To use custom certificates to authenticate connections to vSphere Integrated Containers Registry, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. Leave the text boxes blank to use auto-generated certificates. 
 
@@ -67,18 +65,23 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
 
     **IMPORTANT**: The installation process requires the single sign-on credentials to set up vSphere Integrated Containers Management Portal and Registry. The vSphere Integrated Containers Management Portal and Registry services cannot start if you do not complete this step.
 
+You can reconfigure the appliance after deployment by editing the settings of the appliance VM. For information about reconfiguring the appliance, see [Reconfigure the vSphere Integrated Containers Appliance](reconfigure_appliance.html).
+
 **What to Do Next**
 
-Access the different vSphere Integrated Containers components and start using them. If, during the OVA deployment, you configured the vSphere Integrated Containers appliance to use different ports for the vSphere Integrated Containers services, replace the port numbers in the URLs below with the appropriate ports. 
+Access the different vSphere Integrated Containers components from the  vSphere Integrated Containers Getting Started page at https://<i>vic_appliance_address</i>:9443. If you configured the vSphere Integrated Containers appliance to use a different port for the vSphere Integrated Containers file server, replace 9443 with the appropriate port. 
 
-- Go to the file server that runs in the vSphere Integrated Containers appliance at https://<i>vic_appliance_address</i>:9443/files and download and unpack the vSphere Integrated Containers Engine binaries bundle, `vic_1.2.x.tar.gz`.
-- Install the vSphere Client plug-ins for vSphere Integrated Containers. For information about installing the plug-ins, see [Installing the vSphere Client Plug-ins](install_vic_plugin.md). 
-- Configure the firewalls on all ESXi hosts to permit VCH deployment. For information about how to configure the firewalls on ESXi hosts, see [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.html).
-- Go to the interactive VCH installer at https://<i>vic_appliance_address</i>:1337 and deploy a demo VCH. For information about how to use the interactive VCH installer, see [Deploy a Virtual Container Host Interactively](deploy_demo_vch.html).
-- Use `vic-machine` to deploy production VCHs. For information about deploying VCHs with `vic-machine`, see [Deploying Virtual Container Hosts with `vic-machine`](deploy_vch.md).
-- Log in to vSphere Integrated Containers Management Portal at https://<i>vic_appliance_address</i>:8282. For information about how to use vSphere Integrated Containers Management Portal, see [View and Manage VCHs, Add Registries, and Provision Containers Through the Management Portal](../vic_cloud_admin/vchs_and_mgmt_portal.md).
+- Click the link to go to the **vSphere Integrated Containers Management Portal**. For information about how to use vSphere Integrated Containers Management Portal, see [View and Manage VCHs, Add Registries, and Provision Containers Through the Management Portal](../vic_cloud_admin/vchs_and_mgmt_portal.md).
+- Scroll down to **Infrastructure deployment tools** and click the link to go to the **web installer to deploy a demo VCH**. For information about how to use the interactive VCH installer, see [Deploy a Virtual Container Host Interactively](deploy_demo_vch.html).
+- Scroll down to **Infrastructure deployment tools** and click the link to **download the vSphere Integrated Containers Engine bundle**. The vSphere Integrated Containers Engine bundle allows you to perform the following tasks:
 
-You can reconfigure the appliance after deployment by editing the settings of the appliance VM. For information about reconfiguring the appliance, see [Reconfigure the vSphere Integrated Containers Appliance](reconfigure_appliance.html).
+   - Use `vic-machine` to configure the firewalls on all ESXi hosts to permit VCH deployment. For information about how to configure the firewalls on ESXi hosts, see [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.html).
+   - Install the vSphere Client plug-ins for vSphere Integrated Containers. For information about installing the plug-ins, see [Installing the vSphere Client Plug-ins](install_vic_plugin.md).       
+   - Use `vic-machine` to deploy production VCHs. For information about deploying VCHs with `vic-machine`, see [Deploy Virtual Container Hosts with `vic-machine`](deploy_vch.md).
+      
+      
+
+
 
 
    

--- a/docs/user_doc/vic_vsphere_admin/open_ports_on_hosts.md
+++ b/docs/user_doc/vic_vsphere_admin/open_ports_on_hosts.md
@@ -11,7 +11,7 @@ The `vic-machine create` command does not modify the firewall. Run `vic-machine 
 **Prerequisites**
 
 * Deploy the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
-* Download the vSphere Integrated Containers Engine bundle, `vic_1.2.x.tar.gz`, from https://<i>vic_appliance_address</i>:9443 and unpack it on your working machine. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
+* In a Web browser, go to https://<i>vic_appliance_address</i>:9443, scroll down to Infrastructure Deployment Tools, click the link to **download the vSphere Integrated Containers Engine bundle**, and unpack it on your working machine. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
 
 **Procedure**
 

--- a/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vc_windows.md
@@ -10,7 +10,7 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
 - The vCenter Server instance on which to install the plug-in runs on Windows. If you are running a vCenter Server appliance instance, see [Install the Client Plug-Ins on a vCenter Server Appliance](plugins_vcsa.md).
 - You deployed the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
 - Log in to the Windows system on which vCenter Server is running. You must perform all of the steps in this procedure on this Windows system.
-- Go to https://<i>vic_appliance_address</i>:9443/files in a Web browser, download the vSphere Integrated Containers Engine package, `vic_1.2.x.tar.gz`, and unpack it on the Desktop. Do not download the client plug-in files, `com.vmware.vic-v1.2.x.zip` and `com.vmware.vic.ui-v1.2.x.zip`, directly from the file server. The plug-in installation script pulls these files from the file server.
+- In a Web browser, go to https://<i>vic_appliance_address</i>:9443, scroll down to Infrastructure Deployment Tools, click the link to **download the vSphere Integrated Containers Engine bundle**, and unpack it on the Desktop. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
 
 **Procedure**
 

--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -14,7 +14,7 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
 **Procedure**
 
 1. Connect as root user to the vCenter Server Appliance by using SSH.<pre>ssh root@<i>vcsa_address</i></pre>
-4. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>curl -k https://<i>vic_appliance_address</i>:9443/files/vic_1.2.x.tar.gz -o vic_1.2.x.tar.gz</pre>**NOTE**: Update `vic_1.2.x` to the appropriate version in the command above and in the next step.
+4. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>curl -k https://<i>vic_appliance_address</i>:9443/files/vic_1.2.x.tar.gz -o vic_1.2.x.tar.gz</pre>**NOTE**: Update `vic_1.2.x` to the appropriate version in the command above and in the next step. If you configured the appliance to use a different port for the file server, replace 9443 with the appropriate port.
 5. Unpack the vSphere Integrated Containers binaries.<pre>tar -zxf vic_1.2.x.tar.gz</pre>
 9. Navigate to `/vic/ui/VCSA`, run the installer script, and follow the prompts.<pre>cd vic/ui/VCSA</pre><pre>./install.sh</pre>
 	1. Enter the IP address of the vCenter Server instance.


### PR DESCRIPTION
Fixes https://github.com/vmware/vic-product/issues/286.

Updated all instructions relating to `vic-machine`, plug-ins, and downloads to direct users to the Getting Started page rather than downloading directly from the file server.

@andrewtchin and @jooskim can you please review? 

We will address links to the Registry interface running on port 443 in a separate PR, that will cover updates related to the unified Registry/Management portal UI. 