### PR TITLE
Add mkdir for vic-machine-server certs directory

### DIFF
--- a/installer/build/scripts/systemd/vic_machine_server/configure_vic_machine_server.sh
+++ b/installer/build/scripts/systemd/vic_machine_server/configure_vic_machine_server.sh
@@ -109,6 +109,7 @@ function detectHostname {
   fi
 }
 
+mkdir -p ${cert_dir}
 chown -R 10000:10000 ${cert_dir}
 mkdir -p ${log_dir}
 chown -R 10000:10000 ${log_dir}


### PR DESCRIPTION
The `/storage/data/certs` directory does not exist on v1.2.x data disks. This change adds a mkdir for that directory in the configuration step of vic-machine-server.