### PR TITLE
Removes the build number from OVA console version

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -168,11 +168,9 @@
                                 </div>
                             </div>
                         </div>
-                        {{if .InitErrorFeedback}}
                         <a href="/?login=true" id="feedback-link" class="btn btn-link px-0 my-2">
                             Re-initialize the vSphere Integrated Container Appliance
                         </a>
-                        {{ end }}
                     </div>
                 </div>
                 {{if .NeedLogin}}

--- a/installer/pkg/version/version.go
+++ b/installer/pkg/version/version.go
@@ -85,7 +85,7 @@ func (v *Build) String() string {
 }
 
 func (v *Build) ShortVersion() string {
-	return fmt.Sprintf("%s-%s-%s", v.Version, v.BuildNumber, v.GitCommit)
+	return fmt.Sprintf("%s-%s", v.Version, v.GitCommit)
 }
 
 // Equal determines if v is equal to b based on BuildNumber


### PR DESCRIPTION
The OVA console version now diplays <tag>-<commit-hash>
on the top line.

Cherry picks commit a8c2e0d565bfaeb8f399047ada68786f5dd7efe5
From PR #652 