### PR TITLE
Adding .bookignore file to exclude covers and graphic_sources from builds

### DIFF
--- a/docs/user_doc/.bookignore
+++ b/docs/user_doc/.bookignore
@@ -1,0 +1,2 @@
+covers/*
+graphic_sources/*


### PR DESCRIPTION
The `.bookignore` file prevents the `covers` and `graphic_sources` folders being included in the HTML output. The fact that the MD source files are copied into the output folders appears to be a bug in Gitbook, because the files are not in the same folder as the master `SUMMARY.md` file.