### PR TITLE
Fix usage of user provided TLS certs

### DIFF
--- a/installer/build/scripts/systemd/scripts/vic-appliance-tls.sh
+++ b/installer/build/scripts/systemd/scripts/vic-appliance-tls.sh
@@ -106,9 +106,11 @@ function secure {
     formatCert "$tls_private_key" $key
     formatCert "$tls_ca_cert" $ca_cert
 
+    ensurePKCS8Format
+
     echo "customized" > $flag
 
-    echo "creating java keystore with provided cert for xenon"
+    echo "creating java keystore with user provided cert"
     createKeystore $cert
     return
   fi
@@ -167,7 +169,12 @@ function ensurePKCS8Format() {
     mv $key.tmp $key
     return
   fi
+  # Override value from environment file
+  tls_private_key="$(cat $key)"
   echo "Converted $key to PKCS8"
+
+  # Cleanup
+  rm -f $key.tmp
 }
 
 # Warn if expiration in less than 60 days
@@ -187,7 +194,6 @@ chown -R "${APPLIANCE_SERVICE_UID}":"${APPLIANCE_SERVICE_UID}" ${cert_dir}
 
 # Init certs
 secure
-ensurePKCS8Format
 checkCertExpiration
 
 # File permissions - components can use shared TLS cert


### PR DESCRIPTION
Auto conversion of PKCS1 to PKCS8 private key was in the wrong place.

```
root@Photon [ ~ ]# journalctl -u !$
journalctl -u vic-appliance-tls
-- Logs begin at Tue 2018-04-10 18:11:33 UTC, end at Tue 2018-04-10 18:15:52 UTC. --
Apr 10 18:12:00 Photon systemd[1]: Starting VIC Appliance TLS Certificate...
Apr 10 18:12:00 Photon vic-appliance-tls.sh[763]: TLS certificate, private key, and CA certificate are set, using customized certificate
Apr 10 18:12:00 Photon vic-appliance-tls.sh[763]: Private key /storage/data/certs/server.key is not in PKCS8 format
Apr 10 18:12:00 Photon vic-appliance-tls.sh[763]: Converted /storage/data/certs/server.key to PKCS8
Apr 10 18:12:00 Photon vic-appliance-tls.sh[763]: creating java keystore with user provided cert
Apr 10 18:12:00 Photon vic-appliance-tls.sh[763]: no keystore present, creating
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: Certificate was added to keystore
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: [Storing /storage/data/certs/trustedcertificates.jks]
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: Certificate expiration date OK
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: /storage/data/certs/server.crt fingerprint: SHA256 Fingerprint=86:1D:A6:68:5F:CC:C7:41:9E:D7:73:4E:1C:BE:28:27:F0:B8:5B:3E:85:7F:D7:2D:8C:F3:67:3D:29:85:FB:C4
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: /storage/data/certs/server.crt fingerprint: SHA1 Fingerprint=76:30:D4:D0:0D:1D:C5:62:80:77:7A:C1:35:B1:70:4F:43:79:33:6B
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: /storage/data/certs/ca.crt fingerprint: SHA256 Fingerprint=99:BC:23:1F:5F:7B:CD:FB:3C:46:7A:E4:4C:66:64:6C:71:38:DE:25:D3:85:A1:DB:A8:A3:DA:8D:60:88:DE:07
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: /storage/data/certs/ca.crt fingerprint: SHA1 Fingerprint=E9:D2:92:F3:81:BD:EB:F8:BA:E1:E1:6E:FF:E0:5F:EE:06:AE:F0:57
Apr 10 18:12:01 Photon vic-appliance-tls.sh[763]: Finished vic-appliance-tls config
Apr 10 18:12:01 Photon systemd[1]: Started VIC Appliance TLS Certificate.
root@Photon [ ~ ]# ls -al /storage/data/certs/
total 28
drwxr-x--- 2 10000 10000 4096 Apr 10 18:12 .
drwxr-xr-x 7 root  root  4096 Apr 10 17:57 ..
-rw------- 1 10000 10000 2228 Apr 10 18:12 ca.crt
-rw------- 1 root  root    11 Apr 10 18:12 cert_gen_type
-rw------- 1 10000 10000 2549 Apr 10 18:12 server.crt
-rw------- 1 10000 10000 3272 Apr 10 18:12 server.key
-rw------- 1 root  root  1910 Apr 10 18:12 trustedcertificates.jks
```