### PR TITLE
Fix re-initialize button in Getting Started page

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -168,11 +168,9 @@
                                 </div>
                             </div>
                         </div>
-                        {{if .InitErrorFeedback}}
                         <a href="/?login=true" id="feedback-link" class="btn btn-link px-0 my-2">
                             Re-initialize the vSphere Integrated Container Appliance
                         </a>
-                        {{ end }}
                     </div>
                 </div>
                 {{if .NeedLogin}}


### PR DESCRIPTION
This commit removes the condition to show the re-initialize button only
when an error alert is present.

Cherry picks fccc0856a1d1de95ecb7f955ffc8c766e60e4e0c
From PR #641 