### PR TITLE
Upgrade script handles chained upgrades 

### DIFF
--- a/installer/build/scripts/upgrade/upgrade-admiral.sh
+++ b/installer/build/scripts/upgrade/upgrade-admiral.sh
@@ -21,7 +21,6 @@ set -euf -o pipefail
 
 admiral_psc_token_file="/etc/vmware/psc/admiral/tokens.properties"
 admiral_upgrade_status_prev="/etc/vmware/admiral/upgrade_status"
-admiral_upgrade_status="/etc/vmware/admiral/upgrade_status_1.3"
 APPLIANCE_IP=$(ip addr show dev eth0 | sed -nr 's/.*inet ([^ ]+)\/.*/\1/p')
 
 # Check if required PSC token is present
@@ -40,7 +39,6 @@ function checkAdmiralPSCToken {
 function upgradeAdmiral {
   echo "Performing pre-upgrade checks" | tee /dev/fd/3
   checkAdmiralPSCToken
-  checkUpgradeStatus "Admiral" ${admiral_upgrade_status}
 
   # Remove files from old upgrade
   if [ -f "${admiral_upgrade_status_prev}" ]; then
@@ -60,8 +58,5 @@ function upgradeAdmiral {
     "https://${APPLIANCE_IP}:8282/config/props/harbor.tab.url" ; \
   systemctl restart admiral.service
 
-  echo "Admiral upgrade complete" | tee /dev/fd/3
-  # Set upgrade completed file
-  /usr/bin/touch ${admiral_upgrade_status}
   sleep 5
 }

--- a/installer/build/scripts/upgrade/upgrade-admiral.sh
+++ b/installer/build/scripts/upgrade/upgrade-admiral.sh
@@ -20,6 +20,7 @@ source /installer.env
 set -euf -o pipefail
 
 admiral_psc_token_file="/etc/vmware/psc/admiral/tokens.properties"
+# File used in previous upgrades to indicate Admiral upgrade was complete
 admiral_upgrade_status_prev="/etc/vmware/admiral/upgrade_status"
 APPLIANCE_IP=$(ip addr show dev eth0 | sed -nr 's/.*inet ([^ ]+)\/.*/\1/p')
 

--- a/installer/build/scripts/upgrade/upgrade-admiral.sh
+++ b/installer/build/scripts/upgrade/upgrade-admiral.sh
@@ -16,7 +16,7 @@
 # This file contains upgrade processes specific to the Admiral component.
 
 source /installer.env
-. ${0%/*}/util.sh
+. "${0%/*}"/util.sh
 set -euf -o pipefail
 
 admiral_psc_token_file="/etc/vmware/psc/admiral/tokens.properties"

--- a/installer/build/scripts/upgrade/upgrade-admiral.sh
+++ b/installer/build/scripts/upgrade/upgrade-admiral.sh
@@ -43,8 +43,8 @@ function upgradeAdmiral {
   checkUpgradeStatus "Admiral" ${admiral_upgrade_status}
 
   # Remove files from old upgrade
-  if [ -f "${harbor_upgrade_status_prev}" ]; then
-    rm -rf ${harbor_upgrade_status_prev}
+  if [ -f "${admiral_upgrade_status_prev}" ]; then
+    rm -rf "${admiral_upgrade_status_prev}"
   fi
 
   echo "Starting Admiral upgrade" | tee /dev/fd/3

--- a/installer/build/scripts/upgrade/upgrade-admiral.sh
+++ b/installer/build/scripts/upgrade/upgrade-admiral.sh
@@ -20,7 +20,8 @@ source /installer.env
 set -euf -o pipefail
 
 admiral_psc_token_file="/etc/vmware/psc/admiral/tokens.properties"
-admiral_upgrade_status="/etc/vmware/admiral/upgrade_status"
+admiral_upgrade_status_prev="/etc/vmware/admiral/upgrade_status"
+admiral_upgrade_status="/etc/vmware/admiral/upgrade_status_1.3"
 APPLIANCE_IP=$(ip addr show dev eth0 | sed -nr 's/.*inet ([^ ]+)\/.*/\1/p')
 
 # Check if required PSC token is present
@@ -41,6 +42,11 @@ function upgradeAdmiral {
   checkAdmiralPSCToken
   checkUpgradeStatus "Admiral" ${admiral_upgrade_status}
 
+  # Remove files from old upgrade
+  if [ -f "${harbor_upgrade_status_prev}" ]; then
+    rm -rf ${harbor_upgrade_status_prev}
+  fi
+
   echo "Starting Admiral upgrade" | tee /dev/fd/3
   systemctl start admiral_startup.service
   echo "Updating Admiral configuration" | tee /dev/fd/3
@@ -55,7 +61,7 @@ function upgradeAdmiral {
   systemctl restart admiral.service
 
   echo "Admiral upgrade complete" | tee /dev/fd/3
-  # Set timestamp file
+  # Set upgrade completed file
   /usr/bin/touch ${admiral_upgrade_status}
   sleep 5
 }

--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -227,13 +227,13 @@ function upgradeHarbor {
 
   # Remove files from old upgrade
   if [ -f "${harbor_upgrade_status_prev}" ]; then
-    rm -rf ${harbor_upgrade_status_prev}
+    rm -rf "${harbor_upgrade_status_prev}"
   fi
   if [ -d "${harbor_backup_prev}" ]; then
-    rm -rf ${harbor_backup_prev}
+    rm -rf "${harbor_backup_prev}"
   fi
   if [ -d "${harbor_migration}" ]; then
-    rm -rf ${harbor_migration}
+    rm -rf "${harbor_migration}"
   fi
 
   # Start Admiral for data migration
@@ -257,7 +257,7 @@ function upgradeHarbor {
 
   # Cleanup
   if [ -d "${harbor_backup}" ]; then
-    rm -rf ${harbor_backup}
+    rm -rf "${harbor_backup}"
   fi
 
   # Set upgrade completed file

--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -22,10 +22,11 @@ set -euf -o pipefail
 data_mount="/storage/data/harbor"
 cfg="${data_mount}/harbor.cfg"
 harbor_backup_prev="/storage/data/harbor_backup"
-harbor_backup="/storage/data/harbor_backup_1.3"
+harbor_backup="/storage/data/harbor_backup_1.3.0"
 harbor_migration="/storage/data/harbor_migration"
 harbor_psc_token_file="/etc/vmware/psc/harbor/tokens.properties"
 
+# File used in previous upgrades to indicate Harbor upgrade was complete
 harbor_upgrade_status_prev="/etc/vmware/harbor/upgrade_status"
 
 DB_USER=""

--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -27,12 +27,9 @@ harbor_migration="/storage/data/harbor_migration"
 harbor_psc_token_file="/etc/vmware/psc/harbor/tokens.properties"
 
 harbor_upgrade_status_prev="/etc/vmware/harbor/upgrade_status"
-harbor_upgrade_status="/etc/vmware/harbor/upgrade_status_1.3"
 
 DB_USER=""
 DB_PASSWORD=""
-APPLIANCE_IP=$(ip addr show dev eth0 | sed -nr 's/.*inet ([^ ]+)\/.*/\1/p')
-TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S %z %Z")
 
 MANAGED_KEY="# Managed by configure_harbor.sh"
 export LC_ALL="C"
@@ -214,7 +211,6 @@ function upgradeHarbor {
     exit 1
   fi
   echo "Performing pre-upgrade checks" | tee /dev/fd/3
-  checkUpgradeStatus "Harbor" ${harbor_upgrade_status}
 
   # Perform sanity check on data volume
   if ! harborDataSanityCheck ${data_mount}; then
@@ -259,9 +255,6 @@ function upgradeHarbor {
   if [ -d "${harbor_backup}" ]; then
     rm -rf "${harbor_backup}"
   fi
-
-  # Set upgrade completed file
-  /usr/bin/touch ${harbor_upgrade_status}
 
   echo "Starting Harbor" | tee /dev/fd/3
   systemctl start harbor_startup.service

--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -16,9 +16,9 @@
 # This file contains general upgrade processes for the ova appliance, such as psc registration and data versioning.
 # File includes
 source /installer.env
-. ${0%/*}/util.sh
-. ${0%/*}/upgrade-admiral.sh
-. ${0%/*}/upgrade-harbor.sh
+. "${0%/*}"/util.sh
+. "${0%/*}"/upgrade-admiral.sh
+. "${0%/*}"/upgrade-harbor.sh
 
 set -euf -o pipefail
 

--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -23,6 +23,7 @@ source /installer.env
 set -euf -o pipefail
 
 upgrade_log_file="/var/log/vmware/upgrade.log"
+appliance_upgrade_status="/etc/vmware/upgrade_status_1.3.0"
 mkdir -p "/var/log/vmware"
 timestamp_file="/registration-timestamps.txt"
 
@@ -31,7 +32,6 @@ VCENTER_USERNAME=""
 VCENTER_PASSWORD=""
 EXTERNAL_PSC=""
 PSC_DOMAIN=""
-APPLIANCE_IP=$(ip addr show dev eth0 | sed -nr 's/.*inet ([^ ]+)\/.*/\1/p')
 TIMESTAMP=$(date +"%Y-%m-%d %H:%M:%S %z %Z")
 
 
@@ -55,9 +55,9 @@ function getPSCTokens {
   set -e
 }
 
-# Write timestamp so credentials prompt is skipped on Getting Started
+# Write timestamp to a file
 function writeTimestamp {
-  echo "${TIMESTAMP}" > ${timestamp_file}
+  echo "${TIMESTAMP}" > "$1"
 }
 
 # Copy the appliance version to /storage/data after successful upgrade
@@ -96,6 +96,8 @@ function enableServicesStart {
 # Check for presence of Admiral's PSC config file. If the file exists, the old
 # OVA is version 1.2.x.
 function proceedWithUpgrade {
+  checkUpgradeStatus "VIC Appliance" ${appliance_upgrade_status}
+
   if [ ! -f "/storage/data/admiral/configs/psc-config.properties" ]; then
     echo "Detected old OVA's version as 1.1.x. We no longer support this upgrade path." | tee /dev/fd/3
     echo -n "If the version of the old OVA is not 1.1.x, please contact VMware support: " | tee /dev/fd/3
@@ -212,7 +214,9 @@ function main {
   disableServicesStart
   registerAppliance
   getPSCTokens
-  writeTimestamp
+
+  # Write timestamp so credentials prompt is skipped on Getting Started
+  writeTimestamp ${timestamp_file}
   echo "Finished preparing upgrade environment" | tee /dev/fd/3
 
   ### -------------------- ###
@@ -224,6 +228,7 @@ function main {
   upgradeHarbor
 
   setDataVersion
+  writeTimestamp ${appliance_upgrade_status}
   enableServicesStart
   echo "Upgrade script complete. Exiting." | tee /dev/fd/3
   echo "-------------------------"

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -15,11 +15,30 @@
 
 # utility functions that may be used by multiple component upgrade scripts
 
-# Check if directory is present
+# Check if directory is present, prompt user to continue
 function checkDir {
   if [ -d "$1" ]; then
-    echo "Directory $1 already exists. If upgrade is not already running or previously completed, remove the directory and retry upgrade." | tee /dev/fd/3
-    exit 1
+    echo "Directory $1 already exists. If upgrade to this version is already running or previously completed, data corruption may occur if you proceed." | tee /dev/fd/3
+    while true; do
+      echo "" | tee /dev/fd/3
+      echo "Do you wish to proceed? [y/n]" | tee /dev/fd/3
+      read response
+      case $response in
+          [Yy] )
+              echo "Continuing with upgrade" | tee /dev/fd/3
+              echo "" | tee /dev/fd/3
+              break
+              ;;
+          [Nn] )
+              echo "Exiting without performing upgrade" | tee /dev/fd/3
+              exit 1
+              ;;
+          *)
+              # unknown option
+              echo "Please enter [y/n]" | tee /dev/fd/3
+              ;;
+      esac
+    done
   fi
 }
 

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -46,13 +46,31 @@ function readFile {
  cat "$1" ; echo
 }
 
-# Check timestamp file, skip if already upgraded
+# Check status file, prompt user to continue
 function checkUpgradeStatus {
   if [ -f "$2" ]; then
-    echo "$1 upgrade status show previously completed" | tee /dev/fd/3
-    echo "If upgrade is not already running or completed, execute the following command and rerun the upgrade script:" | tee /dev/fd/3
-    echo "    rm $2" | tee /dev/fd/3
-    return 1
+    echo "Detected $1 upgrade was previously completed" | tee /dev/fd/3
+    echo "If upgrade to this version is already running or previously completed, data corruption may occur if you proceed." | tee /dev/fd/3
+    while true; do
+      echo "" | tee /dev/fd/3
+      echo "Do you wish to proceed? [y/n]" | tee /dev/fd/3
+      read response
+      case $response in
+          [Yy] )
+              echo "Continuing with upgrade" | tee /dev/fd/3
+              echo "" | tee /dev/fd/3
+              break
+              ;;
+          [Nn] )
+              echo "Exiting without performing upgrade" | tee /dev/fd/3
+              exit 1
+              ;;
+          *)
+              # unknown option
+              echo "Please enter [y/n]" | tee /dev/fd/3
+              ;;
+      esac
+    done
   fi
   return 0
 }


### PR DESCRIPTION
Fixes #1095 
I'm switching to only checking if the entire upgrade process was completed, not individual components since recovery from a single component upgrade failing was dubious at best. This cleans up files left by previous upgrades and adds a versioned timestamp file when the 1.3.0 upgrade succeeds. I think future upgrade should use `/storage/data/version` to determine if upgrade should proceed.
Testing completed with chained upgrade 1.1.1 -> 1.2.1 -> 1.3-dev
