### PR TITLE
Fix keyword in DRS nightly test

### DIFF
--- a/tests/manual-test-cases/Group5-Interoperability-Tests/5-8-DRS.robot
+++ b/tests/manual-test-cases/Group5-Interoperability-Tests/5-8-DRS.robot
@@ -36,7 +36,7 @@ Test
     Set Environment Variable  TEST_RESOURCE  /ha-datacenter/host/cls/Resources
     Set Global Variable  ${OVA_USERNAME_ROOT}  root
     Set Global Variable  ${OVA_PASSWORD_ROOT}  e2eFunctionalTest
-    Install VIC Product OVA Only  vic-*.ova  %{OVA_NAME}
+    Install And Initialize VIC Product OVA  vic-*.ova  %{OVA_NAME}
 
     Set Browser Variables
 


### PR DESCRIPTION
I forgot to update this when I merged my upgrade tests PR, which renamed the keyword.