### PR TITLE
Update test cleanup step

### DIFF
--- a/tests/common-ova/OVA-Cleanup.robot
+++ b/tests/common-ova/OVA-Cleanup.robot
@@ -22,7 +22,9 @@ Suite Setup  Global Environment Setup
 
 
 *** Test Cases ***
-Teardown Common OVA
+Copy OVA Support Bundle
     Set Test OVA IP If Available
     Copy Support Bundle  %{OVA_IP}
+
+Teardown Common OVA
     Cleanup VIC Product OVA  %{OVA_NAME}


### PR DESCRIPTION
Fix for cleanup to run even when the copy support bundle fails. Currently, its leaving behind some OVA appliances due to copy logs failure which is impacting other builds.