### PR TITLE
Pull dbpass from cfg in upgrade script

### DIFF
--- a/installer/packer/scripts/upgrade/upgrade_1.1_to_1.2.sh
+++ b/installer/packer/scripts/upgrade/upgrade_1.1_to_1.2.sh
@@ -140,6 +140,21 @@ function configureHarborCfgUnset {
   fi
 }
 
+# Returns value from cfg given key to search for
+# Stored in cfg as key = value
+function readHarborCfgKey {
+  local cfg_key=$1
+  local  __resultvar=$2
+  local value
+  value=$(grep "^$cfg_key =" $cfg | cut -d'=' -f 2 | xargs)
+
+  if [ -z "$value" ]; then
+      echo "Key not found: $cfg_key"
+    else
+      eval "$__resultvar"="'$value'"
+    fi
+}
+
 # Add managed keyword to key if not already managed
 function configureHarborCfgManageKey {
   local cfg_key=$1
@@ -439,6 +454,7 @@ function main {
     case $key in
       --dbpass)
         DB_PASSWORD="$2"
+        echo "--dbpass overriding stored password"
         shift # past argument
         ;;
       --dbuser)
@@ -469,7 +485,13 @@ function main {
   fi
 
   if [ -z "${DB_PASSWORD}" ]; then
-    echo "--dbpass not set"
+    echo "Getting password from harbor.cfg"
+    readHarborCfgKey db_password DB_PASSWORD
+  fi
+
+  # If DB_PASSWORD not set by cfg, exit
+  if [ -z "${DB_PASSWORD}" ]; then
+    echo "--dbpass not set and value not found in $cfg"
     exit 1
   fi
 


### PR DESCRIPTION
If the --dpbass parameter is not set, pull the password from
the harbor cfg file.  If it is passed to the upgrade script,
use the passed password.

Fixes: #629 