### PR TITLE
Update installer BUILD doc with correct information

### DIFF
--- a/installer/BUILD.md
+++ b/installer/BUILD.md
@@ -36,17 +36,20 @@ sudo ./build/build.sh ova-dev
 ```
 
 If called with the values below, `build.sh` will include the Harbor version from
-`installer/build/harbor.tgz`, the VIC Engine version from `installer/build/vic.tar.gz`, and 
+`installer/build/harbor.tgz`, the VIC Engine version from `installer/build/vic_XXXX.tar.gz`, and 
 Admiral tag `vic_dev` (since `--admiral` was not specified it defaults to the `vic_dev` tag)
 ```
-./build/build.sh ova-dev --harbor harbor.tgz --vicengine vic.tar.gz
+./build/build.sh ova-dev --harbor harbor.tgz --vicengine vic_XXXX.tar.gz
 ```
 
 If called with the values below, `build.sh` will include the Harbor and VIC Engine versions
 specified by their respective URLs, and Admiral tag `vic_v1.1.1`
 ```
-./build/build.sh ova-dev --admiral v1.1.1 --harbor https://example.com/harbor.tgz --vicengine https://example.com/vic.tar.gz
+./build/build.sh ova-dev --admiral v1.1.1 --harbor https://example.com/harbor.tgz --vicengine https://example.com/vic_XXXX.tar.gz
 ```
+
+Note: the VIC Engine artifact used when building the OVA must be named following the `vic_*.tar.gz` format.
+This is required by the OVA in order to automatically configure the VIC Engine UI plugins correctly for installation.
 
 #### Upload
 


### PR DESCRIPTION
This fixes the BUILD readme with correct file naming instructions. The naming convention used in the previous doc does not work with the OVA's UI plugin configuration.