### PR TITLE
Add an initialization success alert

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -41,6 +41,13 @@
                     </div>
                 </div>
                 {{ end }}
+                {{if .InitSuccessFeedback }}
+                <div id="feedback-alert" class="alert alert-success">
+                    <div class="alert-item">
+                        <span class="alert-text">{{ .InitSuccessFeedback }}</span>
+                    </div>
+                </div>
+                {{ end }}
                 <div class="row flex-items-xs-middle my-1">
                     <div class="col-xs"></div>
                     <div class="col-xs">


### PR DESCRIPTION
This change adds a success alert for the Getting Started page
if the OVA init tasks finish with success.

This includes the html template changes only.

Towards #554