### PR TITLE
Add success message to Getting Started page

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -31,10 +31,10 @@
         </header>
         <main class="content-container">
             <div class="content-area">
-                {{if .Feedback }}
+                {{if .InitErrorFeedback }}
                 <div id="feedback-alert" class="alert alert-danger">
                     <div class="alert-item">
-                        <span class="alert-text">{{ .Feedback }}</span>
+                        <span class="alert-text">{{ .InitErrorFeedback }}</span>
                         <div class="alert-actions">
                             <a href="/?login=true" title="Login" class="alert-action">Re-initialize</a>
                         </div>
@@ -146,7 +146,7 @@
                                 </div>
                             </div>
                         </div>
-                        {{if .Feedback}}
+                        {{if .InitErrorFeedback}}
                         <a href="/?login=true" id="feedback-link" class="btn btn-link px-0 my-2">
                             Re-initialize the vSphere Integrated Container Appliance
                         </a>

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -53,12 +53,13 @@ type config struct {
 
 // IndexHTMLOptions contains fields for html templating in index.html
 type IndexHTMLOptions struct {
-	InvalidLogin   bool
-	Feedback       string
-	NeedLogin      bool
-	AdmiralAddr    string
-	DemoVCHAddr    string
-	FileserverAddr string
+	InvalidLogin        bool
+	InitErrorFeedback   string
+	InitSuccessFeedback string
+	NeedLogin           bool
+	AdmiralAddr         string
+	DemoVCHAddr         string
+	FileserverAddr      string
 }
 
 var (
@@ -189,8 +190,9 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 	defer trace.End(trace.Begin(""))
 
 	html := &IndexHTMLOptions{
-		NeedLogin: needInitializationServices(req),
-		Feedback:  "",
+		NeedLogin:           needInitializationServices(req),
+		InitErrorFeedback:   "",
+		InitSuccessFeedback: "",
 	}
 
 	if req.Method == http.MethodPost {
@@ -205,7 +207,12 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 
 		} else {
 			log.Infof("Validation succeeded")
-			html.Feedback = startInitializationServices()
+			html.InitErrorFeedback = startInitializationServices()
+			// Display success message upon init success.
+			if html.InitErrorFeedback == "" {
+				html.InitSuccessFeedback = "Installation successful. Refer to the Post-install and Deployment tasks below."
+			}
+
 			html.NeedLogin = false
 		}
 	}


### PR DESCRIPTION
This change adds a InitSuccessFeedback variable for the Getting
Started page's html template so we can show a success message if
the OVA init tasks (tag and PSC register) finish with success.

This commit does not include the html template changes.

Towards #554