### PR TITLE
Removed OVA option to provide custom certs for registry.

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -43,7 +43,6 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
     - In the **Registry Port** text box, optionally change the port on which to publish the vSphere Integrated Containers Registry service.
     - In the **Notary Port** text box, optionally change the port on which to publish the Docker Notary service for vSphere Integrated Containers Registry.
     - Optionally check the **Garbage Collection** check box to enable garbage collection on the registry when the appliance reboots. 
-    - To use custom certificates to authenticate connections to vSphere Integrated Containers Registry, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. Leave the text boxes blank to use auto-generated certificates. 
 
 7. Expand **Management Portal Configuration** to configure the deployment of vSphere Integrated Containers Management Portal. 
 


### PR DESCRIPTION
Noticed in vic-42ddaaa6.ova that the options to add SSL certs for VIC registry have been removed from the OVA. 

No associated issue. @anchal-agrawal are you a good candidate to review this in @andrewtchin 's absence? Thanks!