### PR TITLE
Filter private values in appliance support bundle

### DIFF
--- a/installer/build/scripts/systemd/scripts/support/appliance-support.sh
+++ b/installer/build/scripts/systemd/scripts/support/appliance-support.sh
@@ -125,9 +125,28 @@ function getPrivateFiles {
   set -e
 }
 
+# filterLine filters line from a file based on a pattern
+function filterLine {
+  local PATTERN="$1"
+  local FILE="$2"
+  local OUTDIR
+  local DIR="${3:-}"
+  if [ -n "$DIR" ]; then
+    OUTDIR="$TMPDIR/$DIR"
+    mkdir -p "$OUTDIR"
+  else
+    OUTDIR="$TMPDIR"
+  fi
+
+  echo "Removing $PATTERN from $OUTDIR/$FILE"
+  sed -i "/$PATTERN/d" "$OUTDIR/$FILE"
+}
+
 # filterEnvironment filters private values from the environment file
 function filterEnvironment {
-  commandToFile "cat /etc/vmware/environment | grep -v APPLIANCE_TLS_PRIVATE_KEY" "environment_filtered" "appliance"
+  commandToFile "cat /etc/vmware/environment" "environment" "appliance"
+  filterLine "APPLIANCE_TLS_PRIVATE_KEY" "environment" "appliance"
+  filterLine "DEFAULT_USERS_DEF_USER_PASSWORD" "environment" "appliance"
 }
 
 # getDiagInfo gathers diagnostic info and logs


### PR DESCRIPTION
Old way wan't working
Now:
```
root@Photon [ /etc/vmware/support ]# ./appliance-support.sh
Running cat /etc/vmware/environment
Removing APPLIANCE_TLS_PRIVATE_KEY from /tmp/vic_appliance_logs_2018-04-30-15-22-03/appliance/environment
Removing DEFAULT_USERS_DEF_USER_PASSWORD from /tmp/vic_appliance_logs_2018-04-30-15-22-03/appliance/environment
Running hostnamectl
Running timedatectl
Running ip address show

...

cat appliance/environment
VIC_MACHINE_SERVER_PORT=8443
APPLIANCE_SERVICE_UID=10000
HOSTNAME=10.160.0.145
IP_ADDRESS=10.160.0.145
ADMIRAL_PORT=8282
REGISTRY_PORT=443
NOTARY_PORT=4443
FILESERVER_PORT=9443
APPLIANCE_TLS_CERT=
APPLIANCE_TLS_CA_CERT=
DEFAULT_USERS_CREATE_DEF_USERS=True
DEFAULT_USERS_DEF_USER_PREFIX=vic
REGISTRY_GC_ENABLED=False
APPLIANCE_PERMIT_ROOT_LOGIN=True
NETWORK_FQDN=
NETWORK_IP0=
NETWORK_NETMASK0=
NETWORK_GATEWAY=
NETWORK_DNS=
NETWORK_SEARCHPATH=
```