### PR TITLE
Removes the build number from OVA console version

### DIFF
--- a/installer/pkg/version/version.go
+++ b/installer/pkg/version/version.go
@@ -85,7 +85,7 @@ func (v *Build) String() string {
 }
 
 func (v *Build) ShortVersion() string {
-	return fmt.Sprintf("%s-%s-%s", v.Version, v.BuildNumber, v.GitCommit)
+	return fmt.Sprintf("%s-%s", v.Version, v.GitCommit)
 }
 
 // Equal determines if v is equal to b based on BuildNumber


### PR DESCRIPTION
The OVA console version now diplays <tag>-<commit-hash>
on the top line.

Cherry picks 56db5e485240b1f597ba6cd9dbab5968af55ed78
From PR https://github.com/vmware/vic-product/pull/652