### PR TITLE
Flagged demo VCH deployment wizard as deprecated.

### DIFF
--- a/docs/user_doc/SUMMARY.md
+++ b/docs/user_doc/SUMMARY.md
@@ -21,7 +21,7 @@
          * [vCenter Server for Windows](vic_vsphere_admin/plugins_vc_windows.md)
          * [vCenter Server Appliance](vic_vsphere_admin/plugins_vcsa.md)
      * [Open the Required Ports on ESXi Hosts](vic_vsphere_admin/open_ports_on_hosts.md)
-  * [Deploy VCHs Interactively](vic_vsphere_admin/deploy_demo_vch.md)
+  * [Deploy Demo VCHs](vic_vsphere_admin/deploy_demo_vch.md)
   * [Deploy VCHs with `vic-machine`](vic_vsphere_admin/deploy_vch.md)
      * [Contents of the vSphere Integrated Containers Engine Binaries](vic_vsphere_admin/contents_of_vic_binaries.md)
      * [Environment Prerequisites for VCH Deployment](vic_vsphere_admin/vic_installation_prereqs.md)

--- a/docs/user_doc/vic_vsphere_admin/SUMMARY.md
+++ b/docs/user_doc/vic_vsphere_admin/SUMMARY.md
@@ -10,7 +10,7 @@
          * [vCenter Server for Windows](plugins_vc_windows.md)
          * [vCenter Server Appliance](plugins_vcsa.md)
      * [Open the Required Ports on ESXi Hosts](open_ports_on_hosts.md)
-  * [Deploy VCHs Interactively](deploy_demo_vch.md)
+  * [Deploy Demo VCHs](deploy_demo_vch.md)
   * [Deploy VCHs with `vic-machine`](deploy_vch.md)
      * [Contents of the vSphere Integrated Containers Engine Binaries](contents_of_vic_binaries.md)
      * [Environment Prerequisites for VCH Deployment](vic_installation_prereqs.md)

--- a/docs/user_doc/vic_vsphere_admin/deploy_demo_vch.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_demo_vch.md
@@ -1,10 +1,12 @@
-# Deploy Virtual Container Hosts Interactively
+# Deploy Demo Virtual Container Hosts
 
 The vSphere Integrated Containers appliance provides an interactive web installer from which you can deploy a basic virtual container host (VCH). 
 
