### PR TITLE
Hande SIGPIPE errors in the build script

### DIFF
--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -105,11 +105,11 @@ setenv ADMIRAL "dev"
 setenv VIC_MACHINE_SERVER "latest"
 
 # set Vic-Engine
-url=$(gsutil ls -l "gs://vic-engine-builds" | grep -v TOTAL | grep vic_ | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+url=$(gsutil ls -l "gs://vic-engine-builds" | grep -v TOTAL | grep vic_ | sort -k2 -r | (trap '' PIPE; head -1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
 setenv VICENGINE "$url"
 
 #set Harbor
-url=$(gsutil ls -l "gs://harbor-builds" | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+url=$(gsutil ls -l "gs://harbor-builds" | grep -v TOTAL | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
 setenv HARBOR "$url"
 
 


### PR DESCRIPTION
The build script uses `head -n1` in a chain of pipes to trim input. This would be fine, except that it also sets `-o pipefail` (which prevents errors in a pipeline from being masked) and `-e` (which causes the script to exit on the first error).

The result is that the script terminates when the output being trimmed by `head` exceeds one line. When this happens no output is printed, but the return value is 141 (=128+13) which tells us SIGPIPE is the culprit.

We confirm `head -n1` is the source of issue by inspecting PIPESTATUS:

```
$ gsutil ls -l "gs://harbor-builds" | grep -v TOTAL | sort -k2 -r | head -n1 | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//'
https://storage.googleapis.com/harbor-builds/harbor-offline-installer-v1.2.0-84-g9847223.tgz
$ echo ${PIPESTATUS[@]}
0 0 141 0 0 0 0
```

This shows us that `head -n1` closed the pipe before `sort` finished writing data (which makes sense), causing `sort` to raise SIGPIPE.

It's not clear why other users of this script have not encountered this behavior, but it is consistent in my environment.