### PR TITLE
Update upgrade script for 1.4.1

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -53,6 +53,7 @@ export REDIRECT_ENABLED=0
 VER_1_2_1="v1.2.1"
 VER_1_3_0="v1.3.0"
 VER_1_3_1="v1.3.1"
+VER_1_4_0="v1.4.0"
 
 function usage {
     echo -e "Usage: $0 [args...]
@@ -163,16 +164,17 @@ function enableServicesStart {
   systemctl start harbor.service
 }
 
-### Valid upgrade paths to v1.4.0
+### Valid upgrade paths to v1.4.1
 #   v1.2.1 /data/version has "appliance=v1.2.1"
 #   v1.3.0 /storage/data/version has "appliance=v1.3.0-3033-f8cc7317"
 #   v1.3.1 /storage/data/version has "appliance=v1.3.1-3409-132fb13d"
+#   v1.4.0 /storage/data/version
 ###
 function proceedWithUpgrade {
   checkUpgradeStatus "VIC Appliance" ${appliance_upgrade_status}
   local ver="$1"
 
-  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ]; then
+  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" || [ "$ver" == "$VER_1_4_0" ]; then
     log ""
     log "Detected old appliance's version as $ver."
 

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -108,7 +108,7 @@ function getApplianceVersion() {
   local VER_1_1_1="v1.1.1"
   local VER_1_2_0="v1.2.0"
   local VER_1_2_1="v1.2.1"
-  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1")
+  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0")
   local COPIED_DIR="$1"
   local ver=""
   local tag=""

--- a/tests/manual-test-cases/Group7-Upgrade/7-04-Upgrade-1.4.0.md
+++ b/tests/manual-test-cases/Group7-Upgrade/7-04-Upgrade-1.4.0.md
@@ -1,0 +1,25 @@
+Test 7-04 - Upgrade 1.4.0
+=======
+
+# Purpose:
+To verify the VIC OVA appliance v1.4.0 upgrades to latest with auto upgrade process works as expected
+
+# References:
+
+# Environment:
+This test requires access to VMWare Nimbus cluster for dynamic ESXi and vCenter creation
+
+# Test Steps:
+1. Deploy a new vCenter in Nimbus that is a simple VC cluster
+2. Install an older version of the VIC OVA appliance
+3. Walk through completing the install and use the VCH creation wizard to create a VCH
+4. Run a variety of docker commands on the VCH appliance
+5. Install the latest version of the VIC OVA appliance
+6. Execute the upgrade script pointing at the old version of the VIC OVA appliance
+7. Walk through completing the install
+8. Run a variety of docker commands on the previously created VCH
+
+# Expected Outcome:
+The VCH and VIC appliance upgrade should succeed without error and each of the docker commands executed against it should return without error
+
+# Possible Problems:

--- a/tests/manual-test-cases/Group7-Upgrade/7-04-Upgrade-1.4.0.robot
+++ b/tests/manual-test-cases/Group7-Upgrade/7-04-Upgrade-1.4.0.robot
@@ -1,0 +1,33 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#	http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 7-04 - Upgrade 1.4.0
+Resource  ../../resources/Util.robot
+Suite Setup  Wait Until Keyword Succeeds  10x  10m  OVA Upgrade Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+
+*** Variables ***
+${old-ova-file-name}=  vic-v1.4.0-4944-f168720a.ova
+${old-ova-version}=  v1.4.0
+${old-ova-cert-path}=  /storage/data/admiral/ca_download
+${new-ova-cert-path}=  /storage/data/admiral/ca_download
+
+*** Keywords ***
+OVA Upgrade Setup
+    Setup Simple VC And Test Environment For Upgrade Test
+
+*** Test Cases ***
+Upgrade OVA 1.4.0
+    Auto Upgrade OVA With Verification  7-04-UPGRADE-1-4-0  ${old-ova-file-name}  ${old-ova-version}  ${old-ova-cert-path}  ${new-ova-cert-path}  ha-datacenter

--- a/tests/manual-test-cases/Group7-Upgrade/TestCases.md
+++ b/tests/manual-test-cases/Group7-Upgrade/TestCases.md
@@ -4,4 +4,5 @@ Group 7 - OVA Upgrade
 [Test 7-01 - Upgrade 1.2.1](7-01-Upgrade-1.2.1.md)
 [Test 7-02 - Upgrade 1.3.0](7-02-Upgrade-1.3.0.md)
 [Test 7-03 - Upgrade 1.3.1](7-03-Upgrade-1.3.1.md)
+[Test 7-04 - Upgrade 1.4.0](7-04-Upgrade-1.4.0.md)
 -

--- a/tests/manual-test-cases/Group8-Manual-Upgrade/8-01-Manual-Upgrade-1.4.0.md
+++ b/tests/manual-test-cases/Group8-Manual-Upgrade/8-01-Manual-Upgrade-1.4.0.md
@@ -1,0 +1,29 @@
+Test 8-01 - Manual Upgrade 1.4.0
+=======
+
+# Purpose:
+To verify the VIC OVA appliance works after upgrading from 1.4.0
+
+# References:
+[VIC appliance design
+document](https://github.com/vmware/vic-product/blob/master/installer/docs/DESIGN.md)
+
+# Environment:
+This test requires access to VMWare Nimbus cluster for dynamic ESXi and vCenter creation
+
+# Test Cases
+
+### Test Steps:
+1. Deploy and initialize a VIC appliance version 1.4.0
+2. Creat a VCH, running container and push an image to harbor
+3. Deploy a current VIC appliance version 1.4.1 or greater. Do NOT power on.
+4. Follow instructions for manually moving or copying `/storage/data`, `/storage/log`, and
+   `/storage/db` disks and adding them to current appliance.
+5. Power on the current appliance, but do NOT initialize it.
+6. Run the appliance upgrade script with `--manual-disks` flag
+
+### Expected Outcome:
+
+- Upgrade script completed successfully
+- Verify container created in step 2 is still available and running
+- Verify image pushed in step 2 can be pulled from harbor

--- a/tests/manual-test-cases/Group8-Manual-Upgrade/8-01-Manual-Upgrade-1.4.0.robot
+++ b/tests/manual-test-cases/Group8-Manual-Upgrade/8-01-Manual-Upgrade-1.4.0.robot
@@ -1,0 +1,50 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 8-01 - Manual Upgrade 1.4.0
+Resource  ../../resources/Util.robot
+Suite Setup     Wait Until Keyword Succeeds  10x  10m  Test Environment Setup
+Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
+
+*** Variables ***
+${datacenter}=  ha-datacenter
+${busybox}=  busybox
+${sample-image-tag}=  test
+
+*** Keywords ***
+Test Environment Setup
+    Setup Simple VC And Test Environment
+    # Used by Install VIC Appliance Secret keyword
+    Set Global Variable       ${OVA_USERNAME_ROOT}  root
+    Set Global Variable       ${OVA_PASSWORD_ROOT}  e2eFunctionalTest
+
+*** Test Cases ***
+Upgrade from v1.4.0
+    ${old-ova-file-name}=        Set Variable  vic-v1.4.0-4944-f168720a.ova
+    ${old-ova-version}=          Set Variable  v1.4.0
+    ${old-appliance-name}=       Set Variable  manual-upgrade-${old-ova-file-name}
+    ${new-appliance-name}=       Set Variable  manual-upgrade-from-1.4.0-LATEST
+    ${old-appliance-cert-path}=  Set Variable  /storage/data/admiral/ca_download
+    ${new-appliance-cert-path}=  Set Variable  /storage/data/admiral/ca_download
+
+    Set Global Variable  ${OVA_CERT_PATH}  ${old-appliance-cert-path}
+    # Deploy old ova, install vch, create container, push an image to harbor and deploy new appliance
+    Manual Upgrade Environment Setup  ${old-ova-file-name}  ${old-appliance-name}  ${new-appliance-name}
+    # Copy data disk and attach to new appliance
+    Copy and Attach Disk  ${old-appliance-name}  ${new-appliance-name}  ${datacenter}
+    # Power on new appliance and run upgrade script
+    Power On Appliance And Run Manual Disk Upgrade  ${new-appliance-name}  %{OLD_OVA_IP}  ${old-ova-version}  ${datacenter}
+    # verify container and image in harbor
+    Verify Running Busybox Container And Its Pushed Harbor Image  %{OVA_IP}  ${sample-image-tag}  ${new-appliance-cert-path}  docker-endpoint=${VCH-PARAMS}

--- a/tests/manual-test-cases/Group8-Manual-Upgrade/TestCases.md
+++ b/tests/manual-test-cases/Group8-Manual-Upgrade/TestCases.md
@@ -4,4 +4,5 @@ Group 8 - Manual Upgrade
 [Test 8-01 - Manual Upgrade 1.2.1](8-01-Manual-Upgrade-1.2.1.md)
 [Test 8-01 - Manual Upgrade 1.3.0](8-01-Manual-Upgrade-1.3.0.md)
 [Test 8-01 - Manual Upgrade 1.3.1](8-01-Manual-Upgrade-1.3.1.md)
+[Test 8-01 - Manual Upgrade 1.4.0](8-01-Manual-Upgrade-1.4.0.md)
 -


### PR DESCRIPTION
VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [x] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1806.

Adds Manual and Automated Nightly upgrade tests for ova upgrade.
Adds 1.4.0 as a valid upgrade version for v1.4.1.

Request for 1.4.1 cherry pick.

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
