### PR TITLE
Fix upgrade script variable

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -175,7 +175,6 @@ function proceedWithUpgrade {
   if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ]; then
     log ""
     log "Detected old appliance's version as $ver."
-    logn "If the old appliance's version is not detected correctly, please enter \"n\" to abort the upgrade and contact VMware support."
 
     if [ -n "${APPLIANCE_VERSION}" ]; then
       if [ "$ver" == "${APPLIANCE_VERSION}" ]; then
@@ -188,6 +187,7 @@ function proceedWithUpgrade {
       fi
     fi
 
+    logn "If the old appliance's version is not detected correctly, please enter \"n\" to abort the upgrade and contact VMware support."
     while true; do
       log ""
       log "Do you wish to proceed with upgrade? [y/n]"
@@ -581,7 +581,7 @@ function main {
 
   if [ -n "${DESTROY_ENABLED}" ] ; then
     log "Destroying the old VIC appliance"
-    govc vm.destroy "$VM_NAME"
+    govc vm.destroy "$OLD_VM_NAME"
     log "Old VIC appliance destroyed"
   fi
 


### PR DESCRIPTION
Fixes `--destroy` flag and log output 

```
root@Photon [ /etc/vmware/upgrade ]# ./upgrade.sh --target 10.160.140.175 --password 'Admin!23' --username 'administrator@vsphere.local' --dc ha-datacenter --fingerprint '10.160.140.175 49:8C:56:6B:F0:E6:54:D1:3F:77:4A:81:DE:BD:61:8B:80:CE:DF:E6' --appliance-username root --appliance-password password --appliance-target 10.192.49.135 --appliance-version v1.3.1 --destroy  --embedded-psc --ssh-insecure-skip-verify
-------------------------------
VIC Appliance Upgrade to v1.4.0
-------------------------------

2018-05-01 19:38:01 [=] Values containing $ (dollar sign), ` (backquote), \' (single quote), " (double quote), and \ (backslash) will not be substituted properly.
2018-05-01 19:38:01 [=] Change any input (passwords) containing these values before running this script.
2018-05-01 19:38:01 [=] Using provided vCenter fingerprint from --fingerprint 10.160.140.175 49:8C:56:6B:F0:E6:54:D1:3F:77:4A:81:DE:BD:61:8B:80:CE:DF:E6
Destroy option enabled. This will delete the old VIC appliance after upgrade. Are you sure? (y/n):y
2018-05-01 19:38:03 [=]
-------------------------
Starting upgrade 2018-05-01 19:38:01 +0000 UTC

2018-05-01 19:38:04 [=] Using provided VIC appliance password from --appliance-password
2018-05-01 19:38:07 [=]
2018-05-01 19:38:07 [=] Detected old appliance's version as v1.3.1.
2018-05-01 19:38:07 [=] Detected old appliance version matches expected value from --appliance-version v1.3.1
2018-05-01 19:38:09 [=] Waiting for old VIC appliance to power off
2018-05-01 19:38:25 [=] Waiting for old VIC appliance to power off
2018-05-01 19:38:42 [=] Migrating old disks to new VIC appliance...
2018-05-01 19:38:42 [=] Copying old data disk. Please wait.
2018-05-01 19:39:43 [=] Copying old database disk. Please wait.
2018-05-01 19:40:51 [=] Copying old log disk. Please wait.
2018-05-01 19:41:55 [=] Finished attaching migrated disks to new VIC appliance
2018-05-01 19:41:55 [=] Preparing upgrade environment
2018-05-01 19:41:55 [=] Disabling and stopping Admiral and Harbor
2018-05-01 19:41:55 [=] Waiting for register appliance...
2018-05-01 19:42:05 [=] Waiting for register appliance...
2018-05-01 19:42:15 [=] Waiting for register appliance...
2018-05-01 19:42:25 [=] Waiting for register appliance...
2018-05-01 19:43:11 [=] Finished preparing upgrade environment
2018-05-01 19:43:11 [=]
-------------------------
Starting Admiral Upgrade 2018-05-01 19:38:01 +0000 UTC

2018-05-01 19:43:11 [=] Performing pre-upgrade checks
2018-05-01 19:43:11 [=] Starting Admiral upgrade
2018-05-01 19:44:02 [=] Updating Admiral configuration
2018-05-01 19:44:02 [=] Restarting Admiral
2018-05-01 19:44:50 [=]
-------------------------
Starting Harbor Upgrade 2018-05-01 19:38:01 +0000 UTC

2018-05-01 19:44:50 [=] Performing pre-upgrade checks
2018-05-01 19:44:50 [=] Starting Harbor upgrade
2018-05-01 19:44:50 [=] [=] Shutting down Harbor
2018-05-01 19:44:50 [=] [=] Migrating Harbor configuration and data
2018-05-01 19:44:50 [=] Testing database credentials...
2018-05-01 19:44:52 [=] Backing up harbor config...
2018-05-01 19:45:00 [=] [=] Successfully migrated Harbor configuration and data
2018-05-01 19:45:00 [=] Harbor upgrade complete
2018-05-01 19:45:00 [=] Starting Harbor
2018-05-01 19:45:02 [=] Enabling and starting Admiral and Harbor
2018-05-01 19:45:03 [=] Destroying the old VIC appliance
2018-05-01 19:45:04 [=] Old VIC appliance destroyed
2018-05-01 19:45:04 [=]
2018-05-01 19:45:04 [=] -------------------------
2018-05-01 19:45:04 [=] Upgrade completed successfully. Exiting.
2018-05-01 19:45:04 [=] -------------------------
2018-05-01 19:45:04 [=]
```