### PR TITLE
Appliance upgrade non-interactive flags

### DIFF
--- a/installer/build/bootable/build-base.sh
+++ b/installer/build/bootable/build-base.sh
@@ -50,7 +50,7 @@ function set_base() {
   log3 "installing ${brprpl}filesystem bash shadow coreutils findutils${reset}"
   tdnf install --installroot "${rt}/" --refresh -y \
     filesystem bash shadow coreutils findutils
-  
+
   log3 "installing ${brprpl}systemd linux-esx tdnf ca-certificates sed gzip tar glibc${reset}"
   tdnf install --installroot "${rt}/" --refresh -y \
     systemd util-linux \
@@ -77,7 +77,7 @@ function set_base() {
     cdrkit xfsprogs sudo \
     lvm2 parted gptfdisk \
     e2fsprogs docker gzip \
-    net-tools logrotate
+    net-tools logrotate sshpass
 
   log3 "installing package dependencies"
   tdnf install --installroot "${rt}/" --refresh -y \

--- a/installer/build/scripts/systemd/scripts/support/appliance-support.sh
+++ b/installer/build/scripts/systemd/scripts/support/appliance-support.sh
@@ -153,6 +153,8 @@ function getDiagInfo {
   commandToFile "cat /run/systemd/resolve/resolv.conf" "resolv.conf" "appliance"
   commandToFile "cat /var/log/vmware/upgrade.log" "upgrade.log" "appliance"
 
+  commandToFile "systemctl status --no-pager docker.service" "systemctl_status_docker.service" "appliance"
+  commandToCompressed "journalctl -u docker.service --no-pager" "journal_docker.service" "appliance"
   commandToFile "systemctl status --no-pager vic-mounts.target" "systemctl_status_vic-mounts.target" "appliance"
   commandToCompressed "journalctl -u vic-mounts.target --no-pager" "journal_vic-mounts.target" "appliance"
   commandToFile "systemctl status --no-pager vic-appliance-docker-images-loaded.path" "systemctl_status_vic-appliance-docker-images-loaded.path" "appliance"

--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -75,7 +75,6 @@ function checkHarborPSCToken {
 }
 
 # Run the harbor migrator docker image
-# TODO(morris-jason): remove the test tag
 function runMigratorCmd {
   local migrator_image="vmware/harbor-migrator:v1.5.0"
 

--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -78,7 +78,7 @@ function checkHarborPSCToken {
 function runMigratorCmd {
   local migrator_image="vmware/harbor-migrator:v1.5.0"
 
-  docker run -it --rm \
+  docker run --rm \
     -e DB_USR=${DB_USER} \
     -e DB_PWD=${DB_PASSWORD} \
     -e SKIP_CONFIRM=y \

--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -145,7 +145,7 @@ function setDataVersion {
   echo "Set new data version: ${new_data_ver}"
 }
 
-# Prevent Admiral and Harbor from starting from path units
+# Prevent Admiral and Harbor from starting
 function disableServicesStart {
   log "Disabling and stopping Admiral and Harbor"
   systemctl stop admiral.service
@@ -154,7 +154,7 @@ function disableServicesStart {
   systemctl disable harbor.service
 }
 
-# Enable Admiral and Harbor starting from path units
+# Enable Admiral and Harbor starting
 function enableServicesStart {
   log "Enabling and starting Admiral and Harbor"
   systemctl enable admiral.service


### PR DESCRIPTION
Adds `--embedded-psc` to skip external PSC prompts
Adds `--appliance-password` for old appliance password
Adds `--fingerprint` for GOVC format vCenter fingerprint
Adds `--ssh-insecure-skip-verify` to skip host key checking for old appliance SSH
Adds `--appliance-version` for expected old appliance version. Exits install if expected != actual