### PR TITLE
Corrected name of vic-machine-server.service

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/deploy_vch_client.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vch_client.md
@@ -2,7 +2,7 @@
 
 If you have installed the HTML5 plug-in for vSphere Integrated Containers, you can deploy virtual container hosts (VCHs) interactively in the vSphere Client.
 
-The different options that you configure in the Create Virtual Container Host wizard in the vSphere Client correspond to `vic-machine create` options. The `vic-machine create` options are exposed by the `vic_machine_server` service of the vSphere Integrated Containers appliance. When you use the Create Virtual Container Host wizard, it deploys VCHs to the vCenter Server instance with which the vSphere Integrated Containers appliance is registered, and uses the vSphere credentials with which you are logged in to the vSphere Client. Consequently, when using the Create Virtual Container Host wizard, you do not need to provide any information about the deployment target, vSphere administrator credentials, or vSphere certificate thumbprints.
+The different options that you configure in the Create Virtual Container Host wizard in the vSphere Client correspond to `vic-machine create` options. The `vic-machine create` options are exposed by the `vic-machine-server` service of the vSphere Integrated Containers appliance. When you use the Create Virtual Container Host wizard, it deploys VCHs to the vCenter Server instance with which the vSphere Integrated Containers appliance is registered, and uses the vSphere credentials with which you are logged in to the vSphere Client. Consequently, when using the Create Virtual Container Host wizard, you do not need to provide any information about the deployment target, vSphere administrator credentials, or vSphere certificate thumbprints.
 
 **Prerequisites**
 

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -7,7 +7,7 @@ The following services run in the vSphere Integrated Containers appliance:
 - vSphere Integrated Containers Registry service
 - vSphere Integrated Containers Management Portal service
 - The file server for vSphere Integrated Containers Engine downloads and installation of the vSphere Client plug-ins
-- The `vic_machine_server` service, that powers the virtual container host deployment and management wizards in the HTML5 vSphere Client plug-in
+- The `vic-machine-server` service, that powers the virtual container host deployment and management wizards in the HTML5 vSphere Client plug-in
 
 You can deploy multiple vSphere Integrated Containers appliances to the same vCenter Server instance. Also, if a Platform Services Controller manages multiple vCenter Server instances, you can deploy multiple appliances to different vCenter Server instances that share that Platform Services Controller.
 

--- a/docs/user_doc/vic_vsphere_admin/restart_services.md
+++ b/docs/user_doc/vic_vsphere_admin/restart_services.md
@@ -5,7 +5,7 @@ You can restart the vSphere Integrated Containers services that run in the appli
 - vSphere Integrated Containers Registry service
 - vSphere Integrated Containers Management Portal service
 - The file server for vSphere Integrated Containers Engine downloads and installation of the vSphere Client plug-ins
-- The `vic_machine_server` service, that powers the Create Virtual Container Host wizard in the HTML5 vSphere Client plug-in
+- The `vic-machine-server` service, that powers the Create Virtual Container Host wizard in the HTML5 vSphere Client plug-in
 
 **Prerequisites**
 
@@ -19,4 +19,4 @@ You deployed the vSphere Integrated Containers appliance.
   - vSphere Integrated Containers Registry: <pre>systemctl restart harbor.service</pre>
   - vSphere Integrated Containers Management Portal services: <pre>systemctl restart admiral.service</pre>
   - Embedded file server: <pre>systemctl restart fileserver.service</pre>
-  - `vic_machine_server`: <pre>systemctl restart vic_machine_server.service</pre>
+  - `vic-machine-server`: <pre>systemctl restart vic-machine-server.service</pre>

--- a/docs/user_doc/vic_vsphere_admin/security_reference.md
+++ b/docs/user_doc/vic_vsphere_admin/security_reference.md
@@ -49,7 +49,7 @@ The vSphere Integrated Containers appliance makes the core vSphere Integrated Co
 |443|HTTPS|Connections to vSphere Integrated Containers Registry from vSphere Integrated Containers Management Portal, VCHs, and Docker clients|
 |4443|HTTPS|Connections to the Docker Content Trust service for vSphere Integrated Containers Registry|
 |8282|HTTPS|Connections to vSphere Integrated Containers Management Portal UI and API|
-|8443|HTTPS|Connections to the `vic_machine_server` service, that powers the Create Virtual Container Host wizard in the HTML5 vSphere Client plug-in|
+|8443|HTTPS|Connections to the `vic-machine-server` service, that powers the Create Virtual Container Host wizard in the HTML5 vSphere Client plug-in|
 |9443|HTTPS|Connections to the appliance intialization and Getting Started page, vSphere Integrated Containers Engine download, and vSphere Client plug-in installer|
 
 ### VCH Endpoint VM

--- a/docs/user_doc/vic_vsphere_admin/service_status.md
+++ b/docs/user_doc/vic_vsphere_admin/service_status.md
@@ -5,7 +5,7 @@ You can check the status of the vSphere Integrated Containers services that run 
 - vSphere Integrated Containers Registry service
 - vSphere Integrated Containers Management Portal service
 - The file server for vSphere Integrated Containers Engine downloads and installation of the vSphere Client plug-ins
-- The `vic_machine_server` service, that powers the Create Virtual Container Host wizard in the HTML5 vSphere Client plug-in
+- The `vic-machine-server` service, that powers the Create Virtual Container Host wizard in the HTML5 vSphere Client plug-in
 
 **Prerequisites**
 
@@ -19,7 +19,7 @@ You deployed the vSphere Integrated Containers appliance.
   - vSphere Integrated Containers Registry: <pre>systemctl status harbor.service</pre>
   - vSphere Integrated Containers Management Portal services: <pre>systemctl status admiral.service</pre>
   - Embedded file server: <pre>systemctl status fileserver.service</pre>
-  - `vic_machine_server`: <pre>systemctl status vic_machine_server.service</pre>
+  - `vic-machine-server`: <pre>systemctl status vic-machine-server.service</pre>
 
 **Result**
 


### PR DESCRIPTION
While checking the services running in the RC2 OVA, I noticed that the doc misnames the `vic-machine-server.service`.

@zjs has this name always been wrong in the docs, or did it change in 1.4? Thanks!