### PR TITLE
Replaced link to pubs.vmware.com with docs.vmware.com

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/install_vic_plugin.md
+++ b/docs/user_doc/vic_vsphere_admin/install_vic_plugin.md
@@ -4,7 +4,7 @@ vSphere Integrated Containers provides a basic plug-in for the Flex-based vSpher
 
 You can deploy the plug-ins on a vCenter Server instance that runs on Windows, or on a vCenter Server Appliance.
 
-For information about the Flex-based vSphere Web Client and the HTML5 vSphere Client for vSphere 6.5, see [Introduction to the vSphere Client](https://pubs.vmware.com/vsphere-65/topic/com.vmware.wcsdk.pg.doc/GUID-3379D310-7802-4B62-8292-D11D928459FC.html) in the vSphere 6.5 documentation.
+For information about the Flex-based vSphere Web Client and the HTML5 vSphere Client for vSphere 6.5, see [Client Interfaces for vSphere](https://docs.vmware.com/en/VMware-vSphere/6.5/com.vmware.vsphere.vcenterhost.doc/GUID-6710A6C4-00AE-4930-BBD6-BDEF78029994.html) in the vSphere 6.5 documentation.
 
 * [Install the Client Plug-Ins on vCenter Server for Windows](plugins_vc_windows.md)
 * [Install the Client Plug-Ins on a vCenter Server Appliance](plugins_vcsa.md)


### PR DESCRIPTION
Fixes https://github.com/vmware/vic-product/issues/1594.

It seems that the copyright info page is still hosted on pubs.vmware.com, so these should not be updated.