### PR TITLE
Fix incorrect version string

### DIFF
--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -66,7 +66,7 @@ function cleanup() {
 
 trap cleanup EXIT
 
-TAG=$(git for-each-ref --format="%(refname:short)" --sort=-authordate --count=1 refs/tags) # e.g. `v0.9.0`
+TAG=$(git describe --abbrev=0 --tags) # e.g. `v0.9.0`
 REV=$(git rev-parse --short=8 HEAD)
 export BUILD_OVA_REVISION="$TAG-$DRONE_BUILD_NUMBER-$REV"
 export BUILD_DCHPHOTON_VERSION="1.13"


### PR DESCRIPTION
Fixes #1152.

Outputs `BUILD_OVA_REVISION=v1.4.0-dev-0-2c6792a8` on `upstream/master` branches.
Outputs `BUILD_OVA_REVISION=v1.3.0-rc2-0-9e2a95b6` on `upstream/releases/1.3.0`