### PR TITLE
OVA build sets version programmatically

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -112,6 +112,7 @@ ova-release: gas $(ovfenv) $(vic-ova-ui) $(ova-webserver) $(ova-engine-installer
 			packer-vic.json
 	@echo adding proper vic OVF file...
 	@cd $(BASE_DIR)packer/vic/vic && $(RM) vic.ovf && $(CP) ../../vic-unified.ovf vic.ovf
+	@cd $(BASE_DIR)packer/vic/vic && $(SED) -i -e s~--version--~$(BUILD_VICENGINE_REVISION)~ vic.ovf
 ifeq ($(OS),darwin)
 	@echo rebuilding OVF manifest in darwin...
 	@cd $(BASE_DIR)packer/vic/vic && $(RM) vic.mf && shasum -a 256 * | $(AWK) '{print "SHA256("$$2") = "$$1}' > vic.mf
@@ -141,6 +142,7 @@ ova-debug: $(ovfenv) $(vic-ova-ui) $(ova-webserver) $(ova-engine-installer) $(to
 			--on-error=abort packer-vic.json
 	@echo adding proper vic OVF file...
 	cd $(BASE_DIR)packer/vic/vic && $(RM) vic.ovf && $(CP) ../../vic-unified.ovf vic.ovf
+	@cd $(BASE_DIR)packer/vic/vic && $(SED) -i -e s~--version--~$(BUILD_VICENGINE_REVISION)~ vic.ovf
 ifeq ($(OS),darwin)
 	@echo rebuilding OVF manifest in darwin...
 	@cd $(BASE_DIR)packer/vic/vic && $(RM) vic.mf && shasum -a 256 * | $(AWK) '{print "SHA256("$$2") = "$$1}' > vic.mf

--- a/installer/packer/vic-unified.ovf
+++ b/installer/packer/vic-unified.ovf
@@ -170,13 +170,16 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
             Version is the actual product version in the
             form X.X.X.X where X is an unsigned 16-bit integer.
 
+            This is set by the $BUILD_VICENGINE_REVISION
+            environment variable.
+
             FullVersion is a descriptive version string
             including, for example, alpha or beta designations
             and other release criteria.
         -->
 
 
-      <Version>1.1.1.1</Version>
+      <Version>--version--</Version>
       <FullVersion/>
       <ProductUrl>https://github.com/vmware/vic</ProductUrl>
       <VendorUrl/>


### PR DESCRIPTION
Building an ova file now sets the version number by replacing
"--version--" with the version set by the BUILD_VICENGINE_REVISION
environment variable.

Cherry-picks 5e05fb1ea68018c4b56b7e0d5812c5691e45fa0c
From PR https://github.com/vmware/vic-product/pull/625