### PR TITLE
first version of jenkins docker-compose example

### DIFF
--- a/tutorials/jenkins/docker-compose.yaml
+++ b/tutorials/jenkins/docker-compose.yaml
@@ -1,0 +1,19 @@
+version: '2'
+services:
+  jenkins:
+    image: "jenkins/jenkins:lts-alpine"
+    cpuset: "2"
+    mem_limit: 4g
+    volumes:
+    - jenkins_home:/var/jenkins_home
+    ports:
+      - "8889:8080"
+      - "50000:50000"
+    environment:
+      - TINI_SUBREAPER=
+volumes:
+  jenkins_home:
+    driver: "vsphere"
+    driver_opts:
+      Capacity: "5G"
+      VolumeStore: "default"


### PR DESCRIPTION
- [ x] Up to date with `master` branch
- [x ] Added tutorial

Added Jenkins docker-compose example in tutorials using the [VIC Jenkins Blog post](https://blogs.vmware.com/cloudnative/2017/09/26/deploy-jenkins-using-vsphere-integrated-containers/) as guidance
