### PR TITLE
Expose port 4444 for google-chrome

### DIFF
--- a/tutorials/selenium/docker-compose.yml
+++ b/tutorials/selenium/docker-compose.yml
@@ -16,7 +16,7 @@ services:
     links:
       - "hub"
     expose:
-      - "5555"
+      - "4444"
   firefox:
     cpu_count: 1
     image: "selenium/node-firefox"


### PR DESCRIPTION
VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
