### PR TITLE
WIP Add harbor and admiral to an internal docker network

### DIFF
--- a/installer/build/ova-manifest.json
+++ b/installer/build/ova-manifest.json
@@ -92,6 +92,11 @@
   },
   {
     "type": "file",
+    "source": "scripts/harbor/configure_internal_network.sh",
+    "destination": "/etc/vmware/harbor/configure_internal_network.sh"
+  },
+  {
+    "type": "file",
     "source": "scripts/upgrade/upgrade.sh",
     "destination": "/etc/vmware/upgrade/upgrade.sh"
   },

--- a/installer/build/scripts/admiral/configure_admiral.sh
+++ b/installer/build/scripts/admiral/configure_admiral.sh
@@ -72,7 +72,7 @@ iptables -w -A INPUT -j ACCEPT -p tcp --dport "${ADMIRAL_PORT}"
 touch $data_dir/custom.conf
 
 # Configure the integration URL
-echo "harbor.tab.url=https://${HOSTNAME}:${REGISTRY_PORT}" > $data_dir/custom.conf
+echo "harbor.tab.url=https://harbor-ui:${REGISTRY_PORT}" > $data_dir/custom.conf
 
 # Copy files needed by Admiral into one directory
 cp $appliance_jks $config_dir

--- a/installer/build/scripts/harbor/configure_internal_network.sh
+++ b/installer/build/scripts/harbor/configure_internal_network.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/bash
+# Copyright 2017 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+set -uf -o pipefail
+
+TIMEOUT=30
+function timecho {
+    echo -e "$(date +"%Y-%m-%d %H:%M:%S") [==] $*"
+}
+
+function connect_once {
+    docker network connect internal $*
+}
+
+function connect {
+    out=$(connect_once $*)
+    while [[ ! $? -eq 0 && $out != *"already exists"* ]]; do
+        timecho "Internal connect for '$*' failed. Retrying in $TIMEOUT seconds..."
+        sleep $TIMEOUT
+        connect_once $*
+    done
+    timecho "Connected '$*' to internal network."
+}
+
+# connect admiral and harbor to a private network
+docker network create internal || true
+connect vic-admiral
+connect harbor-ui

--- a/installer/build/scripts/harbor/configure_internal_network.sh
+++ b/installer/build/scripts/harbor/configure_internal_network.sh
@@ -20,12 +20,12 @@ function timecho {
 }
 
 function connect_once {
-    docker network connect internal $*
+    docker network connect internal $* 2>&1
 }
 
 function connect {
     out=$(connect_once $*)
-    while [[ ! $? -eq 0 && $out != *"already exists"* ]]; do
+    while [[ ! $? -eq 0 && "$out" != *"already exists"* ]]; do
         timecho "Internal connect for '$*' failed. Retrying in $TIMEOUT seconds..."
         sleep $TIMEOUT
         connect_once $*

--- a/installer/build/scripts/harbor/harbor.service
+++ b/installer/build/scripts/harbor/harbor.service
@@ -16,6 +16,7 @@ ExecStartPre=-/usr/bin/docker rm dch-push
 ExecStartPre=/usr/bin/bash /etc/vmware/harbor/configure_harbor.sh
 ExecStartPre=/usr/bin/python /etc/vmware/harbor/prepare --conf /storage/data/harbor/harbor.cfg --with-notary --with-clair
 ExecStart=/etc/vmware/harbor/start_harbor.sh
+ExecStartPost=/usr/bin/bash /etc/vmware/harbor/configure_internal_network.sh
 ExecStop=/usr/local/bin/docker-compose -f /etc/vmware/harbor/docker-compose.yml -f /etc/vmware/harbor/docker-compose.notary.yml -f /etc/vmware/harbor/docker-compose.clair.yml down -v
 ExecStopPost=/usr/local/bin/docker-compose -f /etc/vmware/harbor/docker-compose.yml -f /etc/vmware/harbor/docker-compose.notary.yml -f /etc/vmware/harbor/docker-compose.clair.yml rm -f
 


### PR DESCRIPTION
Fixes #419

Containers are successfully added to a internal network, but there are unintended consequences of changing harbor.tab.url to accomplish this. 
Waiting for responses from @reasonerjt and @lazarin on #419.