### PR TITLE
Fix typos in OVF descriptor, issue: #651

### DIFF
--- a/installer/packer/vic-unified.ovf
+++ b/installer/packer/vic-unified.ovf
@@ -283,18 +283,18 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
     </ProductSection>
     <ProductSection ovf:class="default_users" ovf:required="false">
       <Info>Out-of-the-box VIC users</Info>
-      <Category>7. Out-of-the box-users configuration</Category>
+      <Category>7. Configure Example Users</Category>
       <Property ovf:key="create_def_users" ovf:type="boolean" ovf:userConfigurable="true" ovf:value="true">
-        <Label>7.1. Create out-of-the-box-users</Label>
-        <Description>Uncheck to skip creation of out-of-the-box users.</Description>
+        <Label>7.1. Create Example Users</Label>
+        <Description>Uncheck to skip creation of Example Users.</Description>
       </Property>
-      <Property ovf:key="def_user_prefix" ovf:qualifiers="MinLen(0),MaxLen(64)" ovf:type="string" ovf:userConfigurable="true" ovf:value="vicdef">
-        <Label>7.2. Out-of-the-box users prefix</Label>
-        <Description>Prefix to be used to create out-of-the-box VIC users.</Description>
+      <Property ovf:key="def_user_prefix" ovf:qualifiers="MinLen(0),MaxLen(64)" ovf:type="string" ovf:userConfigurable="true" ovf:value="vic">
+        <Label>7.2. Username Prefix for Example Users</Label>
+        <Description>Username prefix to be used to create Example Users for vSphere Integrated Containers.</Description>
       </Property>
       <Property ovf:key="def_user_password" ovf:password="true" ovf:qualifiers="MinLen(0),MaxLen(128)" ovf:type="string" ovf:userConfigurable="true" ovf:value="VicPro!23">
-        <Label>7.3. Out-of-the-box users password</Label>
-        <Description>Password to be used to create out-of-the-box VIC users. The password must follow the rules set for vSphere.</Description>
+        <Label>7.3. Password for Example Users</Label>
+        <Description>Password to be used to create Example Users. The password must follow the rules set for vSphere.</Description>
       </Property>
     </ProductSection>
     <ProductSection ovf:class="vm" ovf:required="false">


### PR DESCRIPTION
Partial fix for this issue: https://github.com/vmware/vic-product/issues/651 .
The rest of the fixes is in the Admiral registration command (description of Example Users).