### PR TITLE
Formatting fix in backup doc

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/backup_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/backup_vch.md
@@ -19,7 +19,7 @@ Containers encourage application designers to think about where state belongs an
 
 ### Container Volumes
 
-Let's assume that a stateful container has one or more volumes attached and a stateless container does not.
+Assume that a stateful container has one or more volumes attached and a stateless container does not.
 
 - A stateless container that reads and writes to a remote database can be easily scaled up or down and can be run in multiple failure domains behind a load-balancer. 
 - A stateful container is tied to running in a location from which it can access its volume store. A container volume is intentionally persistent by nature and can exist beyond the lifespan of a container or even of a VCH.

--- a/docs/user_doc/vic_vsphere_admin/backup_volumes.md
+++ b/docs/user_doc/vic_vsphere_admin/backup_volumes.md
@@ -98,9 +98,10 @@ $ exit</pre>
 
     The volumes and the data that they contain are still available after you have deleted the containers.
     <pre>
-DRIVER              VOLUME NAME
-vsphere             mydata
-vsphere             mylogs
-vsphere             myshared
-</pre>
+    DRIVER              VOLUME NAME
+    vsphere             mydata
+    vsphere             mylogs
+    vsphere             myshared
+    </pre>
+
 2. Browse the three datastores to see that the files that the container created are still present.


### PR DESCRIPTION
Fixes the formatting problem that was visible in https://github.com/stuclem/vic-product/blob/backupfix/docs/user_doc/vic_vsphere_admin/backup_volumes.md. HTML output is fine.