### PR TITLE
Fixed filename for VIC engine bundle

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -23,7 +23,7 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
 5. Set the following environment variables:
 
     - vSphere Integrated Containers appliance address:<pre>export VIC_ADDRESS=<i>vic_appliance_address</i></pre>
-    - vSphere Integrated Containers Engine bundle file:<pre>export VIC_BUNDLE=vic_1.3.0.tar.gz</pre>
+    - vSphere Integrated Containers Engine bundle file:<pre>export VIC_BUNDLE=vic_v1.3.0.tar.gz</pre>
 
     If you have installed a different version of the appliance, update `1.3.0` to the appropriate version in the command above. You can see the correct version by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser.
 5. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.

--- a/docs/user_doc/vic_vsphere_admin/upgrade_h5_plugin_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/upgrade_h5_plugin_vcsa.md
@@ -20,7 +20,7 @@ If you have previous installations of the vSphere Client plug-ins for vSphere In
 2. Set the following environment variables:
 
     - vSphere Integrated Containers appliance address:<pre>export VIC_ADDRESS=<i>vic_appliance_address</i></pre>
-    - vSphere Integrated Containers Engine bundle file:<pre>export VIC_BUNDLE=vic_1.3.0.tar.gz</pre>
+    - vSphere Integrated Containers Engine bundle file:<pre>export VIC_BUNDLE=vic_v1.3.0.tar.gz</pre>
 
     If you are upgrading to a different version of the appliance, update `1.3.0` to the appropriate version in the command above. You can see the correct version by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser.
 4. Use `curl` to copy the new vSphere Integrated Containers Engine binaries from the file server in the upgraded vSphere Integrated Containers appliance to the vCenter Server Appliance.


### PR DESCRIPTION
Noticed in the GA build that the VIC engine bundle includes `v` in the filename.