### PR TITLE
Add support for external PSC in Getting Started page

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -211,6 +211,10 @@
                                             <input id="user" type="text" name="user" placeholder="username@domain.local">
                                             <input type="password" name="password" placeholder="Password" />
                                         </div>
+                                        <div class="form-group">
+                                            <label for="psc">PSC Instance, if external</label>
+                                            <input id="psc" type="text" name="psc" placeholder="FQDN">
+                                        </div>
                                     </div>
                                     <div class="text-sm-right">
                                         <button id="login-submit" type="submit" class="btn btn-primary">Continue</button>

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -65,6 +65,9 @@ type IndexHTMLOptions struct {
 var (
 	admin = &lib.LoginInfo{}
 	c     config
+
+	// pscInstance holds the form input for the PSC field
+	pscInstance string
 )
 
 const initServicesTimestamp = "./registration-timestamps.txt"
@@ -200,9 +203,10 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 		admin.Target = req.FormValue("target")
 		admin.User = req.FormValue("user")
 		admin.Password = req.FormValue("password")
+		pscInstance = req.FormValue("psc")
 
 		if err := admin.VerifyLogin(); err != nil {
-			log.Infof("Validation failed")
+			log.Infof("Validation failed: %s", err.Error())
 			html.InvalidLogin = true
 
 		} else {

--- a/installer/fileserver/tasks.go
+++ b/installer/fileserver/tasks.go
@@ -49,11 +49,14 @@ func registerWithPSC(ctx context.Context) error {
 		domain = userFields[1]
 	}
 
-	// Obtain the hostname of the vCenter host
-	vcHostname, err := optmanager.QueryOptionValue(ctx, admin.Validator.Session, vcHostnameOption)
-	if err != nil {
-		return err
+	if pscInstance == "" {
+		// Obtain the hostname of the vCenter host to use as PSC instance
+		pscInstance, err = optmanager.QueryOptionValue(ctx, admin.Validator.Session, vcHostnameOption)
+		if err != nil {
+			return err
+		}
 	}
+	log.Infof("PSC instance: %s", pscInstance)
 
 	// Obtain the OVA VM's IP
 	vmIP, err := ip.FirstIPv4(ip.Eth0Interface)
@@ -93,7 +96,7 @@ func registerWithPSC(ctx context.Context) error {
 			// NOTE(anchal): version set to 6.0 to use SAML for both versions 6.0 and 6.5
 			"--version=6.0",
 			"--tenant=" + domain,
-			"--domainController=" + vcHostname,
+			"--domainController=" + pscInstance,
 			"--username=" + admin.User,
 			"--password=" + admin.Password,
 			"--admiralUrl=" + fmt.Sprintf("https://%s:%s", vmIP.String(), admiralPort),


### PR DESCRIPTION
This change allows the user to specify an external PSC instance
(not embedded on the vCenter host) as an optional input field in
the Getting Started page's login modal.

Cherry-picks commit d517bb9b83147b54244de9714c57a3363c9361fb for 1.2.1.