### PR TITLE
Verbose output from pabot commands

### DIFF
--- a/tests/robot-run.sh
+++ b/tests/robot-run.sh
@@ -40,7 +40,7 @@ if [ "${DRONE_BUILD_NUMBER}" -eq 0 ]; then
 else
     # run pabot cmd on CI
     echo "Running integration tests on CI..."
-    pabot --processes 3 -d robot-logs --output original.xml $run_options tests/test-cases
+    pabot --verbose --processes 3 -d robot-logs --output original.xml $run_options tests/test-cases
     # do not try re-run if all the tests were passed
     if [ $? -eq 0 ]; then
         echo "All tests passed on first try, no re-run required"
@@ -48,6 +48,6 @@ else
     fi
 
     # re-run only failed tests and merge results
-    pabot --processes 3 -d robot-logs --rerunfailed robot-logs/original.xml --output rerun.xml $run_options tests/test-cases
+    pabot --verbose --processes 3 -d robot-logs --rerunfailed robot-logs/original.xml --output rerun.xml $run_options tests/test-cases
     rebot -d robot-logs --merge robot-logs/original.xml robot-logs/rerun.xml
 fi

--- a/tests/vic-product-nightly.sh
+++ b/tests/vic-product-nightly.sh
@@ -63,7 +63,7 @@ if [[ ! -f vic-product/$input ]]; then
 fi
 echo "VIC Product OVA download complete...";
 
-docker run --net grid --privileged --rm --link selenium-hub:selenium-grid-hub -v /var/run/docker.sock:/var/run/docker.sock -v /etc/docker/certs.d:/etc/docker/certs.d -v $PWD/vic-product:/go -v /vic-cache:/vic-cache --env-file vic-internal/vic-product-nightly-secrets.list gcr.io/eminent-nation-87317/vic-integration-test:1.46 pabot --processes 4 --removekeywords TAG:secret --exclude skip tests/manual-test-cases
+docker run --net grid --privileged --rm --link selenium-hub:selenium-grid-hub -v /var/run/docker.sock:/var/run/docker.sock -v /etc/docker/certs.d:/etc/docker/certs.d -v $PWD/vic-product:/go -v /vic-cache:/vic-cache --env-file vic-internal/vic-product-nightly-secrets.list gcr.io/eminent-nation-87317/vic-integration-test:1.46 pabot --verbose --processes 4 --removekeywords TAG:secret --exclude skip tests/manual-test-cases
 cat vic-product/pabot_results/*/stdout.txt | grep -E '::|\.\.\.' | grep -E 'PASS|FAIL' > console.log
 
 # Pretty up the email results


### PR DESCRIPTION
Turns on verbose for `pabot` which makes it convenient to read logs directly on drone and jenkins UI.