### PR TITLE
Documenting support for docker commit

### DIFF
--- a/docs/user_doc/vic_app_dev/container_operations.md
+++ b/docs/user_doc/vic_app_dev/container_operations.md
@@ -25,7 +25,7 @@
 | **Command** | **Docker Reference** | **Supported** |
 | --- | --- | --- |
 |`build`|[Build an image from a Dockerfile](https://docs.docker.com/engine/reference/commandline/build/)|No|
-|`commit`|[Create a new image from a container’s changes](https://docs.docker.com/engine/reference/commandline/commit/)|Yes, since 1.2|
+|`commit`|[Create a new image from a container’s changes](https://docs.docker.com/engine/reference/commandline/commit/)|Yes, since 1.2. You can only run `docker commit` on stopped containers.|
 |`history`|[Show the history of an image](https://docs.docker.com/engine/reference/commandline/history/)|No|
 |`images`|[Images](https://docs.docker.com/engine/reference/commandline/images/)|Yes, since 1.0. Supports `--filter`, `--no-trunc`, and `--quiet`|
 |`import`|[Import the contents from a tarball to create a filesystem image](https://docs.docker.com/engine/reference/commandline/import/)|No|

--- a/docs/user_doc/vic_app_dev/container_operations.md
+++ b/docs/user_doc/vic_app_dev/container_operations.md
@@ -25,7 +25,7 @@
 | **Command** | **Docker Reference** | **Supported** |
 | --- | --- | --- |
 |`build`|[Build an image from a Dockerfile](https://docs.docker.com/engine/reference/commandline/build/)|No|
-|`commit`|[Create a new image from a container’s changes](https://docs.docker.com/engine/reference/commandline/commit/)|No|
+|`commit`|[Create a new image from a container’s changes](https://docs.docker.com/engine/reference/commandline/commit/)|Yes, since 1.2|
 |`history`|[Show the history of an image](https://docs.docker.com/engine/reference/commandline/history/)|No|
 |`images`|[Images](https://docs.docker.com/engine/reference/commandline/images/)|Yes, since 1.0. Supports `--filter`, `--no-trunc`, and `--quiet`|
 |`import`|[Import the contents from a tarball to create a filesystem image](https://docs.docker.com/engine/reference/commandline/import/)|No|


### PR DESCRIPTION
Looks like we only mention `docker commit` in the table of supported Docker commands. Mentioned that you can only run it on stopped containers.

Fixes https://github.com/vmware/vic-product/issues/316.

@sflxn, can you please review? Are there any other caveats that we need to mention? Thanks! 