### PR TITLE
Add drone step to publish failed builds

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -234,7 +234,7 @@ pipeline:
       repo: vmware/vic-product
       event: [push, tag]
       branch: [master, 'releases/*', 'refs/tags/*']
-      status: success
+      status: [success, failure]
 
   bundle-stage-builds:
     group: post-build
@@ -253,7 +253,7 @@ pipeline:
       event: [deployment]
       environment: [staging]
       branch: [master, 'releases/*', 'refs/tags/*']
-      status: success
+      status: [success, failure]
 
   bundle-release-builds:
     group: post-build
@@ -271,7 +271,7 @@ pipeline:
       event: [deployment]
       environment: [release]
       branch: ['releases/*', 'refs/tags/*']
-      status: success
+      status: [success, failure]
 
   publish-gcs-builds:
     image: 'victest/drone-gcs:1'
@@ -322,6 +322,22 @@ pipeline:
       environment: [release]
       branch: ['releases/*', 'refs/tags/*']
       status: success
+
+  publish-gcs-builds-on-fail:
+    image: 'victest/drone-gcs:1'
+    pull: true
+    secrets:
+      - google_key
+    source: bundle
+    target: vic-product-failed-builds
+    acl:
+      - 'allUsers:READER'
+    cache_control: 'public,max-age=3600'
+    when:
+      repo: vmware/vic-product
+      event: [push, tag, deployment]
+      branch: [master, 'releases/*', 'refs/tags/*']
+      status: failure
 
   notify-slack-on-fail:
     image: plugins/slack


### PR DESCRIPTION
VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1711 + created a new GCS bucket `vic-product-failed-builds` and verified drone can publish to it.

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->