### PR TITLE
Fixed nomenclature for VDS

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/bridge_network.md
+++ b/docs/user_doc/vic_vsphere_admin/bridge_network.md
@@ -18,7 +18,7 @@ The sections in this topic each correspond to an entry in the Configure Networks
 
 A port group that container VMs use to communicate with each other. 
 
-Before you deploy a VCH, you must create a distributed virtual switch and a port group for the bridge network. You must add the target ESXi host or hosts to the distributed virtual switch, and assign a VLAN ID to the port group, to ensure that the bridge network is isolated. For information about how to create a distributed virtual switch and port group, see [Networking Requirements for VCH Deployment](vic_installation_prereqs.md#vchnetworkreqs).
+Before you deploy a VCH, you must create a VMware vSphere Distributed Switch and a port group for the bridge network. You must add the target ESXi host or hosts to the switch, and assign a VLAN ID to the port group, to ensure that the bridge network is isolated. For information about how to create a vSphere Distributed Switch and port group, see [Networking Requirements for VCH Deployment](vic_installation_prereqs.md#vchnetworkreqs).
 
 **IMPORTANT** 
 
@@ -39,7 +39,7 @@ You designate the bridge network by specifying the `vic-machine create --bridge-
 
 The `--bridge-network` option is **mandatory** if you are deploying a VCH to vCenter Server. 
 
-The `--bridge-network` option is **optional** if you are deploying a VCH to an ESXi host that is not managed by vCenter Server. In this case, if you do not specify `--bridge-network`, `vic-machine` creates a  virtual switch and a port group that each have the same name as the VCH. You can optionally specify this option to assign an existing port group for use as the bridge network for container VMs. You can also optionally specify this option to create a new virtual switch and port group that have a different name to the VCH.
+The `--bridge-network` option is **optional** if you are deploying a VCH to an ESXi host that is not managed by vCenter Server. In this case, if you do not specify `--bridge-network`, `vic-machine` creates a vSphere Distributed Switch and a port group that each have the same name as the VCH. You can optionally specify this option to assign an existing port group for use as the bridge network for container VMs. You can also optionally specify this option to create a new switch and port group that have a different name to the VCH.
 
 
 <pre>--bridge-network <i>port_group_name</i></pre>

--- a/docs/user_doc/vic_vsphere_admin/vch_networking.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_networking.md
@@ -36,7 +36,7 @@ You can direct traffic between containers, the VCH, the external Internet, and y
 
 **IMPORTANT**: All hosts in a cluster should be attached to the port groups that you use for the VCH networks and for any mapped container networks. 
 
-For general information VCH networking requirements and how to create a distributed virtual switch and port group, see [Networking Requirements for VCH Deployment](vic_installation_prereqs.md#vchnetworkreqs).
+For general information VCH networking requirements and how to create a VMware vSphere Distributed Switch and port group, see [Networking Requirements for VCH Deployment](vic_installation_prereqs.md#vchnetworkreqs).
 
 - **Bridge Networks**: In Docker terminology, the VCH bridge network corresponds to the default bridge network on a Docker host. You can also create additional bridge networks, that correspond to Docker user-defined networks. You must create a dedicated port group for the bridge network for every VCH. For information about VCH bridge networks, see [Configure Bridge Networks](bridge_network.md).
 - **Public Network:** The network that container VMs and VCHs use to access the Internet. If you use the Create Virtual Container Host Wizard, you must create a port group for the public network. You cannot use the same port group for the public network as you use for the bridge network. However, you can use the public network port group for the client and management networks. For information about VCH public networks, see [Configure the Public Network](public_network.md).

--- a/docs/user_doc/vic_vsphere_admin/vic_installation_prereqs.md
+++ b/docs/user_doc/vic_vsphere_admin/vic_installation_prereqs.md
@@ -98,10 +98,10 @@ The following network requirements apply to deployment of VCHs to standalone ESX
 
 The following network requirements apply to the deployment of VCHs to vCenter Server: 
  
-- Create a distributed virtual switch with a port group for each VCH, for use as the bridge network. You can create multiple port groups on the same distributed virtual switch, but each VCH requires its own port group for the bridge network. 
+- Create a VMware vSphere Distributed Switch with a port group for each VCH, for use as the bridge network. You can create multiple port groups on the same switch, but each VCH requires its own port group for the bridge network. 
   - For information about bridge networks, see [Configure Bridge Networks](bridge_network.md). 
-  - For information about how to create a distributed virtual switch and a port group, see [Create a vSphere Distributed Switch](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-D21B3241-0AC9-437C-80B1-0C8043CC1D7D.html) in the vSphere  documentation. 
-  - For information about how to add hosts to a distributed virtual switch, see [Add Hosts to a vSphere Distributed Switch](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-E90C1B0D-82CB-4A3D-BE1B-0FDCD6575725.html) in the vSphere  documentation.
+  - For information about how to create a vSphere Distributed Switch and a port group, see [Create a vSphere Distributed Switch](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-D21B3241-0AC9-437C-80B1-0C8043CC1D7D.html) in the vSphere  documentation. 
+  - For information about how to add hosts to a vSphere Distributed Switch, see [Add Hosts to a vSphere Distributed Switch](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.networking.doc/GUID-E90C1B0D-82CB-4A3D-BE1B-0FDCD6575725.html) in the vSphere  documentation.
 - If you use the Create Virtual Container Host wizard to deploy VCHs, you must create and use a port group for the public network. The VCH endpoint VM must be able to obtain an IP address on this port group. If you use `vic-machine` to deploy VCHs, it is still strongly recommended that use a port group for the public network. Using the default VM Network for the public network instead of a port group prevents vSphere vMotion from moving the VCH endpoint VM between hosts in the cluster. You can use the same port group as the public network for multiple VCHs.
 - Optionally create port groups for each of the management and client networks. 
 - Optionally create port groups for use as mapped container networks. For information about container networks, see [Configure Container Networks](container_networks.md). 


### PR DESCRIPTION
Fixes https://github.com/vmware/vic-product/issues/1459, to replace some remaining instances of "distributed virtual switch" with "vSphere Distributed Switch".