-This VCH has limited cabilities and is for demonstration purposes only, to allow you to start experimenting with vSphere Integrated Containers. For a description of the role and function of VCHs, see [vSphere Integrated Containers Engine Concepts](../vic_overview/introduction.md#concepts) in *Overview of vSphere Integrated Containers*.    
+**IMPORTANT**: The demo VCH installer is deprecated in this release. To deploy VCHs interactively, use the VCH deployment wizard in the vSphere Client.
 
-**IMPORTANT**: The demo VCH has the minimum configuration that deployment to vCenter Server requires. Only the bridge network, public network, image store, and compute resource options are currently supported. As a consequence, the demo VCH has the following limitations:
+This VCH has limited cabilities and is for demonstration purposes only, to allow you to start experimenting with vSphere Integrated Containers. For a description of the role and function of VCHs, see [vSphere Integrated Containers Engine Concepts](../vic_overview/introduction.md#concepts) in *Overview of vSphere Integrated Containers*.   
+
+The demo VCH has the minimum configuration that deployment to vCenter Server requires. Only the bridge network, public network, image store, and compute resource options are currently supported. As a consequence, the demo VCH has the following limitations:
 
 - It does not implement any TLS authentication options, and as such is completely unsecured. Do not use the demo VCH in production environments. 
 - It only supports DHCP. You cannot assign a static IP address to the VCH on any of its interfaces.

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -65,7 +65,9 @@ You install vSphere Integrated Containers by deploying a virtual appliance. The 
    - To use custom certificates to authenticate connections to the vSphere Integrated Containers Engine file server, optionally paste the content of the appropriate certificate and key files in the **SSL Cert** and **SSL Cert Key** text boxes. The file server supports RSA format for TLS private keys. 
    - Leave the text boxes blank to use auto-generated certificates.    
 
-7. Expand **Demo VCH Installer Wizard Configuration** to optionally change the port on which the interactive web installer for virtual container hosts (VCHs) runs.
+7. Expand **Demo VCH Installer Wizard Configuration** to optionally change the port on which the interactive web installer for virtual container hosts (VCHs) runs. 
+
+    **NOTE**: The demo VCH installer wizard is deprecated in this release. 
 8. Expand **Configure Example Users** to configure the ready-made  example user accounts that vSphere Integrated Containers creates by default in the Platform Services Controller.
     
      You can use these accounts to test the different user personas that can access vSphere Integrated Containers Management Portal and Registry.

--- a/docs/user_doc/vic_vsphere_admin/restart_services.md
+++ b/docs/user_doc/vic_vsphere_admin/restart_services.md
@@ -15,3 +15,5 @@ You deployed the vSphere Integrated Containers appliance.
   - vSphere Integrated Containers Management Portal services: `systemctl restart admiral.service`
   - Embedded file server: `systemctl restart fileserver.service`
   - Demo VCH Installer Wizard: `systemctl restart engine_installer.service`
+
+        **NOTE**: The demo VCH installer wizard is deprecated in this release. 

--- a/docs/user_doc/vic_vsphere_admin/security_reference.md
+++ b/docs/user_doc/vic_vsphere_admin/security_reference.md
@@ -47,7 +47,7 @@ The vSphere Integrated Containers appliance makes the core vSphere Integrated Co
 |Port|Protocol|Description|
 |---|---|---|
 |443|HTTPS|Connections to vSphere Integrated Containers Registry from vSphere Integrated Containers Management Portal, VCHs, and Docker clients|
-|1337|HTTPS|Connections to the Demo VCH Installer|
+|1337|HTTPS|Connections to the Demo VCH Installer. **NOTE**: The demo VCH installer wizard is deprecated in this release. |
 |4443|HTTPS|Connections to the Docker Content Trust service for vSphere Integrated Containers Registry|
 |8282|HTTPS|Connections to vSphere Integrated Containers Management Portal UI and API|
 |9443|HTTPS|Connections to the appliance intialization and Getting Started page, vSphere Integrated Containers Engine download, and vSphere Client plug-in installer|

--- a/docs/user_doc/vic_vsphere_admin/service_status.md
+++ b/docs/user_doc/vic_vsphere_admin/service_status.md
@@ -16,6 +16,8 @@ You deployed the vSphere Integrated Containers appliance
   - Embedded file server: `systemctl status fileserver.service`
   - Demo VCH Installer Wizard: `systemctl status engine_installer.service`
 
+        **NOTE**: The demo VCH installer wizard is deprecated in this release. 
+
 **Result**
 
 The output shows the status of the service that you specified, as well as the most recent log entries.

--- a/docs/user_doc/vic_vsphere_admin/ts_no_access_to_vic_services.md
+++ b/docs/user_doc/vic_vsphere_admin/ts_no_access_to_vic_services.md
@@ -4,14 +4,14 @@ Attempts to connect to the Web-based services of the vSphere Integrated Containe
 
 ## Problem ##
 
-The appliance and its services are running correctly. Some users can access the Getting Started page, file server, and vSphere Integrated Containers Management Portal, and Demo VCH Installer Wizard without problems, but for other users the connections fail.
+The appliance and its services are running correctly. Some users can access the Getting Started page, file server, and vSphere Integrated Containers Management Portal without problems, but for other users the connections fail.
 
 ## Cause ##
 
-Some users are attempting to access the Getting Started page, file server, vSphere Integrated Containers Management Portal, and Demo VCH Installer Wizard from client systems that have IP addresses in the range 172.17.0.0-172.22.0.0/16. 
+Some users are attempting to access the Getting Started page, file server, and vSphere Integrated Containers Management Portal from client systems that have IP addresses in the range 172.17.0.0-172.22.0.0/16. 
 
 vSphere Integrated Containers appliance use the  172.17.0.0-172.22.0.0/16 networks internally. The routing table in the appliance contains routes for these subnets, which causes issues if users attempt to access vSphere Integrated Containers services from an address for which the appliance has a directly connected route. Attempts to connect to the appliance from client systems with IP addresses in the range 172.17.0.0-172.22.0.0/16 fail because the appliance routes return traffic to itself instead of to the client system. 
 
 ## Solution ##
 
-Access the Getting Started page, file server, vSphere Integrated Containers Management Portal, and Demo VCH Installer Wizard from client systems with IP addresses that are not in the 172.17.0.0-172.22.0.0/16 subnets.
+Access the Getting Started page, file server, and vSphere Integrated Containers Management Portal from client systems with IP addresses that are not in the 172.17.0.0-172.22.0.0/16 subnets.

--- a/docs/user_doc/vic_vsphere_admin/verify_vch_deployment.md
+++ b/docs/user_doc/vic_vsphere_admin/verify_vch_deployment.md
@@ -6,10 +6,7 @@ After you have deployed a virtual container host (VCH), you can verify the deplo
 
 **Prerequisites**
 
--  You deployed a VCH in one of the following ways: 
-
-   - You followed the instructions in [Deploy a Demo VCH](deploy_demo_vch.md) to deploy a basic VCH with no security.
-   - You followed the instructions in [Deploy a VCH to an ESXi Host with No vCenter Server](deploy_vch_esxi.md) or [Deploy a VCH to a Basic vCenter Server Cluster](deploy_vch_vcenter.md), specifying the `--no-tlsverify` option.
+- You followed the instructions in [Deploy a VCH to an ESXi Host with No vCenter Server](deploy_vch_esxi.md) or [Deploy a VCH to a Basic vCenter Server Cluster](deploy_vch_vcenter.md), specifying the `--no-tlsverify` option.
 - You have installed a Docker client.
 - If you deployed the VCH to vCenter Server, connect a vSphere Client to that vCenter Server instance.
 - If you deployed the VCH to an ESXi host, connect a vSphere Client to that host.
@@ -24,17 +21,11 @@ After you have deployed a virtual container host (VCH), you can verify the deplo
 
     The vApp or resource pool contains the VCH endpoint VM.   
 
-3.  Run the `docker info` command to confirm that you can connect to the VCH.
-
-    - Demo VCH: <pre>docker -H <i>vch_address</i>:2376 info</pre>
-    - Deployment with `vic-machine create`: <pre>docker -H <i>vch_address</i>:2376 --tls info</pre>
+3.  Run the `docker info` command to confirm that you can connect to the VCH.<pre>docker -H <i>vch_address</i>:2376 --tls info</pre>
 
      You should see confirmation that the Storage Driver is ``` vSphere Integrated Containers Backend Engine```.
 
-1.  Pull a Docker container image into the VCH, for example, the `BusyBox` container.
-
-    - Demo VCH: <pre>docker -H <i>vch_address</i>:2376 pull busybox</pre>
-    - Deployment with `vic-machine create`: <pre>docker -H <i>vch_address</i>:2376 --tls pull busybox</pre>
+1.  Pull a Docker container image into the VCH, for example, the `BusyBox` container.<pre>docker -H <i>vch_address</i>:2376 --tls pull busybox</pre>
 1. View the container image files in the vSphere Web Client or vSphere Client.
 
     - vCenter Server: Go to **Storage**, right-click the datastore that you designated as the image store, and select **Browse Files**. 
@@ -44,10 +35,7 @@ After you have deployed a virtual container host (VCH), you can verify the deplo
   
 1. Expand the `VIC` folder to navigate to the `images` folder.  The `images` folder contains a folder for every container image that you pull into the VCH. The folders contain the container image files.
   
-1. In your Docker client, run the Docker container that you pulled into the VCH.
-
-    - Demo VCH: <pre>docker -H <i>vch_address</i>:2376 run --name test busybox</pre>
-    - Deployment with `vic-machine create`: <pre>docker -H <i>vch_address</i>:2376 --tls run --name test busybox</pre>
+1. In your Docker client, run the Docker container that you pulled into the VCH.<pre>docker -H <i>vch_address</i>:2376 --tls run --name test busybox</pre>
 
 1. View the container VMs in the vSphere Client.
 


### PR DESCRIPTION
Towards https://github.com/vmware/vic-product/issues/1106, pending a decision about whether or not to remove this wizard completely.

@andrewtchin and @morris-jason can you please review?