### PR TITLE
Add common/config cleanup before running harbor prepare

### DIFF
--- a/installer/packer/scripts/harbor/configure_harbor.sh
+++ b/installer/packer/scripts/harbor/configure_harbor.sh
@@ -243,3 +243,6 @@ iptables -w -A INPUT -j ACCEPT -p tcp --dport "${NOTARY_PORT}"
 echo "Enable harbor startup"
 systemctl enable harbor_startup.service
 systemctl enable harbor.service
+
+# cleanup common/config directory in preparation for running the harbor "prepare" script
+rm -rf /etc/vmware/harbor/common/config


### PR DESCRIPTION
Before:

```console
$ docker login 10.160.222.67
Username: administrator@vsphere.local
Password:
Login Succeeded
$ govc vm.power -force -off vic-1.2-test
Powering off VirtualMachine:vm-117... OK
$ govc vm.power -force -on vic-1.2-test
Powering on VirtualMachine:vm-117... OK
$ docker login 10.160.222.67
Username (administrator@vsphere.local): administrator@vsphere.local
Password:
Error response from daemon: login attempt to https://10.160.222.67/v2/ failed with status: 401 Unauthorized
```

After: 

```console
$ docker login 10.160.222.67
Username: administrator@vsphere.local
Password:
Login Succeeded
$ govc vm.power -force -off vic-1.2-test
Powering off VirtualMachine:vm-117... OK
$ govc vm.power -force -on vic-1.2-test
Powering on VirtualMachine:vm-117... OK
$ docker login 10.160.222.67
Username (administrator@vsphere.local): administrator@vsphere.local
Password:
Login Succeeded
```

Fixes vmware/vic#5035