### PR TITLE
Cache harbor registry images (#1713)

### DIFF
--- a/installer/build/build-cache.sh
+++ b/installer/build/build-cache.sh
@@ -29,6 +29,7 @@ images=(
   vmware/admiral:vic_${BUILD_ADMIRAL_REVISION}
   vmware/dch-photon:${BUILD_DCHPHOTON_VERSION}
   gcr.io/eminent-nation-87317/vic-machine-server:${BUILD_VIC_MACHINE_SERVER_REVISION}
+  vmware/registry:2.6.2-photon
 )
 
 # cache other deps


### PR DESCRIPTION
Caches the harbor registry image in the
vic appliance ova. Fixes #1712.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: 46cf5c714a
From PR: #1713 
-->
