### PR TITLE
Change owner of CA certificate and token file after they are copied to Harbor

### DIFF
--- a/installer/build/scripts/harbor/configure_harbor.sh
+++ b/installer/build/scripts/harbor/configure_harbor.sh
@@ -102,6 +102,7 @@ fi
 
 echo "Copying CA certificate to ${ca_download_dir}"
 cp ${appliance_ca_cert} ${ca_download_dir}
+chown --recursive 10000:10000 ${ca_download_dir}
 
 if [ "${REGISTRY_PORT}" == "443" ] || [ "${REGISTRY_PORT}" == "80" ]; then
   configureHarborCfg "hostname" "${HOSTNAME}"

--- a/installer/build/scripts/systemd/scripts/psc/get_token.sh
+++ b/installer/build/scripts/systemd/scripts/psc/get_token.sh
@@ -38,6 +38,7 @@ getToken /etc/vmware/psc/admiral/psc-config.properties /etc/vmware/psc/admiral/t
 # Copy harbor token to container mount path
 mkdir -p /storage/data/harbor/psc
 cp /etc/vmware/psc/harbor/tokens.properties /storage/data/harbor/psc/tokens.properties
+chown --recursive 10000:10000 /storage/data/harbor/psc
 
 # Set PSC dir permissions if not set
 dirs=("/etc/vmware/psc/admiral" "/etc/vmware/psc/engine" "/etc/vmware/psc/harbor")


### PR DESCRIPTION
After ca.crt and tokens.properties are copied to Harbor's directory the owner changed to root.

This PR changes the owner to 10000:10000 after it's copied.

This fixes the build issue in master branch.