### PR TITLE
Use component release versions in release builds

### DIFF
--- a/installer/build/Dockerfile
+++ b/installer/build/Dockerfile
@@ -6,4 +6,5 @@ ENV PATH=$PATH:/root/gsutil:/usr/local/go/bin
 RUN set -eux; \
     tdnf install -y make tar gzip python2 python-pip sed git gawk docker; \
     curl -L'#' -k https://storage.googleapis.com/pub/gsutil.tar.gz | tar xzf - -C $HOME;  \
-    curl -L'#' -k https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz | tar xzf - -C /usr/local;
+    curl -L'#' -k https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz | tar xzf - -C /usr/local; \
+    curl -o /usr/bin/jq -L'#' -k https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x /usr/bin/jq;

--- a/installer/scripts/ci-build.sh
+++ b/installer/scripts/ci-build.sh
@@ -26,7 +26,7 @@ echo "BRANCH = $DRONE_BRANCH"
 if [ -n "${ADMIRAL}" ]; then
   OPTIONS="--admiral $ADMIRAL"
 elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
-  admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1)
+  admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1 | cut -d'_' -f2)
   OPTIONS="--admiral $admiral_release"
 fi
 

--- a/installer/scripts/ci-build.sh
+++ b/installer/scripts/ci-build.sh
@@ -47,6 +47,7 @@ fi
 if [ -n "${VIC_MACHINE_SERVER}" ]; then
   OPTIONS="$OPTIONS --vicmachineserver $VIC_MACHINE_SERVER"
 elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
+  vicmachineserver_release="latest"
   OPTIONS="$OPTIONS --vicmachineserver $vicmachineserver_release"
 fi
 

--- a/installer/scripts/ci-build.sh
+++ b/installer/scripts/ci-build.sh
@@ -20,22 +20,37 @@ cd installer
 INSTALLER_DIR=$(pwd)
 OPTIONS=""
 
+echo "BRANCH = $DRONE_BRANCH"
+
 # set options
 if [ -n "${ADMIRAL}" ]; then
   OPTIONS="--admiral $ADMIRAL"
+elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
+  admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1)
+  OPTIONS="--admiral $admiral_release"
 fi
 
 if [ -n "${HARBOR}" ]; then
   OPTIONS="$OPTIONS --harbor $HARBOR"
+elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
+  harbor_release=$(gsutil ls -l "gs://harbor-releases" | grep -v TOTAL | grep offline-installer | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+  OPTIONS="$OPTIONS --harbor $harbor_release"
 fi
 
 if [ -n "${VICENGINE}" ]; then
   OPTIONS="$OPTIONS --vicengine $VICENGINE"
+elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
+  vicengine_release=$(gsutil ls -l "gs://vic-engine-releases" | grep -v TOTAL | grep vic_ | sort -k2 -r | (trap '' PIPE; head -1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+  OPTIONS="$OPTIONS --vicengine $vicengine_release"
 fi
 
 if [ -n "${VIC_MACHINE_SERVER}" ]; then
   OPTIONS="$OPTIONS --vicmachineserver $VIC_MACHINE_SERVER"
+elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
+  OPTIONS="$OPTIONS --vicmachineserver $vicmachineserver_release"
 fi
+
+echo "OPTIONS = $OPTIONS"
 
 # invoke build script
 $INSTALLER_DIR/build/build.sh ova-ci $OPTIONS


### PR DESCRIPTION
Makes progress towards #1287 by pulling in release component versions on release branches of vic-product.

note: Not to be merge until after 1.3.1 final.