### PR TITLE
Update Admiral Cluster API Request

### DIFF
--- a/installer/engine_installer/html/exec.html
+++ b/installer/engine_installer/html/exec.html
@@ -45,7 +45,7 @@
                     var messages = msg.data.split('\n');
                     for (var i = 0; i < messages.length; i++) {
                       appendLog(messages[i]);
-                      $("html,body").animate({ scrollTop: $("#log-scroll").offset().top }, "fast");
+                      $("html").animate({ scrollTop: $("#log-scroll").offset().top }, "fast");
                     }
                   };
                 } else {
@@ -168,8 +168,8 @@
 
               </div>
             </div>
+            <div id="log-scroll"></div>
           </div>
-          <span id="log-scroll"></span>
         </section>
       </main>
     </div>

--- a/installer/engine_installer/logstream.go
+++ b/installer/engine_installer/logstream.go
@@ -17,8 +17,8 @@ package main
 import (
 	"bufio"
 	"fmt"
+	"io"
 	"net/http"
-	"os"
 	"os/exec"
 	"regexp"
 	"strings"
@@ -37,10 +37,11 @@ const (
 )
 
 var (
-	// lock for single command execution
 	cmdDone   = make(chan error, 1)
 	logStream = NewLogStream()
-	mu        sync.Mutex
+	// lock for single command execution
+	mu sync.Mutex
+	wg sync.WaitGroup
 )
 
 // LogStream streams a command's execution over a websocket connection
@@ -67,44 +68,53 @@ func (ls *LogStream) start() {
 	defer trace.End(trace.Begin(""))
 
 	// log reader and writer.
-	logReader, logWriter, err := os.Pipe()
-	if err != nil {
-		log.Infoln("ERROR")
-		log.Infoln(err)
-	}
-	defer logReader.Close()
-	defer logWriter.Close()
+	logReader, logWriter := io.Pipe()
+	wg := sync.WaitGroup{}
 
-	// attach cmd std out and std err to log Writer
-	ls.cmd.Stderr = logWriter
-	ls.cmd.Stdout = logWriter
-	r, _ := regexp.Compile(`DOCKER_HOST=(\d{1,3}\.){3}(\d{1,3}):\d{4}`)
-
+	// write logReader contents to the websocket stream
 	go func() {
+
+		// #nosec: Errors unhandled.
+		r, _ := regexp.Compile(`DOCKER_HOST=(\d{1,3}\.){3}(\d{1,3}):\d{4}`)
+
+		// read cmd output from the logReader pipe
 		s := bufio.NewScanner(logReader)
 		for s.Scan() {
 			ls.send(string(s.Bytes()))
-			//if we get a docker endpoint the setup is complete and we should attach this vch to admiral
+
+			// if we get a docker endpoint the setup is complete and we should attach this vch to admiral
 			match := r.Find(s.Bytes())
 			stringMatch := string(match)
-			if err == nil && strings.Contains(stringMatch, "=") {
+			if strings.Contains(stringMatch, "=") {
 				dockerIP := strings.Split(stringMatch, "=")[1]
 				log.Infof("Docker endpoint is: %s\n", dockerIP)
-				go setupDefaultAdmiral(string(dockerIP))
+				go func() {
+					wg.Add(1)
+					defer wg.Done()
+					err := setupDefaultAdmiral(string(dockerIP))
+					if err != nil {
+						ls.send(fmt.Sprintf("Failed to add %s to the Container Management Portal", dockerIP))
+						return
+					}
+					ls.send(fmt.Sprintf("Added %s to the Container Management Portal.", dockerIP))
+				}()
 			}
 		}
 	}()
 
+	// run the vic-machine command and write it's stdout/stderr to the logWriter
 	go func() {
+		defer logWriter.Close()
+
+		// attach cmd std out and std err to log Writer
+		ls.cmd.Stderr = logWriter
+		ls.cmd.Stdout = logWriter
 		cmdDone <- ls.cmd.Run()
 	}()
 
 	select {
 	case <-time.After(waitTime):
-		if err := ls.cmd.Process.Kill(); err != nil {
-			ls.send(fmt.Sprintf("failed to kill create: %v ", err))
-		}
-		ls.send("Create exited after timeout")
+		ls.send("Create exited after timeout.")
 	case err := <-cmdDone:
 		if err != nil {
 			ls.send(fmt.Sprintf("Create failed with error: %v\n", err))
@@ -112,6 +122,8 @@ func (ls *LogStream) start() {
 			ls.send("Execution complete.")
 		}
 	}
+
+	wg.Wait() // block on setting up the default admiral cluster
 }
 
 func (ls *LogStream) websocketServer(resp http.ResponseWriter, req *http.Request) {

--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -128,12 +128,12 @@
                                             <clr-icon shape="host" size="24"></clr-icon> Deploy a VCH
                                         </div>
                                         <div class="card-text">
-                                            <a href="{{ .FileserverAddr }}/files/" target="_blank">Download the vSphere Integrated Containers Engine bundle.</a>
+                                            <a href="{{ .FileserverAddr }}" target="_blank">Download the vSphere Integrated Containers Engine bundle.</a>
                                                 vSphere Integrated Containers Engine provides a command-line utility named vic-machine that you use to deploy virtual container hosts (VCHs) in production. 
                                         </div>
                                     </div>
                                     <div class="card-footer">
-                                        <a class="btn btn-sm btn-link" href="{{ .FileserverAddr }}/files/" target="_blank">Download</a>
+                                        <a class="btn btn-sm btn-link" href="{{ .FileserverAddr }}" target="_blank">Download</a>
                                         <a class="btn btn-sm btn-link" target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.2/vic_vsphere_admin/deploy_vch.html">Read more</a>
                                     </div>
                                 </div>

--- a/installer/packer/scripts/fileserver/configure_fileserver.sh
+++ b/installer/packer/scripts/fileserver/configure_fileserver.sh
@@ -173,6 +173,7 @@ fi
 secure
 
 iptables -w -A INPUT -j ACCEPT -p tcp --dport $port
+iptables -w -A INPUT -j ACCEPT -p tcp --dport 80
 
 # Update configurations
 updateConfigFiles


### PR DESCRIPTION
Fixes #542.

 - Refactors the Engine Installer Logstreamer to wait for a response when adding the demo vch to the an admiral cluster.
 - Correctly masks the password when the demo vch page is refreshed after a command was run.
 - Adds auth token to admiral api requests from the engine installer.
 - Adds the vic-tar.gz file from the fileserver to the Getting Started Page.
 - Redirects port 80 to the tls fileserver address