### PR TITLE
Fix typo in cache script

### DIFF
--- a/installer/build/cache.sh
+++ b/installer/build/cache.sh
@@ -45,7 +45,7 @@ function add() {
     curl -fL"#" "$src" -o "$dest"
   else
     cp "$src" "$dest"
-    eecho "copied from local fs"
+    echo "copied from local fs"
   fi
 }
 


### PR DESCRIPTION
This is a quick typo fix in the cache script. This bug becomes apparent when you specify a local copy of vic-engine during the OVA build.