### PR TITLE
Print warning banner upon SSH login to OVA and address scan results 

### DIFF
--- a/installer/build/scripts/system_settings.sh
+++ b/installer/build/scripts/system_settings.sh
@@ -25,7 +25,7 @@ systemctl enable harbor_startup.path admiral_startup.path get_token.timer
 systemctl enable fileserver_startup.service fileserver.service
 systemctl enable engine_installer_startup.service engine_installer.service
 systemctl enable vic_machine_server.service
-ss
+
 # Clean up temporary directories
 rm -rf /tmp/* /var/tmp/*
 tdnf clean all

--- a/installer/build/scripts/system_settings.sh
+++ b/installer/build/scripts/system_settings.sh
@@ -32,7 +32,6 @@ tdnf clean all
 
 # Warning message for client ssh
 message="########################################################################
-##  Welcome!                                                           #
 ##  SSH access to the vSphere Integrated Containers Appliance can be   #
 ##  used in exceptional cases that cannot be handled through standard  #
 ##  remote management or CLI tools. This is primarily intended for use #

--- a/installer/build/scripts/system_settings.sh
+++ b/installer/build/scripts/system_settings.sh
@@ -52,10 +52,11 @@ fi
 echo "$message" > "/etc/motd"
 
 # Disable IPv6 redirection and router advertisements in kernel settings
-echo "net.ipv6.conf.all.accept_redirects = 0" >> "/etc/sysctl.d/40-ipv6.conf"
-echo "net.ipv6.conf.default.accept_redirects = 0" >> "/etc/sysctl.d/40-ipv6.conf"
-echo "net.ipv6.conf.all.accept_ra = 0" >> "/etc/sysctl.d/40-ipv6.conf"
-echo "net.ipv6.conf.default.accept_ra = 0" >> "/etc/sysctl.d/40-ipv6.conf"
+settings="net.ipv6.conf.all.accept_redirects = 0
+net.ipv6.conf.default.accept_redirects = 0
+net.ipv6.conf.all.accept_ra = 0
+net.ipv6.conf.default.accept_ra = 0"
+echo "$settings" > "/etc/sysctl.d/40-ipv6.conf"
 
 # Hardening SSH configuration
 afsetting=$(grep "AllowAgentForwarding" /etc/ssh/sshd_config)


### PR DESCRIPTION
Fixes #742 , #892 


1. A warning message is print before and after login to OVA via SSH

![screen shot 2017-10-13 at 4 40 19 pm](https://user-images.githubusercontent.com/6562128/31634259-7f61ba5e-b288-11e7-9b55-42ef5b8b37e2.png)

2. SSH forwarding is disabled 
```
AllowAgentForwarding no
AllowTcpForwarding no
```

3. IPv6 ICMP redirection is disabled
```
net.ipv6.conf.all.accept_redirect = 0
net.ipv6.conf.default.accept_redirect = 0
 ```

4. IPv6 Router Advertisement is disabled
```
net.ipv6.conf.all.accept_ra = 0
net.ipv6.conf.default.accept_ra = 0
```