### PR TITLE
Rename ovf keys for registry port

### DIFF
--- a/installer/build/bootable/config/builder.ovf
+++ b/installer/build/bootable/config/builder.ovf
@@ -246,7 +246,7 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
     <ProductSection ovf:class="registry" ovf:required="false">
       <Info>Registry Properties</Info>
       <Category>3. Registry Configuration</Category>
-      <Property ovf:key="port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="443">
+      <Property ovf:key="registry_port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="443">
         <Label>3.1. Registry Port</Label>
         <Description>Specifies the port on which registry will be published.</Description>
       </Property>
@@ -262,7 +262,7 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
     <ProductSection ovf:class="management_portal" ovf:required="false">
       <Info>Management Portal Properties</Info>
       <Category>4. Management Portal Configuration</Category>
-      <Property ovf:key="port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="8282">
+      <Property ovf:key="management_portal_port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="8282">
         <Label>4.1. Management Portal Port</Label>
         <Description>Specifies the port on which Management Portal will be published.</Description>
       </Property>

--- a/installer/build/scripts/systemd/scripts/vic-appliance-environment.sh
+++ b/installer/build/scripts/systemd/scripts/vic-appliance-environment.sh
@@ -23,8 +23,8 @@ APPLIANCE_TLS_CERT="$(ovfenv -k appliance.tls_cert | sed -E ':a;N;$!ba;s/\r{0,1}
 APPLIANCE_TLS_PRIVATE_KEY="$(ovfenv -k appliance.tls_cert_key | sed -E ':a;N;$!ba;s/\r{0,1}\n//g')"
 APPLIANCE_TLS_CA_CERT="$(ovfenv -k appliance.ca_cert | sed -E ':a;N;$!ba;s/\r{0,1}\n//g')"
 
-ADMIRAL_PORT="$(ovfenv -k management_portal.port)"
-REGISTRY_PORT="$(ovfenv -k registry.port)"
+ADMIRAL_PORT="$(ovfenv -k management_portal.management_portal_port)"
+REGISTRY_PORT="$(ovfenv -k registry.registry_port)"
 NOTARY_PORT="$(ovfenv -k registry.notary_port)"
 FILESERVER_PORT="$(ovfenv -k appliance.config_port)"
 HOSTNAME=""

--- a/installer/docs/BUILD.md
+++ b/installer/docs/BUILD.md
@@ -112,8 +112,8 @@ docker run -it --net=host -v $GOPATH/src/github.com/vmware/vic-product/installer
   --net:Network="VM Network" \
   --prop:appliance.root_pwd="password" \
   --prop:appliance.permit_root_login=True \
-  --prop:management_portal.port=8282 \
-  --prop:registry.port=443 \
+  --prop:management_portal.management_portal_port=8282 \
+  --prop:registry.registry_port=443 \
   /test-bin/$(ls -1t bin | grep "\.ova") \
   vi://$VC_USER:$VC_PASSWORD@$VC_IP/$VC_COMPUTE
 ```

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -142,7 +142,7 @@ func Init(conf *config) {
 
 	if ip, err := ip.FirstIPv4(ip.Eth0Interface); err == nil {
 		conf.serverHostname = getHostname(ovf, ip)
-		if port, ok := ovf.Properties["management_portal.port"]; ok {
+		if port, ok := ovf.Properties["management_portal.management_portal_port"]; ok {
 			conf.admiralPort = port
 		}
 	}

--- a/installer/fileserver/tasks.go
+++ b/installer/fileserver/tasks.go
@@ -74,7 +74,7 @@ func registerWithPSC(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	admiralPort := ovf.Properties["management_portal.port"]
+	admiralPort := ovf.Properties["management_portal.management_portal_port"]
 
 	// Out of the box users
 	defCreateUsers, foundCreateUsers := ovf.Properties["default_users.create_def_users"]


### PR DESCRIPTION
VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [x] Considered impact to upgrade
- [x] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1624 

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
