### PR TITLE
Use unprivileged user for vic-machine-server

### DIFF
--- a/installer/build/scripts/systemd/vic_machine_server/configure_vic_machine_server.sh
+++ b/installer/build/scripts/systemd/vic_machine_server/configure_vic_machine_server.sh
@@ -15,6 +15,7 @@
 set -euf -o pipefail
 
 cert_dir="/storage/data/certs"
+log_dir="/storage/log/vic-machine-server"
 cert="${cert_dir}/server.cert.pem"
 key="${cert_dir}/server.key.pem"
 ca_cert="${cert_dir}/ca.crt"
@@ -107,6 +108,9 @@ function detectHostname {
     return
   fi
 }
+
+chown -R 10000:10000 ${cert_dir}
+chown -R 10000:10000 ${log_dir}
 
 hostname=""
 ip_address=$(ip addr show dev eth0 | sed -nr 's/.*inet ([^ ]+)\/.*/\1/p')

--- a/installer/build/scripts/systemd/vic_machine_server/vic_machine_server.service
+++ b/installer/build/scripts/systemd/vic_machine_server/vic_machine_server.service
@@ -12,7 +12,7 @@ EnvironmentFile=/etc/vmware/environment
 ExecStartPre=-/usr/bin/docker kill vic-machine-server
 ExecStartPre=-/usr/bin/docker rm -f vic-machine-server
 ExecStartPre=/etc/vmware/vic_machine_server/configure_vic_machine_server.sh
-ExecStart=/usr/bin/docker run --rm --name vic-machine-server -v /storage/data/certs:/certs -v /storage/log/vic-machine-server:/var/log/vic-machine-server -p ${VIC_MACHINE_SERVER_PORT}:443 vmware/vic-machine-server:ova
+ExecStart=/usr/bin/docker run --rm --user 10000:10000 --name vic-machine-server -v /storage/data/certs:/certs -v /storage/log/vic-machine-server:/var/log/vic-machine-server -p ${VIC_MACHINE_SERVER_PORT}:443 vmware/vic-machine-server:ova
 ExecStop=/usr/bin/docker stop vic-machine-server
 
 [Install]


### PR DESCRIPTION
Fixes #973. Setting the container user in the ova systemd units instead of the dockerfile for separation of concerns. 