### PR TITLE
Make naming for demo VCH installer consistent

### DIFF
--- a/installer/engine_installer/html/auth.html
+++ b/installer/engine_installer/html/auth.html
@@ -2,7 +2,7 @@
 <html itemscope="" itemtype="http://schema.org/Organization" lang="en-US">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
-    <title>VCH Installer</title>
+    <title>Demo VCH Installer Wizard</title>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0">
     <meta content="yes" name="apple-mobile-web-app-capable">
@@ -34,7 +34,7 @@
       <main class="content-area">
 
         <section class="community-top-section">
-          <h1 id="community">Default VCH Installer</h1>
+          <h1 id="community">Demo VCH Installer Wizard</h1>
         </section>
 
         <section>


### PR DESCRIPTION
This commit fixes the naming in the html template for the demo VCH
installer wizard page.

Towards #551