### PR TITLE
Set user for Admiral data directory

### DIFF
--- a/installer/build/scripts/admiral/configure_admiral.sh
+++ b/installer/build/scripts/admiral/configure_admiral.sh
@@ -217,7 +217,7 @@ sed -i "/\b\(keystore.file\)\b/d" $config_dir/psc-config.properties
 echo "keystore.file=/configs/psc-config.keystore" >> $config_dir/psc-config.properties
 
 # Set access for UID 999 used by Admiral container
-chown -R 999:999 $data_dir
+chown -R 10000:10000 $data_dir
 
 # Start on startup
 echo "Enable admiral startup."

--- a/installer/build/scripts/admiral/configure_admiral.sh
+++ b/installer/build/scripts/admiral/configure_admiral.sh
@@ -216,6 +216,9 @@ cp $admiral_psc_dir/psc-config.properties $config_dir
 sed -i "/\b\(keystore.file\)\b/d" $config_dir/psc-config.properties
 echo "keystore.file=/configs/psc-config.keystore" >> $config_dir/psc-config.properties
 
+# Set access for UID 999 used by Admiral container
+chown -R 999:999 $data_dir
+
 # Start on startup
 echo "Enable admiral startup."
 systemctl enable admiral_startup.service


### PR DESCRIPTION
Fixes #972 

```
root@localhost [ /storage/data ]# ls -al
total 44
drwxr-xr-x 7 root  root   4096 Nov  1 20:34 .
drwxr-xr-x 5 root  root   4096 Nov  1 20:49 ..
drwxr-x--- 6 10000 10000  4096 Nov  1 20:52 admiral
drwxr-x--- 2 root  root   4096 Nov  1 20:34 certs
drwxr-x--- 2 root  root   4096 Nov  1 20:34 fileserver
drwxr-x--- 7 root  root   4096 Nov  1 20:53 harbor
drwx------ 2 root  root  16384 Nov  1 20:30 lost+found
-rw-r----- 1 root  root    244 Nov  1 20:52 version
root@localhost [ /storage/data ]# cd admiral/
root@localhost [ /storage/data/admiral ]# ls -al
total 32
drwxr-x--- 6 10000 10000 4096 Nov  1 20:52 .
drwxr-xr-x 7 root  root  4096 Nov  1 20:34 ..
drwxr-xr-x 5 10000 10000 4096 Nov  1 20:51 8282
drwx------ 2 10000 10000 4096 Nov  1 20:52 ca_download
drwx------ 2 10000 10000 4096 Nov  1 20:50 cert
-rw------- 1 10000 10000   12 Nov  1 20:50 cert_gen_type
drwx------ 2 10000 10000 4096 Nov  1 20:52 configs
-rw------- 1 10000 10000   41 Nov  1 20:52 custom.conf

```