### PR TITLE
Always start fileserver regardless of configure errors

### DIFF
--- a/installer/build/ova-manifest.json
+++ b/installer/build/ova-manifest.json
@@ -175,6 +175,11 @@
   },
   {
     "type": "file",
+    "source": "../fileserver/files/error_index.html",
+    "destination": "/opt/vmware/fileserver/index.html"
+  },
+  {
+    "type": "file",
     "source": "../landing_server/html",
     "destination": "/opt/vmware/landing_server/html"
   },

--- a/installer/build/scripts/fileserver/configure_fileserver.sh
+++ b/installer/build/scripts/fileserver/configure_fileserver.sh
@@ -17,6 +17,7 @@ set -xuf -o pipefail
 umask 077
 data_dir="/opt/vmware/fileserver"
 cert="/storage/data/certs/server.crt"
+error_index_file="${data_dir}/files/index.html"
 
 ca_download_dir="${data_dir}/ca_download"
 mkdir -p ${ca_download_dir}
@@ -25,7 +26,7 @@ function updateConfigFiles {
   ui_dir="${data_dir}/files"
   # cove cli has package in form of vic-adm_*.tar.gz, so use 'vic_*.tar.gz' here
   # to avoid including cove cli
-  tar_gz=$(find "${ui_dir}" -name "vic_*.tar.gz")
+  tar_gz=$(find "${data_dir}" -name "vic_*.tar.gz")
 
   # untar vic package to tmp dir
   tar -zxf "${tar_gz}" -C /tmp
@@ -61,9 +62,10 @@ iptables -w -A INPUT -j ACCEPT -p tcp --dport "${FILESERVER_PORT}"
 updateConfigFiles
 if [ $? -eq 0 ]; then
   echo "Fileserver configuration complete."
+  [ -f "${error_index_file}" ] && rm "${error_index_file}"
 else
   echo "Fileserver configuration failed."
-  cat >"index.html" <<EOF 
+  cat >"${error_index_file}" <<EOF 
 <html>
   <h1>VIC Appliance Fileserver has hit an error...</h1>
   <p>The VIC Appliance Fileserver failed to configure the vic archive.</p>

--- a/installer/build/scripts/fileserver/configure_fileserver.sh
+++ b/installer/build/scripts/fileserver/configure_fileserver.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -euf -o pipefail
+set -xuf -o pipefail
 
 umask 077
 data_dir="/opt/vmware/fileserver"
@@ -55,9 +55,19 @@ function updateConfigFiles {
   rm -rf /tmp/vic
 }
 
-
 iptables -w -A INPUT -j ACCEPT -p tcp --dport "${FILESERVER_PORT}"
-iptables -w -A INPUT -j ACCEPT -p tcp --dport 80
 
 # Update configurations
 updateConfigFiles
+if [ $? -eq 0 ]; then
+  echo "Fileserver configuration complete."
+else
+  echo "Fileserver configuration failed."
+  cat >"index.html" <<EOF 
+<html>
+  <h1>VIC Appliance Fileserver has hit an error...</h1>
+  <p>The VIC Appliance Fileserver failed to configure the vic archive.</p>
+  <p>It may contain incorrect values required to install the VIC UI plugin.</p>
+</html>
+EOF
+fi

--- a/installer/build/scripts/fileserver/configure_fileserver.sh
+++ b/installer/build/scripts/fileserver/configure_fileserver.sh
@@ -12,7 +12,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-set -xuf -o pipefail
+set -uf -o pipefail
 
 umask 077
 data_dir="/opt/vmware/fileserver"
@@ -70,6 +70,13 @@ else
   <h1>VIC Appliance Fileserver has hit an error...</h1>
   <p>The VIC Appliance Fileserver failed to configure the vic archive.</p>
   <p>It may contain incorrect values required to install the VIC UI plugin.</p>
+  <p>
+    In order to correct this error, you must do one of the following:
+    <ul>
+      <li>Restart the VIC Appliance.</li>
+      <li>Using ssh, restart the fileserver with <pre>systemctl restart fileserver</pre></li>
+    </ul>
+  </p>
 </html>
 EOF
 fi

--- a/installer/build/scripts/fileserver/configure_fileserver.sh
+++ b/installer/build/scripts/fileserver/configure_fileserver.sh
@@ -52,7 +52,7 @@ function updateConfigFiles {
   sed -i -e s%${cur_file_server_w}%vic_ui_host_url=${file_server}%g $wconfig
 
   # tar all files again
-  tar zcf "$tar_gz" -C /tmp vic
+  tar zcf "$ui_dir/$(basename $tar_gz)" -C /tmp vic
   rm -rf /tmp/vic
 }
 

--- a/installer/build/scripts/fileserver/configure_fileserver.sh
+++ b/installer/build/scripts/fileserver/configure_fileserver.sh
@@ -62,7 +62,9 @@ iptables -w -A INPUT -j ACCEPT -p tcp --dport "${FILESERVER_PORT}"
 updateConfigFiles
 if [ $? -eq 0 ]; then
   echo "Fileserver configuration complete."
-  [ -f "${error_index_file}" ] && rm "${error_index_file}"
+  if [ -f "${error_index_file}" ]; then
+    rm "${error_index_file}"
+  fi
 else
   echo "Fileserver configuration failed."
   cat >"${error_index_file}" <<EOF 

--- a/installer/build/scripts/fileserver/fileserver.service
+++ b/installer/build/scripts/fileserver/fileserver.service
@@ -10,7 +10,7 @@ Restart=on-failure
 RestartSec=15
 EnvironmentFile=/etc/vmware/environment
 ExecStartPre=-/usr/bin/systemctl stop landing_server.service
-ExecStartPre=-/usr/bin/bash /etc/vmware/fileserver/configure_fileserver.sh
+ExecStartPre=/usr/bin/bash /etc/vmware/fileserver/configure_fileserver.sh
 ExecStart=/etc/vmware/fileserver/start_fileserver.sh
 
 [Install]

--- a/installer/build/scripts/fileserver/fileserver.service
+++ b/installer/build/scripts/fileserver/fileserver.service
@@ -10,7 +10,7 @@ Restart=on-failure
 RestartSec=15
 EnvironmentFile=/etc/vmware/environment
 ExecStartPre=-/usr/bin/systemctl stop landing_server.service
-ExecStartPre=/usr/bin/bash /etc/vmware/fileserver/configure_fileserver.sh
+ExecStartPre=-/usr/bin/bash /etc/vmware/fileserver/configure_fileserver.sh
 ExecStart=/etc/vmware/fileserver/start_fileserver.sh
 
 [Install]

--- a/installer/build/scripts/provisioners/provision_fileserver.sh
+++ b/installer/build/scripts/provisioners/provision_fileserver.sh
@@ -14,21 +14,22 @@
 # limitations under the License.
 set -euf -o pipefail
 
-FILES_DIR="/opt/vmware/fileserver/files"
+DATA_DIR="/opt/vmware/fileserver"
+FILES_DIR="${DATA_DIR}/files"
 
 mkdir -p /etc/vmware/fileserver # Fileserver config scripts
-mkdir -p ${FILES_DIR}            # Files to serve
+mkdir -p ${FILES_DIR}           # Files to serve
+mkdir -p ${DATA_DIR}            # Backup of the original vic tar
 
 cd /var/tmp
 
 echo "Provisioning VIC Engine ${BUILD_VICENGINE_FILE}"
 cp /etc/cache/${BUILD_VICENGINE_FILE} .
 
-
 # Copy UI plugin zip files to fileserver directory
 tar tf "${BUILD_VICENGINE_FILE}" | grep "vic/ui" | grep ".zip" | xargs  -I '{}' tar xzf "${BUILD_VICENGINE_FILE}" -C ${FILES_DIR} '{}' --strip-components=3
 
-mv "${BUILD_VICENGINE_FILE}" ${FILES_DIR}
+mv "${BUILD_VICENGINE_FILE}" ${DATA_DIR}
 
 # Write version files
 echo "engine=${BUILD_VICENGINE_FILE}" >> /data/version

--- a/installer/build/scripts/provisioners/provision_fileserver.sh
+++ b/installer/build/scripts/provisioners/provision_fileserver.sh
@@ -30,6 +30,7 @@ cp /etc/cache/${BUILD_VICENGINE_FILE} .
 tar tf "${BUILD_VICENGINE_FILE}" | grep "vic/ui" | grep ".zip" | xargs  -I '{}' tar xzf "${BUILD_VICENGINE_FILE}" -C ${FILES_DIR} '{}' --strip-components=3
 
 mv "${BUILD_VICENGINE_FILE}" ${DATA_DIR}
+touch "${FILES_DIR}/${BUILD_VICENGINE_FILE}"
 
 # Write version files
 echo "engine=${BUILD_VICENGINE_FILE}" >> /data/version

--- a/installer/build/scripts/provisioners/provision_fileserver.sh
+++ b/installer/build/scripts/provisioners/provision_fileserver.sh
@@ -30,7 +30,6 @@ cp /etc/cache/${BUILD_VICENGINE_FILE} .
 tar tf "${BUILD_VICENGINE_FILE}" | grep "vic/ui" | grep ".zip" | xargs  -I '{}' tar xzf "${BUILD_VICENGINE_FILE}" -C ${FILES_DIR} '{}' --strip-components=3
 
 mv "${BUILD_VICENGINE_FILE}" ${DATA_DIR}
-touch "${FILES_DIR}/${BUILD_VICENGINE_FILE}"
 
 # Write version files
 echo "engine=${BUILD_VICENGINE_FILE}" >> /data/version

--- a/installer/fileserver/files/error_index.html
+++ b/installer/fileserver/files/error_index.html
@@ -1,0 +1,12 @@
+<html>
+  <h1>Error starting VIC Appliance Fileserver.</h1>
+  <p>The VIC Appliance Fileserver failed to configure the VIC archive.</p>
+  <p>It may contain incorrect values required to install the VIC UI plugin.</p>
+  <p>
+    In order to correct this error, you must do one of the following:
+    <ul>
+      <li>Restart the guest OS.</li>
+      <li>SSH to the VIC appliance and execute <pre>systemctl restart fileserver</pre></li>
+    </ul>
+  </p>
+</html>


### PR DESCRIPTION
VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [x] Considered impact to upgrade
- [x] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

Partial fix for #1505.

This does not address the root of the problem:
 - We still need to identify what was/is corrupting the vic tar.
 - Hopefully, since we now keep a backup of the original vic tar, this error won't occur. But that's not guaranteed. 
 - Error message provided to the user is helpful but not actionable. 