### PR TITLE
Add BridgeNetworkRange to Demo VCH Installer Wizard

### DIFF
--- a/installer/engine_installer/engine_installer.go
+++ b/installer/engine_installer/engine_installer.go
@@ -44,6 +44,7 @@ type EngineInstallerConfigOptions struct {
 type EngineInstaller struct {
 	loginInfo       lib.LoginInfo
 	BridgeNetwork   string `json:"bridge-net"`
+	BridgeNetworkRange   string `json:"bridge-net-range"`
 	PublicNetwork   string `json:"public-net"`
 	ImageStore      string `json:"img-store"`
 	ComputeResource string `json:"compute"`
@@ -60,6 +61,7 @@ type AuthHTML struct {
 // ExecHTMLOptions contains fields for html templating in exec.html
 type ExecHTMLOptions struct {
 	BridgeNetwork   template.HTML
+	BridgeNetworkRange   template.HTML
 	PublicNetwork   template.HTML
 	ImageStore      template.HTML
 	ComputeResource template.HTML
@@ -147,6 +149,7 @@ func (ei *EngineInstaller) buildCreateCommand(binaryPath string) {
 	createCommand = append(createCommand, []string{"--name", ei.Name}...)
 	createCommand = append(createCommand, []string{"--public-network", ei.PublicNetwork}...)
 	createCommand = append(createCommand, []string{"--bridge-network", ei.BridgeNetwork}...)
+	createCommand = append(createCommand, []string{"--bridge-network-range", ei.BridgeNetworkRange}...)
 	createCommand = append(createCommand, []string{"--compute-resource", ei.ComputeResource}...)
 	createCommand = append(createCommand, []string{"--image-store", ei.ImageStore}...)
 	if ip, err := ip.FirstIPv4(ip.Eth0Interface); err == nil {

--- a/installer/engine_installer/html/exec.html
+++ b/installer/engine_installer/html/exec.html
@@ -26,6 +26,7 @@
         $("#log").html("");
         var data = {
           "bridge-net": $("[name='bridge-net'] option:selected").text(),
+          "bridge-net-range": $("[name='bridge-net-range']").val(),
           "public-net": $("[name='public-net'] option:selected").text(),
           "img-store": $("[name='img-store'] option:selected").text(),
           "compute": $("[name='compute'] option:selected").text(),
@@ -92,6 +93,10 @@
                   <div class="row">
                     <div class="forty">Bridge Network: </div>
                     <div class="sixty form-group" style="padding-left: 0;">{{.BridgeNetwork}}</div>
+                  </div>
+                  <div class="row">
+                    <div class="forty">Bridge Network Range: </div>
+                    <div class="sixty form-group" style="padding-left: 0;">{{.BridgeNetworkRange}}</div>
                   </div>
                   <div class="row">
                     <div class="forty">Public Network: </div>

--- a/installer/engine_installer/server.go
+++ b/installer/engine_installer/server.go
@@ -35,6 +35,7 @@ import (
 const (
 	publicNetName = "public-net"
 	bridgeNetName = "bridge-net"
+	bridgeNetRangeName = "bridge-net-range"
 	imgStoreName  = "img-store"
 	computeName   = "compute"
 	port          = ":1337"
@@ -131,6 +132,7 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 
 			html.PublicNetwork = getSelectOptionHTML(opts.Networks, publicNetName)
 			html.BridgeNetwork = getSelectOptionHTML(opts.Networks, bridgeNetName)
+			html.BridgeNetworkRange = getSelectOptionHTML(opts.Networks, bridgeNetRangeName)
 			html.ImageStore = getSelectOptionHTML(opts.Datastores, imgStoreName)
 			html.ComputeResource = getSelectOptionHTML(opts.ResourcePools, computeName)
 


### PR DESCRIPTION
My main infrastructure network is 172.16.100.0 which conflicting with bridge network inside VCH. Thus deployment with Demo VCH Install Wizard is not working (all traffic for external purposes goes throughout bridge network instead of client network). This request is to add BridgeNetworkRange to the Demo Installer Wizard.