### PR TITLE
Fixed a bunch of links that used html instead of md as suffix.

### DIFF
--- a/docs/user_doc/vic_overview/introduction.md
+++ b/docs/user_doc/vic_overview/introduction.md
@@ -260,8 +260,6 @@ The following global permissions are unique for the cloud administrator role:
 
 vSphere Integrated Containers Registry is an enterprise-class registry server that you can use to store and distribute container images. vSphere Integrated Containers Registry allows DevOps administrators to organize image repositories in projects, and to set up role-based access control to those projects to define which users can access which repositories. vSphere Integrated Containers Registry also provides rule-based replication of images between registries, implements Docker Content Trust, and provides detailed logging for project and user auditing.
 
-For a more detailed overview of vSphere Integrated Containers Registry, see [Managing Images, Projects, and Users with vSphere Integrated Containers Registry](../vic_cloud_admin/using_registry.md) in *Configure and Manage vSphere Integrated Containers*.
-
 vSphere Integrated Containers Registry is an enterprise-class registry server that you can use to store and distribute container images. vSphere Integrated Containers Registry extends the open source Docker Distribution project by adding the features that enterprise users require, such as user management, access control, and activity auditing. You can improve image transfer efficiency by deploying vSphere Integrated Containers Registry alongside vSphere Integrated Containers Engine, so that your registry is located close to the build and run environment. 
 
 ### Rule Based Image Replication <a id="replication"></a>

--- a/docs/user_doc/vic_overview/introduction.md
+++ b/docs/user_doc/vic_overview/introduction.md
@@ -203,7 +203,7 @@ vSphere Integrated Containers Management Portal is a highly scalable and very li
 - Live state updates that provide a live view of the container system.
 - Multi-container template management, that enables logical multi-container application deployments.
 
-For a more information about vSphere Integrated Containers Management Portal, see [View and Manage VCHs, Add Registries, and Provision Containers Through the Management Portal](../vic_cloud_admin/vchs_and_mgmt_portal.html) in *Configure and Manage vSphere Integrated Containers*.
+For a more information about vSphere Integrated Containers Management Portal, see [View and Manage VCHs, Add Registries, and Provision Containers Through the Management Portal](../vic_cloud_admin/vchs_and_mgmt_portal.md) in *Configure and Manage vSphere Integrated Containers*.
 
 ### Projects and Role-Based Access Control <a id="projects"></a>
 
@@ -260,7 +260,7 @@ The following global permissions are unique for the cloud administrator role:
 
 vSphere Integrated Containers Registry is an enterprise-class registry server that you can use to store and distribute container images. vSphere Integrated Containers Registry allows DevOps administrators to organize image repositories in projects, and to set up role-based access control to those projects to define which users can access which repositories. vSphere Integrated Containers Registry also provides rule-based replication of images between registries, implements Docker Content Trust, and provides detailed logging for project and user auditing.
 
-For a more detailed overview of vSphere Integrated Containers Registry, see [Managing Images, Projects, and Users with vSphere Integrated Containers Registry](../vic_cloud_admin/using_registry.html) in *Configure and Manage vSphere Integrated Containers*.
+For a more detailed overview of vSphere Integrated Containers Registry, see [Managing Images, Projects, and Users with vSphere Integrated Containers Registry](../vic_cloud_admin/using_registry.md) in *Configure and Manage vSphere Integrated Containers*.
 
 vSphere Integrated Containers Registry is an enterprise-class registry server that you can use to store and distribute container images. vSphere Integrated Containers Registry extends the open source Docker Distribution project by adding the features that enterprise users require, such as user management, access control, and activity auditing. You can improve image transfer efficiency by deploying vSphere Integrated Containers Registry alongside vSphere Integrated Containers Engine, so that your registry is located close to the build and run environment. 
 

--- a/docs/user_doc/vic_quickstart.md
+++ b/docs/user_doc/vic_quickstart.md
@@ -2,7 +2,7 @@
 
 If you want to start experimenting with vSphere Integrated Containers straight away, see the following topics:
 
-- [Deploy the vSphere Integrated Containers Appliance](vic_vsphere_admin/deploy_vic_appliance.html)
+- [Deploy the vSphere Integrated Containers Appliance](vic_vsphere_admin/deploy_vic_appliance.md)
 - [Deploy Virtual Container Hosts Interactively](vic_vsphere_admin/deploy_demo_vch.md)
 - [View and Manage VCHs, Add Registries, and Provision Containers Through the Management Portal](vic_cloud_admin/vchs_and_mgmt_portal.md)
 - [Supported Docker Commands](vic_app_dev/container_operations.md)

