### PR TITLE
Fix minor documentation issues related to the build script

### DIFF
--- a/installer/BUILD.md
+++ b/installer/BUILD.md
@@ -31,20 +31,20 @@ required environment variables.
 
 If called without any values, `build.sh` will get the latest build for each component
 ```
-./scripts/build.sh ova-dev
+./build/build.sh ova-dev
 ```
 
 If called with the values below, `build.sh` will include the Harbor version from
 `packer/scripts/harbor.tgz`, the VIC Engine version from `packer/scripts/vic.tar.gz`, and 
 Admiral tag `vic_dev` (since `--admiral` was not specified it defaults to the `vic_dev` tag)
 ```
-./scripts/build.sh ova-dev --harbor harbor.tgz --vicengine vic.tar.gz
+./build/build.sh ova-dev --harbor harbor.tgz --vicengine vic.tar.gz
 ```
 
 If called with the values below, `build.sh` will include the Harbor and VIC Engine versions
 specified by their respective URLs, and Admiral tag `vic_v1.1.1`
 ```
-./scripts/build.sh ova-dev --admiral v1.1.1 --harbor https://example.com/harbor.tgz --vicengine https://example.com/vic.tar.gz
+./build/build.sh ova-dev --admiral v1.1.1 --harbor https://example.com/harbor.tgz --vicengine https://example.com/vic.tar.gz
 ```
 
 #### Upload

--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -61,6 +61,7 @@ GIT_TAG="$(git describe --tags)"
 export BUILD_OVA_REVISION=${GIT_TAG}
 export BUILD_DCHPHOTON_VERSION="1.13"
 
+[ $# -gt 0 ] || usage
 step=$1; shift
 [ ! "$step" == "ova-ci" ] || [ ! "$step" == "ova-dev" ] || usage
 


### PR DESCRIPTION
1.  Correct path to build script in documentation 
2.  Display usage (instead of failing with an error) if build script called without args 

