### PR TITLE
Use restart policy always for Harbor jobservice

### DIFF
--- a/installer/build/scripts/provisioners/provision_harbor.sh
+++ b/installer/build/scripts/provisioners/provision_harbor.sh
@@ -36,11 +36,11 @@ f = open(file, "r+")
 dataMap = yaml.safe_load(f)
 for _, s in enumerate(dataMap["services"]):
   if "restart" in dataMap["services"][s]:
-      if "always" in dataMap["services"][s]["restart"]:
+      if "always" in dataMap["services"][s]["restart"] and s != "jobservice":
         dataMap["services"][s]["restart"] = "on-failure"
   if "volumes" in dataMap["services"][s]:
     for kvol, vol in enumerate(dataMap["services"][s]["volumes"]):
-      # Fixing up volumes in compose file. 
+      # Fixing up volumes in compose file.
       if vol.startswith( '/data/database' ):
         dataMap["services"][s]["volumes"][kvol] = vol.replace("/data/database", "/storage/db/harbor/database", 1)
       elif vol.startswith( '/data/notary-db' ):


### PR DESCRIPTION
Fixes #1667 

docker-compose.yml
```
networks:
  harbor:
    external: false
services:
  adminserver:
    container_name: harbor-adminserver
    depends_on:
    - log
    env_file:
    - ./common/config/adminserver/env
    image: vmware/harbor-adminserver:v1.5.0
    logging:
      driver: syslog
      options:
        syslog-address: tcp://127.0.0.1:1514
        tag: adminserver
    networks:
    - harbor
    restart: on-failure
    volumes:
    - /storage/data/harbor/config/:/etc/adminserver/config/:z
    - /storage/data/harbor/secretkey:/etc/adminserver/key:z
    - /storage/data/harbor/:/data/:z
  jobservice:
    container_name: harbor-jobservice
    depends_on:
    - redis
    - ui
    - adminserver
    env_file:
    - ./common/config/jobservice/env
    image: vmware/harbor-jobservice:v1.5.0
    logging:
      driver: syslog
      options:
        syslog-address: tcp://127.0.0.1:1514
        tag: jobservice
    networks:
    - harbor
    restart: always
    volumes:
    - /storage/data/harbor/job_logs:/var/log/jobs:z
    - ./common/config/jobservice/config.yml:/etc/jobservice/config.yml:z
```
