### PR TITLE
Increase grub timeout. (#1357)

### DIFF
--- a/installer/build/baseimage/install.sh
+++ b/installer/build/baseimage/install.sh
@@ -39,7 +39,6 @@ progress "importing local gpg key"
 rpm --import /etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 
 progress "configuring grub"
-sed -i 's/set timeout=5/set timeout=0/' /boot/grub2/grub.cfg
 sed -i '/linux/ s/$/ consoleblank=0/' /boot/grub2/grub.cfg
 
 progress "setting umask to 022"

--- a/installer/build/baseimage/stage.sh
+++ b/installer/build/baseimage/stage.sh
@@ -211,7 +211,7 @@ function setup_grub() {
 # Begin /boot/grub2/grub.cfg
 
 set default=0
-set timeout=0
+set timeout=5
 search -n -u $BOOT_UUID -s
 loadfont ${BOOT_DIRECTORY}grub2/ascii.pf2
 


### PR DESCRIPTION
Adds five seconds to the vic-product ova grub timeout. 
Fixes #1345 and contributes to #1341.