### PR TITLE
Add params to Admiral's docker run command

### DIFF
--- a/installer/packer/scripts/admiral/start_admiral.sh
+++ b/installer/packer/scripts/admiral/start_admiral.sh
@@ -27,7 +27,7 @@ admiral_xenon_opts="--publicUri=https://${OVA_VM_IP}:8282/ --bindAddress=0.0.0.0
   -v "$ADMIRAL_DATA_LOCATION:/var/admiral" \
   -v "$ADMIRAL_DATA_LOCATION/configs:/configs" \
   -e ADMIRAL_PORT=-1 \
-  -e JAVA_OPTS="-Ddcp.net.ssl.trustStore=/configs/trustedcertificates.jks -Ddcp.net.ssl.trustStorePassword=changeit" \
+  -e JAVA_OPTS="-Ddcp.net.ssl.trustStore=/configs/trustedcertificates.jks -Ddcp.net.ssl.trustStorePassword=changeit -Dencryption.key.file=/var/admiral/8282/encryption.key -Dinit.encryption.key.file=true" \
   -e CONFIG_FILE_PATH="/configs/config.properties" \
   -e XENON_OPTS="${admiral_xenon_opts}" \
   --log-driver=json-file \


### PR DESCRIPTION
This change adds two JAVA_OPTS values to the Admiral container,
per request from @lazarin.