### PR TITLE
Store vic machine server logs in log disk

### DIFF
--- a/installer/build/baseimage/install.sh
+++ b/installer/build/baseimage/install.sh
@@ -66,7 +66,7 @@ tdnf install -q --refresh -y \
     iproute2 iptables iputils \
     cdrkit xfsprogs sudo \
     lvm2 parted gptfdisk \
-    e2fsprogs docker &>/dev/null
+    e2fsprogs docker logrotate &>/dev/null
 
 progress "installing package dependencies"
 tdnf install -q --refresh -y \

--- a/installer/build/ova-manifest.json
+++ b/installer/build/ova-manifest.json
@@ -169,6 +169,11 @@
     },
     {
       "type": "file",
+      "source": "scripts/systemd/vic_machine_server/vic-machine-server-logrotate",
+      "destination": "/etc/logrotate.d/vic-machine-server"
+    },
+    {
+      "type": "file",
       "source": "scripts/systemd/harbor/harbor_startup.service",
       "destination": "/usr/lib/systemd/system/harbor_startup.service"
     },

--- a/installer/build/scripts/systemd/vic_machine_server/vic-machine-server-logrotate
+++ b/installer/build/scripts/systemd/vic_machine_server/vic-machine-server-logrotate
@@ -5,6 +5,5 @@
     compress
     delaycompress
     missingok
-    notifempty
-    create 644 root root
+    create 644 10000 10000
 }

--- a/installer/build/scripts/systemd/vic_machine_server/vic-machine-server-logrotate
+++ b/installer/build/scripts/systemd/vic_machine_server/vic-machine-server-logrotate
@@ -1,0 +1,10 @@
+/storage/log/vic-machine-server/vic-machine-server.log {
+	daily
+    size 1M
+	rotate 31
+	compress
+	delaycompress
+	missingok
+	notifempty
+	create 644 root root
+}

--- a/installer/build/scripts/systemd/vic_machine_server/vic-machine-server-logrotate
+++ b/installer/build/scripts/systemd/vic_machine_server/vic-machine-server-logrotate
@@ -1,10 +1,10 @@
 /storage/log/vic-machine-server/vic-machine-server.log {
-	daily
-    size 1M
-	rotate 31
-	compress
-	delaycompress
-	missingok
-	notifempty
-	create 644 root root
+    daily
+    size 1G
+    rotate 10
+    compress
+    delaycompress
+    missingok
+    notifempty
+    create 644 root root
 }

--- a/installer/build/scripts/systemd/vic_machine_server/vic_machine_server.service
+++ b/installer/build/scripts/systemd/vic_machine_server/vic_machine_server.service
@@ -12,7 +12,7 @@ EnvironmentFile=/etc/vmware/environment
 ExecStartPre=-/usr/bin/docker kill vic-machine-server
 ExecStartPre=-/usr/bin/docker rm -f vic-machine-server
 ExecStartPre=/etc/vmware/vic_machine_server/configure_vic_machine_server.sh
-ExecStart=/usr/bin/docker run --rm --name vic-machine-server -v /storage/data/certs:/certs -p ${VIC_MACHINE_SERVER_PORT}:443 vmware/vic-machine-server:ova
+ExecStart=/usr/bin/docker run --rm --name vic-machine-server -v /storage/data/certs:/certs -v /storage/log/vic-machine-server:/var/log/vic-machine-server -p ${VIC_MACHINE_SERVER_PORT}:443 vmware/vic-machine-server:ova
 ExecStop=/usr/bin/docker stop vic-machine-server
 
 [Install]


### PR DESCRIPTION
Fixes #944 by:
 - adding a logrotate config to the appliance
 - adding a volume mount to the vic-machine-server service