### PR TITLE
unify harbor db and clair db password in first boot

### DIFF
--- a/installer/build/scripts/harbor/configure_harbor.sh
+++ b/installer/build/scripts/harbor/configure_harbor.sh
@@ -138,9 +138,10 @@ configureHarborCfg ssl_cert $cert
 configureHarborCfg ssl_cert_key $key
 configureHarborCfg secretkey_path $data_dir
 
-# Set MySQL and Clair DB passwords on first boot
-configureHarborCfgOnce db_password "$(genPass)"
-configureHarborCfgOnce clair_db_password "$(genPass)"
+# Set Harbor DB and Clair DB passwords on first boot
+random_pwd=$(genPass)
+configureHarborCfgOnce db_password "$random_pwd"
+configureHarborCfgOnce clair_db_password "$random_pwd"
 
 setPortInYAML $harbor_compose_file "${REGISTRY_PORT}" "${NOTARY_PORT}"
 


### PR DESCRIPTION
As for Harbor DB migrates to pgsql, the clair DB needs to share the same password with harbor DB. This commit is to fix it in vic env.