### PR TITLE
Update VIC curl download command to https

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -19,7 +19,7 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
 
 1. Connect as root user to the vCenter Server Appliance by using SSH.<pre>$ ssh root@<i>vcsa_address</i></pre>
 4. Start bash.<pre>$ shell</i></pre>
-5. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>$ curl -kL  http://<i>vic_appliance_address</i>:9443/files/vic_<i>version</i>.tar.gz -o vic_<i>version</i>.tar.gz</pre>**NOTE**: Update <i>version</i> to the appropriate version in the command above and in the next step. You can see the full file name by going to http://<i>vic_appliance_address</i>:9443/files/ in a browser.
+5. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>$ curl -kL  https://<i>vic_appliance_address</i>:9443/files/vic_<i>version</i>.tar.gz -o vic_<i>version</i>.tar.gz</pre>**NOTE**: Update <i>version</i> to the appropriate version in the command above and in the next step. You can see the full file name by going to http://<i>vic_appliance_address</i>:9443/files/ in a browser.
 5. Unpack the vSphere Integrated Containers binaries.<pre>$ tar -zxf vic_<i>version</i>.tar.gz</pre>
 9. Navigate to `/vic/ui/VCSA`, run the installer script, and follow the prompts.<pre>$ cd vic/ui/VCSA</pre><pre>$ ./install.sh</pre>
 	1. Enter the IP address of the vCenter Server instance.

--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -19,7 +19,7 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
 
 1. Connect as root user to the vCenter Server Appliance by using SSH.<pre>$ ssh root@<i>vcsa_address</i></pre>
 4. Start bash.<pre>$ shell</i></pre>
-5. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>$ curl -kL  https://<i>vic_appliance_address</i>:9443/files/vic_<i>version</i>.tar.gz -o vic_<i>version</i>.tar.gz</pre>**NOTE**: Update <i>version</i> to the appropriate version in the command above and in the next step. You can see the full file name by going to http://<i>vic_appliance_address</i>:9443/files/ in a browser.
+5. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.<pre>$ curl -kL  https://<i>vic_appliance_address</i>:9443/files/vic_<i>version</i>.tar.gz -o vic_<i>version</i>.tar.gz</pre>**NOTE**: Update <i>version</i> to the appropriate version in the command above and in the next step. You can see the full file name by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser.
 5. Unpack the vSphere Integrated Containers binaries.<pre>$ tar -zxf vic_<i>version</i>.tar.gz</pre>
 9. Navigate to `/vic/ui/VCSA`, run the installer script, and follow the prompts.<pre>$ cd vic/ui/VCSA</pre><pre>$ ./install.sh</pre>
 	1. Enter the IP address of the vCenter Server instance.


### PR DESCRIPTION
Previously the docs show http, which results in an error if the docs are actually followed to the letter. The file is served over https and since the port is not 443, https needs to be specified or the resulting tarball is corrupted.