### PR TITLE
Added that Mgmt Portal requires PKCS8 cert key.

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -50,7 +50,7 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
     - In the **Management Portal Port** text box, optionally change the port on which to publish the vSphere Integrated Containers Management Portal service.
     - To use custom certificates to authenticate connections to vSphere Integrated Containers Management Portal, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. 
 
-        **IMPORTANT**: vSphere Integrated Containers Management Portal does not support RSA format for TLS private keys. You must specify TLS private keys in PKCS8 format. Make sure there is no whitespace at the end of the key.
+        **IMPORTANT**: vSphere Integrated Containers Management Portal does not support RSA format for TLS private keys. You must specify TLS private keys in PKCS8 format. Make sure there is no whitespace at the end of the key. To convert an RSA key to PKCS8 format, run the following command: <pre>$ openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in <i>key_name</i>.io.key.pem -out <i>key_name</i>.io.key.pkcs8</pre>
 
     - Leave the text boxes blank to use auto-generated certificates.
 7. Expand **Fileserver Configuration** to configure the file server from which you download the vSphere Integrated Containers Engine binaries, and which publishes the plug-in packages for the vSphere Client. 

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -48,11 +48,16 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
 7. Expand **Management Portal Configuration** to configure the deployment of vSphere Integrated Containers Management Portal. 
 
     - In the **Management Portal Port** text box, optionally change the port on which to publish the vSphere Integrated Containers Management Portal service.
-    - To use custom certificates to authenticate connections to vSphere Integrated Containers Management Portal, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. Leave the text boxes blank to use auto-generated certificates.
+    - To use custom certificates to authenticate connections to vSphere Integrated Containers Management Portal, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. 
+
+        **IMPORTANT**: vSphere Integrated Containers Management Portal does not support RSA format for TLS private keys. You must specify TLS private keys in PKCS8 format. Make sure there is no whitespace at the end of the key.
+
+    - Leave the text boxes blank to use auto-generated certificates.
 7. Expand **Fileserver Configuration** to configure the file server from which you download the vSphere Integrated Containers Engine binaries, and which publishes the plug-in packages for the vSphere Client. 
 
    - In the **Fileserver Port** text box, optionally change the port on which the vSphere Integrated Containers Engine file server runs.
-   - To use custom certificates to authenticate connections to the vSphere Integrated Containers Engine file server, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. Leave the text boxes blank to use auto-generated certificates.
+   - To use custom certificates to authenticate connections to the vSphere Integrated Containers Engine file server, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. The file server supports RSA format for TLS private keys. 
+   - Leave the text boxes blank to use auto-generated certificates.    
 
 7. Expand **Demo VCH Installer Wizard Configuration** to optionally change the port on which the interactive web installer for virtual container hosts (VCHs) runs.
 8. Click **Next** and **Finish** to deploy the vSphere Integrated Containers appliance.

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -50,7 +50,7 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
     - In the **Management Portal Port** text box, optionally change the port on which to publish the vSphere Integrated Containers Management Portal service.
     - To use custom certificates to authenticate connections to vSphere Integrated Containers Management Portal, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. 
 
-        **IMPORTANT**: vSphere Integrated Containers Management Portal does not support RSA format for TLS private keys. You must specify TLS private keys in PKCS8 format. Make sure there is no whitespace at the end of the key. To convert an RSA key to PKCS8 format, run the following command: <pre>$ openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in <i>key_name</i>.io.key.pem -out <i>key_name</i>.io.key.pkcs8</pre>
+        **IMPORTANT**: vSphere Integrated Containers Management Portal does not support RSA format for TLS private keys. You must specify TLS private keys in PKCS8 format. Make sure there is no whitespace at the end of the key. To convert an RSA key to PKCS8 format, run the following command: <pre>$ openssl pkcs8 -topk8 -inform PEM -outform PEM -nocrypt -in <i>key_name</i>.pem -out <i>key_name</i>.pkcs8.pem</pre>
 
     - Leave the text boxes blank to use auto-generated certificates.
 7. Expand **Fileserver Configuration** to configure the file server from which you download the vSphere Integrated Containers Engine binaries, and which publishes the plug-in packages for the vSphere Client. 


### PR DESCRIPTION
Fixes https://github.com/vmware/vic-product/issues/347.

@andrewtchin can you please review?

In https://github.com/vmware/vic-product/issues/347 you include a procedure to convert RSA key to PKCS8. Do we need to include that in our docs, since it's generic open SSL stuff?