### PR TITLE
Use Hostname in PSC registration

### DIFF
--- a/installer/build/scripts/admiral/configure_admiral.sh
+++ b/installer/build/scripts/admiral/configure_admiral.sh
@@ -183,11 +183,11 @@ secure
 
 configureScript $admiral_start_script ADMIRAL_DATA_LOCATION $data_dir
 configureScript $admiral_start_script ADMIRAL_EXPOSED_PORT "$ADMIRAL_PORT"
-configureScript $admiral_start_script OVA_VM_IP "$ip_address"
+configureScript $admiral_start_script OVA_VM_IP "${hostname}"
 
 configureScript $admiral_add_default_users_script ADMIRAL_DATA_LOCATION $data_dir
 configureScript $admiral_add_default_users_script ADMIRAL_EXPOSED_PORT "$ADMIRAL_PORT"
-configureScript $admiral_add_default_users_script OVA_VM_IP "$ip_address"
+configureScript $admiral_add_default_users_script OVA_VM_IP "${hostname}"
 
 iptables -w -A INPUT -j ACCEPT -p tcp --dport "$ADMIRAL_PORT"
 

--- a/installer/build/scripts/admiral/configure_admiral.sh
+++ b/installer/build/scripts/admiral/configure_admiral.sh
@@ -157,10 +157,6 @@ function secure {
 function detectHostname {
   hostname=$(hostnamectl status --static) || true
   if [ -n "$hostname" ]; then
-    if [ "$hostname" = "localhost.localdomain" ]; then
-      hostname=""
-      return
-    fi
     echo "Get hostname from command 'hostnamectl status --static': $hostname"
     return
   fi

--- a/installer/build/scripts/fileserver/configure_fileserver.sh
+++ b/installer/build/scripts/fileserver/configure_fileserver.sh
@@ -148,10 +148,6 @@ function secure {
 function detectHostname {
   hostname=$(hostnamectl status --static) || true
   if [ -n "$hostname" ]; then
-    if [ "$hostname" = "localhost.localdomain" ]; then
-      hostname=""
-      return
-    fi
     echo "Get hostname from command 'hostnamectl status --static': $hostname"
     return
   fi

--- a/installer/build/scripts/harbor/configure_harbor.sh
+++ b/installer/build/scripts/harbor/configure_harbor.sh
@@ -81,10 +81,6 @@ function configureHarborCfgOnce {
 function detectHostname {
   hostname=$(hostnamectl status --static) || true
   if [ -n "$hostname" ]; then
-    if [ "$hostname" = "localhost.localdomain" ]; then
-      hostname=""
-      return
-    fi
     echo "Get hostname from command 'hostnamectl status --static': $hostname"
     return
   fi

--- a/installer/build/scripts/systemd/vic_machine_server/configure_vic_machine_server.sh
+++ b/installer/build/scripts/systemd/vic_machine_server/configure_vic_machine_server.sh
@@ -103,10 +103,6 @@ function secure {
 function detectHostname {
   hostname=$(hostnamectl status --static) || true
   if [ -n "$hostname" ]; then
-    if [ "$hostname" = "localhost.localdomain" ]; then
-      hostname=""
-      return
-    fi
     echo "Get hostname from command 'hostnamectl status --static': $hostname"
     return
   fi

--- a/installer/build/vic-unified.ovf
+++ b/installer/build/vic-unified.ovf
@@ -222,7 +222,7 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
         <Label>2.5. Domain Search Path</Label>
         <Description>The domain search path (space separated domain names) for this VM. Leave blank if DHCP is desired.</Description>
       </Property>
-      <Property ovf:key="fqdn" ovf:type="string" ovf:userConfigurable="true" ovf:value="localhost.localdomain">
+      <Property ovf:key="fqdn" ovf:type="string" ovf:userConfigurable="true">
         <Label>2.6. FQDN</Label>
         <Description>The fully qualified domain name of this VM. Leave blank if DHCP is desired.</Description>
       </Property>

--- a/installer/engine_installer/engine_installer.go
+++ b/installer/engine_installer/engine_installer.go
@@ -54,7 +54,8 @@ type EngineInstaller struct {
 
 // AuthHTML holds the invalid login variable
 type AuthHTML struct {
-	InvalidLogin bool
+	InvalidLogin    bool
+	ConnectionError bool
 }
 
 // ExecHTMLOptions contains fields for html templating in exec.html
@@ -75,7 +76,7 @@ func NewEngineInstaller() *EngineInstaller {
 	return &EngineInstaller{Name: "default-vch"}
 }
 
-func (ei *EngineInstaller) populateConfigOptions() *EngineInstallerConfigOptions {
+func (ei *EngineInstaller) populateConfigOptions() (*EngineInstallerConfigOptions, error) {
 	defer trace.End(trace.Begin(""))
 
 	vc := ei.loginInfo.Validator.IsVC()
@@ -84,7 +85,7 @@ func (ei *EngineInstaller) populateConfigOptions() *EngineInstallerConfigOptions
 	dcs, err := ei.loginInfo.Validator.ListDatacenters()
 	if err != nil {
 		log.Infoln(err)
-		return nil
+		return nil, err
 	}
 	for _, d := range dcs {
 		log.Infof("DC: %s\n", d)
@@ -93,7 +94,7 @@ func (ei *EngineInstaller) populateConfigOptions() *EngineInstallerConfigOptions
 	comp, err := ei.loginInfo.Validator.ListComputeResource()
 	if err != nil {
 		log.Infoln(err)
-		return nil
+		return nil, err
 	}
 	for _, c := range comp {
 		log.Infof("compute: %s\n", c)
@@ -102,7 +103,7 @@ func (ei *EngineInstaller) populateConfigOptions() *EngineInstallerConfigOptions
 	rp, err := ei.loginInfo.Validator.ListResourcePool("*")
 	if err != nil {
 		log.Infoln(err)
-		return nil
+		return nil, err
 	}
 	for _, p := range rp {
 		log.Infof("rp: %s\n", p)
@@ -111,7 +112,7 @@ func (ei *EngineInstaller) populateConfigOptions() *EngineInstallerConfigOptions
 	nets, err := ei.loginInfo.Validator.ListNetworks(!vc) // set to false for vC
 	if err != nil {
 		log.Infoln(err)
-		return nil
+		return nil, err
 	}
 	for _, n := range nets {
 		log.Infof("net: %s\n", n)
@@ -120,7 +121,7 @@ func (ei *EngineInstaller) populateConfigOptions() *EngineInstallerConfigOptions
 	dss, err := ei.loginInfo.Validator.ListDatastores()
 	if err != nil {
 		log.Infoln(err)
-		return nil
+		return nil, err
 	}
 	for _, d := range dss {
 		log.Infof("ds: %s\n", d)
@@ -130,7 +131,7 @@ func (ei *EngineInstaller) populateConfigOptions() *EngineInstallerConfigOptions
 		Networks:      nets,
 		Datastores:    dss,
 		ResourcePools: rp,
-	}
+	}, nil
 }
 
 func (ei *EngineInstaller) buildCreateCommand(binaryPath string) {

--- a/installer/engine_installer/html/auth.html
+++ b/installer/engine_installer/html/auth.html
@@ -45,6 +45,13 @@
             </span>
           </div>
           {{end}}
+          {{if .ConnectionError}}
+          <div class="alert-item">
+            <span class="alert-text">
+                Unable to gather config options from vCenter.
+            </span>
+          </div>
+          {{end}}
           <form method="post">
             <h4>Login to vCenter: </h4>
             <div class="form-group">

--- a/installer/fileserver/register.go
+++ b/installer/fileserver/register.go
@@ -53,7 +53,9 @@ func registerHandler(resp http.ResponseWriter, req *http.Request) {
 		admin.Target = r.Target
 		admin.User = r.User
 		admin.Password = r.Password
-		if err := admin.VerifyLogin(); err != nil {
+		cancel, err := admin.VerifyLogin()
+		defer cancel()
+		if err != nil {
 			http.Error(resp, err.Error(), http.StatusUnauthorized)
 			return
 		}

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -212,8 +212,9 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 		admin.Password = req.FormValue("password")
 		pscInstance = req.FormValue("psc")
 		pscDomain = req.FormValue("pscDomain")
-
-		if err := admin.VerifyLogin(); err != nil {
+		cancel, err := admin.VerifyLogin()
+		defer cancel()
+		if err != nil {
 			log.Infof("Validation failed: %s", err.Error())
 			html.InvalidLogin = true
 

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -141,12 +141,7 @@ func Init(conf *config) {
 	}
 
 	if ip, err := ip.FirstIPv4(ip.Eth0Interface); err == nil {
-		fqdn, err := os.Hostname()
-		if err == nil && fqdn != "" {
-			conf.serverHostname = fqdn
-		} else {
-			conf.serverHostname = ip.String()
-		}
+		conf.serverHostname = getHostname(ovf, ip)
 		if port, ok := ovf.Properties["management_portal.port"]; ok {
 			conf.admiralPort = port
 		}

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -232,7 +232,7 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 
 	html.AdmiralAddr = fmt.Sprintf("https://%s:%s", c.serverHostname, c.admiralPort)
 	html.DemoVCHAddr = fmt.Sprintf("https://%s:%s", c.serverHostname, c.installerPort)
-	html.FileserverAddr = fmt.Sprintf("https://%s:%s/files/%s", c.serverHostname, c.addr, c.vicTarName)
+	html.FileserverAddr = fmt.Sprintf("https://%s%s/files/%s", c.serverHostname, c.addr, c.vicTarName)
 
 	renderTemplate(resp, "html/index.html", html)
 }

--- a/installer/fileserver/tasks.go
+++ b/installer/fileserver/tasks.go
@@ -76,6 +76,13 @@ func registerWithPSC(ctx context.Context) error {
 		return err
 	}
 	admiralPort := ovf.Properties["management_portal.port"]
+	fqdn := ovf.Properties["network.fqdn"]
+	var url string
+	if fqdn == "" {
+		url = fmt.Sprintf("https://%s:%s", vmIP.String(), admiralPort)
+	} else {
+		url = fmt.Sprintf("https://%s:%s", fqdn, admiralPort)
+	}
 
 	// Out of the box users
 	defCreateUsers, foundCreateUsers := ovf.Properties["default_users.create_def_users"]
@@ -105,7 +112,7 @@ func registerWithPSC(ctx context.Context) error {
 			"--domainController=" + pscInstance,
 			"--username=" + admin.User,
 			"--password=" + admin.Password,
-			"--admiralUrl=" + fmt.Sprintf("https://%s:%s", vmIP.String(), admiralPort),
+			"--admiralUrl=" + url,
 			"--configDir=" + pscConfDir,
 		}
 

--- a/installer/fileserver/tasks.go
+++ b/installer/fileserver/tasks.go
@@ -76,12 +76,12 @@ func registerWithPSC(ctx context.Context) error {
 		return err
 	}
 	admiralPort := ovf.Properties["management_portal.port"]
-	fqdn := ovf.Properties["network.fqdn"]
+	fqdn, err := os.Hostname()
 	var url string
-	if fqdn == "" {
-		url = fmt.Sprintf("https://%s:%s", vmIP.String(), admiralPort)
-	} else {
+	if err == nil && fqdn != "" {
 		url = fmt.Sprintf("https://%s:%s", fqdn, admiralPort)
+	} else {
+		url = fmt.Sprintf("https://%s:%s", vmIP.String(), admiralPort)
 	}
 
 	// Out of the box users

--- a/installer/fileserver/tasks.go
+++ b/installer/fileserver/tasks.go
@@ -154,8 +154,9 @@ func getHostname(ovf lib.Environment, vmIP net.IP) string {
 		log.Errorf(err.Error())
 		return vmIP.String()
 	}
-	if string(out) == "" {
+	outString := strings.TrimSpace(string(out))
+	if outString == "" {
 		return vmIP.String()
 	}
-	return string(out)
+	return outString
 }

--- a/installer/lib/login.go
+++ b/installer/lib/login.go
@@ -37,7 +37,7 @@ type LoginInfo struct {
 }
 
 // Verify login based on info given, return non nil error if validation fails.
-func (info *LoginInfo) VerifyLogin() error {
+func (info *LoginInfo) VerifyLogin() (context.CancelFunc, error) {
 	defer trace.End(trace.Begin(""))
 
 	var u url.URL
@@ -59,7 +59,6 @@ func (info *LoginInfo) VerifyLogin() error {
 	input.Password = &passwd
 
 	ctx, cancel := context.WithTimeout(context.Background(), loginTimeout)
-	defer cancel()
 	loginResponse := make(chan error, 1)
 	var v *validate.Validator
 	var err error
@@ -83,5 +82,5 @@ func (info *LoginInfo) VerifyLogin() error {
 
 	}
 
-	return <-loginResponse
+	return cancel, <-loginResponse
 }


### PR DESCRIPTION
Fixes #816, fixes #1014 by removing the default ovf hostname. Uses the hostname, if set, during psc registration as the admiral url.

@sergiosagu and @lcastellano can you please review for proper use of fqdn's to configure admiral and harbor?