### PR TITLE
Add retries for some upgrade tasks

### DIFF
--- a/installer/build/scripts/harbor/harbor.service
+++ b/installer/build/scripts/harbor/harbor.service
@@ -2,7 +2,7 @@
 Description=Harbor Container Registry
 Documentation=http://github.com/vmware/harbor
 After=vic-appliance-ready.target psc-ready.target admiral.service 
-Requires=vic-appliance-ready.target psc-ready.target 
+Requires=vic-appliance-ready.target psc-ready.target
 
 [Service]
 Type=simple
@@ -10,6 +10,7 @@ Restart=on-failure
 RestartSec=15
 ExecStartPre=-/usr/local/bin/docker-compose -f /etc/vmware/harbor/docker-compose.yml -f /etc/vmware/harbor/docker-compose.notary.yml -f /etc/vmware/harbor/docker-compose.clair.yml down -v
 ExecStartPre=-/usr/local/bin/docker-compose -f /etc/vmware/harbor/docker-compose.yml -f /etc/vmware/harbor/docker-compose.notary.yml -f /etc/vmware/harbor/docker-compose.clair.yml rm -f
+ExecStartPre=-/usr/bin/docker stop dch-push && /usr/bin/docker rm dch-push
 ExecStartPre=/usr/bin/bash /etc/vmware/harbor/configure_harbor.sh
 ExecStartPre=/usr/bin/python /etc/vmware/harbor/prepare --conf /storage/data/harbor/harbor.cfg --with-notary --with-clair
 ExecStart=/etc/vmware/harbor/start_harbor.sh

--- a/installer/build/scripts/harbor/start_harbor.sh
+++ b/installer/build/scripts/harbor/start_harbor.sh
@@ -50,7 +50,13 @@ fi
 dch_tag="dch-photon:${BUILD_DCHPHOTON_VERSION}"
 docker run -d --name dch-push -v /storage/data/harbor/registry:/var/lib/registry -p 5000:5000 vmware/registry:2.6.2-photon
 docker tag "vmware/$dch_tag" "127.0.0.1:5000/default-project/$dch_tag"
-sleep 3
+
+# wait for the registry to be up using docker health check
+while [ "$(docker inspect --format='{{json .State.Health}}' dch-push | jq .Status)" != "\"healthy\"" ]; do 
+  timecho "waiting for temporary registry to come up";
+  sleep 5;
+done;
+
 docker push "127.0.0.1:5000/default-project/$dch_tag"
 docker rm -f dch-push
 

--- a/installer/build/scripts/harbor/start_harbor.sh
+++ b/installer/build/scripts/harbor/start_harbor.sh
@@ -53,12 +53,12 @@ docker tag "vmware/$dch_tag" "127.0.0.1:5000/default-project/$dch_tag"
 
 # wait for the registry to be up using docker health check
 while [ "$(docker inspect --format='{{json .State.Health}}' dch-push | jq .Status)" != "\"healthy\"" ]; do 
-  timecho "waiting for temporary registry to come up";
-  sleep 5;
+  echo "$(date +"%Y-%m-%d %H:%M:%S") [==] waiting for temporary registry to come up";
+  sleep 1;
 done;
 
 docker push "127.0.0.1:5000/default-project/$dch_tag"
-docker rm -f dch-push
+docker stop dch-push && docker rm dch-push
 
 /usr/local/bin/docker-compose -f /etc/vmware/harbor/docker-compose.yml \
                               -f /etc/vmware/harbor/docker-compose.notary.yml \

--- a/installer/build/scripts/upgrade/upgrade-admiral.sh
+++ b/installer/build/scripts/upgrade/upgrade-admiral.sh
@@ -63,15 +63,15 @@ function upgradeAdmiral {
   echo "Updating Admiral configuration" | tee /dev/fd/3
 
   tab_retries=0
-  max_tab_retries=20 # 60 seconds
-  while [ "$(setTabUrl)" != "200" && ${tab_retries} -lt ${max_tab_retries} ]; do
+  max_tab_retries=6 # 60 seconds
+  while [[ "$(setTabUrl)" != "200" && ${tab_retries} -lt ${max_tab_retries} ]]; do
     timecho "Waiting for admiral api tab update..."
-    sleep 3
+    sleep 10
     ((tab_retries++))
   done
 
   if [ ${tab_retries} -eq ${max_tab_retries} ]; then
-    timecho "Admiral api could not be reached. Exiting..."
+    timecho "Admiral api could not be reached. Exiting..." | tee /dev/fd/3
     exit 1
   fi
 

--- a/installer/build/scripts/upgrade/upgrade-admiral.sh
+++ b/installer/build/scripts/upgrade/upgrade-admiral.sh
@@ -36,6 +36,18 @@ function checkAdmiralPSCToken {
   fi
 }
 
+function setTabUrl {
+  curl \
+    -s -o /dev/null --insecure \
+    -w "%{http_code}" \
+    -X PUT \
+    -H "x-xenon-auth-token: $(cat /etc/vmware/psc/admiral/tokens.properties)" \
+    -H 'cache-control: no-cache' \
+    -H 'content-type: application/json' \
+    -d "{ \"key\" : \"harbor.tab.url\", \"value\" : \"$(grep harbor.tab.url /storage/data/admiral/configs/config.properties | cut -d'=' -f2)\" }" \
+    "https://${APPLIANCE_IP}:8282/config/props/harbor.tab.url";
+}
+
 # Upgrade entry point from upgrade.sh
 function upgradeAdmiral {
   echo "Performing pre-upgrade checks" | tee /dev/fd/3
@@ -49,15 +61,22 @@ function upgradeAdmiral {
   echo "Starting Admiral upgrade" | tee /dev/fd/3
   systemctl start admiral.service
   echo "Updating Admiral configuration" | tee /dev/fd/3
-  curl \
-    -s --insecure \
-    -X PUT \
-    -H "x-xenon-auth-token: $(cat /etc/vmware/psc/admiral/tokens.properties)" \
-    -H 'cache-control: no-cache' \
-    -H 'content-type: application/json' \
-    -d "{ \"key\" : \"harbor.tab.url\", \"value\" : \"$(grep harbor.tab.url /storage/data/admiral/configs/config.properties | cut -d'=' -f2)\" }" \
-    "https://${APPLIANCE_IP}:8282/config/props/harbor.tab.url" ; \
-  systemctl restart admiral.service
 
+  tab_retries=0
+  max_tab_retries=20 # 60 seconds
+  while [ "$(setTabUrl)" != "200" && ${tab_retries} -lt ${max_tab_retries} ]; do
+    timecho "Waiting for admiral api tab update..."
+    sleep 3
+    ((tab_retries++))
+  done
+
+  if [ ${tab_retries} -eq ${max_tab_retries} ]; then
+    timecho "Admiral api could not be reached. Exiting..."
+    exit 1
+  fi
+
+  echo "Restarting Admiral" | tee /dev/fd/3
+  systemctl restart admiral.service
   sleep 5
 }
+

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -134,3 +134,7 @@ function getApplianceVersion() {
   echo $VER_UNKNOWN
   return
 }
+
+function timecho {
+  echo -e "$(date +"%Y-%m-%d %H:%M:%S") [==] $@"
+}


### PR DESCRIPTION
Fixes #1351 by retrying some critical upgrade tasks, like dch push in `start_harbor.sh` and admiral config changes.