### PR TITLE
Correctly show validation error when verifying login to VCSA on OVA UI

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -163,7 +163,7 @@
                                         <div class="alert alert-danger mt-0 mb-2">
                                             <div class="alert-item">
                                                 <span class="alert-text">
-                                                    Username or password are incorrect. Please enter them again.
+                                                    Validation failed: {{ .ValidationError }}
                                                 </span>
                                             </div>
                                         </div>

--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -159,7 +159,7 @@
                             <div class="modal-body">
                                 <form id="login-form" method="post" class="pt-0">
                                     <div id="login-body">
-                                        {{if .InvalidLogin}}
+                                        {{if .ValidationError }}
                                         <div class="alert alert-danger mt-0 mb-2">
                                             <div class="alert-item">
                                                 <span class="alert-text">

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -60,6 +60,7 @@ type IndexHTMLOptions struct {
 	AdmiralAddr         string
 	DemoVCHAddr         string
 	FileserverAddr      string
+	ValidationError     string
 }
 
 var (
@@ -214,7 +215,7 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 		if err != nil {
 			log.Infof("Validation failed: %s", err.Error())
 			html.InvalidLogin = true
-
+			html.ValidationError = err.Error()
 		} else {
 			log.Infof("Validation succeeded")
 			html.InitErrorFeedback = startInitializationServices()

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -53,7 +53,6 @@ type config struct {
 
 // IndexHTMLOptions contains fields for html templating in index.html
 type IndexHTMLOptions struct {
-	InvalidLogin        bool
 	InitErrorFeedback   string
 	InitSuccessFeedback string
 	NeedLogin           bool
@@ -201,6 +200,7 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 		NeedLogin:           needInitializationServices(req),
 		InitErrorFeedback:   "",
 		InitSuccessFeedback: "",
+		ValidationError:     "",
 	}
 
 	if req.Method == http.MethodPost {
@@ -214,7 +214,6 @@ func indexHandler(resp http.ResponseWriter, req *http.Request) {
 		defer cancel()
 		if err != nil {
 			log.Infof("Validation failed: %s", err.Error())
-			html.InvalidLogin = true
 			html.ValidationError = err.Error()
 		} else {
 			log.Infof("Validation succeeded")


### PR DESCRIPTION
Fixes #1203 

When registering appliance to VCSA, after supplying username and password to VCSA, if the login attempt fails, any validation error now shows up as a warning banner with detailed message describing why the login failed.

For example, when the VCSA cannot be reached:
![screen shot 2017-12-06 at 4 38 26 pm](https://user-images.githubusercontent.com/6562128/33690062-728f539e-daa7-11e7-8489-4c19064d004e.png)

when the username and password are invalid:
![screen shot 2017-12-06 at 4 39 07 pm](https://user-images.githubusercontent.com/6562128/33690070-803b5b8c-daa7-11e7-816e-8be796f54473.png)

Before this change, the error message was generic (`incorrect username and password`) for all validation errors. However it doesn't require the html form titled "Complete VIC appliance installation" to reload (the error message banner just appears on top of the form).
Now with the change, the html form has to reload for the error banner to show up on the top. So when the error banner appears, all fields form has been cleared. 