--- a/docs/user_doc/vic_vsphere_admin/deploy_demo_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_demo_vch.md
@@ -8,8 +8,8 @@ The demo VCH has the minimum configuration that deployment to vCenter Server req
 
 **Prerequisites** 
 
-- You deployed the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.html).
-- You opened port 2377 for outgoing connections on all ESXi hosts in your vCenter Server environment. For information about opening port 2377, see [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.html).
+- You deployed the vSphere Integrated Containers appliance. For information about deploying the appliance, see [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md).
+- You opened port 2377 for outgoing connections on all ESXi hosts in your vCenter Server environment. For information about opening port 2377, see [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.md).
 - You must create two distributed port groups, one each for the bridge and public networks, on the vCenter Server instance on which to deploy the VCH. For information about how to create a distributed virtual switch and a port group, see [Create a vSphere Distributed Switch](https://pubs.vmware.com/vsphere-65/topic/com.vmware.vsphere.networking.doc/GUID-D21B3241-0AC9-437C-80B1-0C8043CC1D7D.html) and [Add Hosts to a vSphere Distributed Switch](https://pubs.vmware.com/vsphere-65/topic/com.vmware.vsphere.networking.doc/GUID-E90C1B0D-82CB-4A3D-BE1B-0FDCD6575725.html) in the vSphere documentation.   
 
 **NOTE**: When using `vic-machine` to deploy VCHs, if you do not specify a network or port group for the public network, the VCH uses the VM Network by default. However, because the VM Network might not be present, the demo VCH requires that you create a port group for the public network. 
@@ -59,5 +59,5 @@ At the end of a successful deployment, **Execution Output** displays information
 **What to Do Next**
 
 - Connect a Docker client to the VCH and run Docker commands against it. For information about running Docker commands against a VCH, see [Verify the Deployment of a VCH](verify_vch_deployment.md).
-- Copy the generated command output under **Create Command** and use it as a template for use with `vic-machine` to create production VCHs. For information about how to deploy production VCHs, see [Using `vic-machine` to Deploy Virtual Container Hosts](deploy_vch.html).
+- Copy the generated command output under **Create Command** and use it as a template for use with `vic-machine` to create production VCHs. For information about how to deploy production VCHs, see [Using `vic-machine` to Deploy Virtual Container Hosts](deploy_vch.md).
 - Go to http://<i>vic_appliance_address</i>, click the link to **Go to the vSphere Integrated Containers Management Portal**, enter the vCenter Server Single Sign-On credentials, and go to **Home** > **Clusters**. After creating a VCH, the web installer adds the VCH to the management portal instance that is running in the appliance. 

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -64,17 +64,17 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
 
     **IMPORTANT**: The installation process requires the single sign-on credentials to set up vSphere Integrated Containers Management Portal and Registry. The vSphere Integrated Containers Management Portal and Registry services cannot start if you do not complete this step.
 
-You can reconfigure the appliance after deployment by editing the settings of the appliance VM. For information about reconfiguring the appliance, see [Reconfigure the vSphere Integrated Containers Appliance](reconfigure_appliance.html).
+You can reconfigure the appliance after deployment by editing the settings of the appliance VM. For information about reconfiguring the appliance, see [Reconfigure the vSphere Integrated Containers Appliance](reconfigure_appliance.md).
 
 **What to Do Next**
 
 Access the different vSphere Integrated Containers components from the  vSphere Integrated Containers Getting Started page at  http://<i>vic_appliance_address</i>.
 
 - Click the link to go to the **vSphere Integrated Containers Management Portal**. For information about how to use vSphere Integrated Containers Management Portal, see [View and Manage VCHs, Add Registries, and Provision Containers Through the Management Portal](../vic_cloud_admin/vchs_and_mgmt_portal.md).
-- Scroll down to **Infrastructure deployment tools** and click the link to go to the **Demo VCH Installer Wizard**. For information about how to use the interactive VCH installer, see [Deploy a Virtual Container Host Interactively](deploy_demo_vch.html).
+- Scroll down to **Infrastructure deployment tools** and click the link to go to the **Demo VCH Installer Wizard**. For information about how to use the interactive VCH installer, see [Deploy a Virtual Container Host Interactively](deploy_demo_vch.md).
 - Scroll down to **Infrastructure deployment tools** and click the link to **download the vSphere Integrated Containers Engine bundle**. The vSphere Integrated Containers Engine bundle allows you to perform the following tasks:
 
-   - Use `vic-machine` to configure the firewalls on all ESXi hosts to permit VCH deployment. For information about how to configure the firewalls on ESXi hosts, see [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.html).
+   - Use `vic-machine` to configure the firewalls on all ESXi hosts to permit VCH deployment. For information about how to configure the firewalls on ESXi hosts, see [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.md).
    - Install the vSphere Client plug-ins for vSphere Integrated Containers. For information about installing the plug-ins, see [Installing the vSphere Client Plug-ins](install_vic_plugin.md).       
    - Use `vic-machine` to deploy production VCHs. For information about deploying VCHs with `vic-machine`, see [Deploy Virtual Container Hosts with `vic-machine`](deploy_vch.md).
       

--- a/docs/user_doc/vic_vsphere_admin/installing_vic.md
+++ b/docs/user_doc/vic_vsphere_admin/installing_vic.md
@@ -5,4 +5,4 @@ You install vSphere Integrated Containers by deploying an OVA appliance. The OVA
 - [Download vSphere Integrated Containers](download_vic.md)
 - [Deploy the vSphere Integrated Containers Appliance](deploy_vic_appliance.md)
 - [Install the vSphere Client plug-ins on vCenter Server](install_vic_plugin.md)
-- [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.html)
+- [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.md)

--- a/docs/user_doc/vic_vsphere_admin/security_reference.md
+++ b/docs/user_doc/vic_vsphere_admin/security_reference.md
@@ -46,7 +46,7 @@ Public interface:
 - vSphere Integrated Containers Engine does not use ports when not configured for debug
 
 ## Service Accounts and Privileges <a id="accounts"></a>
-vSphere Integrated Containers Engine does not create service accounts and does not assign privileges. The `--ops-user` and `--ops-password` options allow a VCH to operate with less-privileged credentials than those that are required for deploying a new VCH. For information about the `--ops-user` option and the permissions that it requires, see the descriptions of `--ops-user` in [VCH Deployment Options](vch_installer_options.html#ops-user) and [Advanced Examples of Deploying a VCH](vch_installer_examples.html#ops-user), and the section [Use Different User Accounts for VCH Deployment and Operation](set_up_ops_user.html).
+vSphere Integrated Containers Engine does not create service accounts and does not assign privileges. The `--ops-user` and `--ops-password` options allow a VCH to operate with less-privileged credentials than those that are required for deploying a new VCH. For information about the `--ops-user` option and the permissions that it requires, see the descriptions of `--ops-user` in [VCH Deployment Options](vch_installer_options.md#ops-user) and [Advanced Examples of Deploying a VCH](vch_installer_examples.md#ops-user), and the section [Use Different User Accounts for VCH Deployment and Operation](set_up_ops_user.md).
 
 
 

--- a/docs/user_doc/vic_vsphere_admin/vch_installer_options.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_installer_options.md
@@ -927,7 +927,7 @@ Short name: `-v`
 
 Deploy the VCH with more verbose levels of logging, and optionally modify the behavior of `vic-machine` for troubleshooting purposes. Specifying the `--debug` option increases the verbosity of the logging for all aspects of VCH operation, not just deployment. For example, by setting the `--debug` option, you increase the verbosity of the logging for VCH initialization, VCH services, container VM initialization, and so on. If not specified, the `--debug` value is set to 0 and verbose logging is disabled.
 
-**NOTE**: Do not confuse the `vic-machine create --debug` option with the `vic-machine debug` command, that enables access to the VCH endpoint VM. For information about `vic-machine debug`, see [Debugging the VCH](debug_vch.html). 
+**NOTE**: Do not confuse the `vic-machine create --debug` option with the `vic-machine debug` command, that enables access to the VCH endpoint VM. For information about `vic-machine debug`, see [Debugging the VCH](debug_vch.md). 
 
 When you specify `vic-machine create --debug`, you set a debugging level of 1, 2, or 3. Setting `--debug` to 2 or 3 changes the behavior of `vic-machine create` as well as increasing the level of verbosity of the logs:
 


### PR DESCRIPTION
Found a load of links that include `.html` in the Markdown, that should be `.md`. 

@anchal-agrawal can you please review?