### PR TITLE
Fix missing gateway addresses (#1314)

### DIFF
--- a/installer/build/baseimage/install.sh
+++ b/installer/build/baseimage/install.sh
@@ -66,7 +66,8 @@ tdnf install -q --refresh -y \
     iproute2 iptables iputils \
     cdrkit xfsprogs sudo \
     lvm2 parted gptfdisk \
-    e2fsprogs docker logrotate &>/dev/null
+    e2fsprogs docker \
+    net-tools logrotate &>/dev/null
 
 progress "installing package dependencies"
 tdnf install -q --refresh -y \


### PR DESCRIPTION
Adds the net-tools package to the vic-product
appliance to properly load gateway addresses,
fixing the mismatch with static ips. (Fixes #1267).