### PR TITLE
Fix Clair CPU Restrictions

### DIFF
--- a/installer/build/bootable/root/etc/systemd/journald.conf.d/10-persistent.conf
+++ b/installer/build/bootable/root/etc/systemd/journald.conf.d/10-persistent.conf
@@ -1,4 +1,0 @@
-[Journal]
-Storage=persistent
-SystemMaxFileSize=100M
-RuntimeMaxFileSize=100M

--- a/installer/build/scripts/provisioners/provision_harbor.sh
+++ b/installer/build/scripts/provisioners/provision_harbor.sh
@@ -36,8 +36,10 @@ f = open(file, "r+")
 dataMap = yaml.safe_load(f)
 for _, s in enumerate(dataMap["services"]):
   if "restart" in dataMap["services"][s]:
-      if "always" in dataMap["services"][s]["restart"] and s != "jobservice":
-        dataMap["services"][s]["restart"] = "on-failure"
+    if "always" in dataMap["services"][s]["restart"] and s != "jobservice":
+      dataMap["services"][s]["restart"] = "on-failure"
+  if s == "clair":
+    dataMap["services"][s]["cpu_quota"] = 50000
   if "volumes" in dataMap["services"][s]:
     for kvol, vol in enumerate(dataMap["services"][s]["volumes"]):
       # Fixing up volumes in compose file.

--- a/installer/build/scripts/provisioners/provision_harbor.sh
+++ b/installer/build/scripts/provisioners/provision_harbor.sh
@@ -36,7 +36,7 @@ f = open(file, "r+")
 dataMap = yaml.safe_load(f)
 for _, s in enumerate(dataMap["services"]):
   if "restart" in dataMap["services"][s]:
-    if "always" in dataMap["services"][s]["restart"] and s != "jobservice":
+    if "always" in dataMap["services"][s]["restart"]:
       dataMap["services"][s]["restart"] = "on-failure"
   if s == "clair":
     dataMap["services"][s]["cpu_quota"] = 50000

--- a/installer/build/scripts/systemd/scripts/support/appliance-support.sh
+++ b/installer/build/scripts/systemd/scripts/support/appliance-support.sh
@@ -171,6 +171,8 @@ function getDiagInfo {
   commandToFile "docker images" "docker_images" "appliance"
   commandToFile "cat /run/systemd/resolve/resolv.conf" "resolv.conf" "appliance"
   commandToFile "cat /var/log/vmware/upgrade.log" "upgrade.log" "appliance"
+  commandToCompressed "dmesg" "dmesg" "appliance"
+  commandToCompressed "journalctl --no-pager" "journalctl" "appliance"
 
   commandToFile "systemctl status --no-pager docker.service" "systemctl_status_docker.service" "appliance"
   commandToCompressed "journalctl -u docker.service --no-pager" "journal_docker.service" "appliance"


### PR DESCRIPTION
VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [x] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

Removes journal logsize limit, restricts Clair cpu usage, and adds kernel debugging logs to the appliance support bundle.
Fixes #1805

Request for 1.4.1 cherry pick.

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
