### PR TITLE
Added links to Patrick's DCH Photon Swarm doc.

### DIFF
--- a/docs/user_doc/vic_app_dev/build_push_images.md
+++ b/docs/user_doc/vic_app_dev/build_push_images.md
@@ -11,6 +11,7 @@ vSphere Integrated Containers Engine can deploy Docker Engine instances for you,
   - [Anonymous `dch-photon` Volumes](#vols) 
 - [Using `dch-photon` with vSphere Integrated Containers Registry](#registry)
 - [Using `dch-photon` with Other Registries](#other)
+- [Instantiating Docker Swarms with `dch-photon`](#swarm)
 
 ## Requirements for Using `dch-photon` <a id="requirements"></a>
 
@@ -40,3 +41,7 @@ When you have deployed `dch-photon` with the registry certificate, you can use i
 ## Using `dch-photon` with TLS Authentication and Other Registries <a id="other"></a>
 
 For information about using `dch-photon` with TLS authentication and with other registries than vSphere Integrated Containers Registry, see [Advanced `dch-photon` Deployment](dchphoton_options.md). 
+
+## Instantiating Docker Swarms with `dch-photon` <a id="swarm"></a>
+
+You can use the `dch-photon` Docker Engine to instantiate a Docker swarm. For information about instantiating a Docker swarm, see [Automating Swarm Creation with vSphere Integrated Containers 1.2](https://blogs.vmware.com/cloudnative/2017/10/03/automating-swarm-creation-with-vic-1-2/).

--- a/docs/user_doc/vic_app_dev/container_operations.md
+++ b/docs/user_doc/vic_app_dev/container_operations.md
@@ -135,4 +135,4 @@ For information about Docker Compose file support, see [Supported Docker Compose
 
 ## Swarm Commands <a id="swarm"></a>
 
-This version of vSphere Integrated Containers Engine does not support Docker Swarm. However, you can use the [`dch-photon` Docker Engine](build_push_images.md) to instantiate a Docker swarm. 
+This version of vSphere Integrated Containers Engine does not directly support Docker Swarm. However, you can use the [`dch-photon` Docker Engine](build_push_images.md) to instantiate a Docker swarm for use with vSphere Integrated Containers. 

--- a/docs/user_doc/vic_app_dev/container_operations.md
+++ b/docs/user_doc/vic_app_dev/container_operations.md
@@ -135,4 +135,4 @@ For information about Docker Compose file support, see [Supported Docker Compose
 
 ## Swarm Commands <a id="swarm"></a>
 
-This version of vSphere Integrated Containers Engine does not support Docker Swarm.
+This version of vSphere Integrated Containers Engine does not support Docker Swarm. However, you can use the [`dch-photon` Docker Engine](build_push_images.md) to instantiate a Docker swarm. 


### PR DESCRIPTION
Towards https://github.com/vmware/vic-product/issues/507.

As an interim fix, I have included links to @pdaigle 's blog about how to do Swarm with DCH Photon. In 1.3, I will integrate this content into the docs properly.

@pdaigle and @pescerosso is this a satisfactory short-term solution?