### PR TITLE
Disable component services start on boot

### DIFF
--- a/installer/build/baseimage/root/etc/systemd/system/docker.service.d/50-override-start.conf
+++ b/installer/build/baseimage/root/etc/systemd/system/docker.service.d/50-override-start.conf
@@ -1,0 +1,7 @@
+[Service]
+#docker writes bad data to this log when ova has a hard reset
+ExecStartPre=
+ExecStartPre=-/usr/bin/bash -c 'rm /var/run/docker/libcontainerd/containerd/events.log'
+#ExecStart=/usr/bin/dockerd -H unix:///var/run/docker.sock --iptables=false --ip-masq=false -s overlay2
+ExecStart=
+ExecStart=/usr/bin/dockerd --storage-driver=overlay2

--- a/installer/build/ova-manifest.json
+++ b/installer/build/ova-manifest.json
@@ -39,11 +39,6 @@
     },
     {
       "type": "file",
-      "source": "scripts/systemd/docker.service",
-      "destination": "/usr/lib/systemd/system/docker.service"
-    },
-    {
-      "type": "file",
       "source": "scripts/systemd/boot.local",
       "destination": "/etc/rc.d/init.d/boot.local"
     },

--- a/installer/build/scripts/admiral/configure_admiral.sh
+++ b/installer/build/scripts/admiral/configure_admiral.sh
@@ -221,6 +221,4 @@ chown -R 10000:10000 $log_dir
 # Start on startup
 echo "Enable admiral startup."
 systemctl enable admiral_startup.service
-echo "Enable admiral."
-systemctl enable admiral.service
 echo "Services enabled. exiting..."

--- a/installer/build/scripts/harbor/configure_harbor.sh
+++ b/installer/build/scripts/harbor/configure_harbor.sh
@@ -156,7 +156,6 @@ iptables -w -A INPUT -j ACCEPT -p tcp --dport "${NOTARY_PORT}"
 # Start on startup
 echo "Enable harbor startup"
 systemctl enable harbor_startup.service
-systemctl enable harbor.service
 
 # cleanup common/config directory in preparation for running the harbor "prepare" script
 rm -rf /etc/vmware/harbor/common/config

--- a/installer/build/scripts/system_settings.sh
+++ b/installer/build/scripts/system_settings.sh
@@ -26,6 +26,7 @@ systemctl enable vic-appliance-ready.target
 systemctl enable vic-appliance-environment.service
 systemctl enable getty@tty2.service
 systemctl enable ovf-network.service ova-firewall.service
+
 systemctl enable harbor_startup.path admiral_startup.path get_token.timer
 systemctl enable fileserver_startup.service fileserver.service
 systemctl enable engine_installer_startup.service engine_installer.service

--- a/installer/build/scripts/systemd/harbor/harbor.service
+++ b/installer/build/scripts/systemd/harbor/harbor.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=Harbor Container Registry
 Documentation=http://github.com/vmware/harbor
-After=vic-appliance-ready.target
+After=vic-appliance-ready.target admiral.service
 Requires=vic-appliance-ready.target
 
 [Service]


### PR DESCRIPTION
Fixes #891 by disabling component services `harbor/admiral.service` and relying on their startup scripts `harbor/admiral_startup.service` to start. This ensures that all certs/keys have been generated or copied before harbor ui serves the cert to the client.
This also includes a docker service fix, which was preventing docker from starting on hard resets.

A quicker fix than #1103 which is more of a systemd overhaul. 