### PR TITLE
Cherry-pick a variety of changes into 1.4.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -79,7 +79,7 @@ pipeline:
 
   unified-ova-build:
     group: build
-    image: 'gcr.io/eminent-nation-87317/vic-product-build:2ea9bdfd'
+    image: 'gcr.io/eminent-nation-87317/vic-product-build:33e3b968'
     pull: true
     privileged: true
     environment:
@@ -91,6 +91,7 @@ pipeline:
       - harbor
       - vic_machine_server
       - vicengine
+      - gs_token_key
     volumes:
       - '/dev:/dev'
       - '/var/run/docker.sock:/var/run/docker.sock'

--- a/installer/build/bootable/build-disks.sh
+++ b/installer/build/bootable/build-disks.sh
@@ -177,8 +177,8 @@ fi
 
 # These sizes are minimal for install, since partitions are resized to full disk space after firstboot.
 IMAGESIZES=(
-  "4GiB"
-  "1GiB"
+  "6GiB"
+  "2GiB"
 )
 IMAGES=(
   "vic-disk1"
@@ -207,7 +207,8 @@ elif [ "${ACTION}" == "export" ]; then
   log1 "export images to VMDKs"
   for i in "${!IMAGES[@]}"; do
     log2 "exporting ${IMAGES[$i]}.img to ${IMAGES[$i]}.vmdk"
-    DEV=$(losetup -l -O NAME,BACK-FILE -a | tail -n +2 | grep "${IMAGES[$i]}" | awk '{print $1}')
+    echo "export ${PACKAGE}/${IMAGES[$i]}"
+    DEV=$(losetup -l -O NAME,BACK-FILE -a | tail -n +2 | grep "${PACKAGE}/${IMAGES[$i]}" | awk '{print $1}')
     convert "${DEV}" "${IMAGEROOTS[$i]}" "${IMAGES[$i]}.img" "${IMAGES[$i]}.vmdk"
   done
 

--- a/installer/build/bootable/build-main.sh
+++ b/installer/build/bootable/build-main.sh
@@ -137,7 +137,7 @@ function main {
     cd "${PACKAGE}"
     sed -i -e s~--version--~${BUILD_OVA_REVISION}~ vic-${BUILD_OVA_REVISION}.ovf
     log2 "rebuilding OVF manifest"
-    sha256sum --tag "vic-${BUILD_OVA_REVISION}.ovf" "vic-${BUILD_OVA_REVISION}.mf" *.vmdk | sed s/SHA256\ \(/SHA256\(/ > "vic-${BUILD_OVA_REVISION}.mf"
+    sha256sum --tag "vic-${BUILD_OVA_REVISION}.ovf" *.vmdk | sed s/SHA256\ \(/SHA256\(/ > "vic-${BUILD_OVA_REVISION}.mf"
     tar -cvf "${RESOURCE}/vic-${BUILD_OVA_REVISION}.ova" "vic-${BUILD_OVA_REVISION}.ovf" "vic-${BUILD_OVA_REVISION}.mf" *.vmdk
 
     OUTFILE=${RESOURCE}/vic-${BUILD_OVA_REVISION}.ova

--- a/installer/build/bootable/config/builder.ovf
+++ b/installer/build/bootable/config/builder.ovf
@@ -246,7 +246,7 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
     <ProductSection ovf:class="registry" ovf:required="false">
       <Info>Registry Properties</Info>
       <Category>3. Registry Configuration</Category>
-      <Property ovf:key="port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="443">
+      <Property ovf:key="registry_port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="443">
         <Label>3.1. Registry Port</Label>
         <Description>Specifies the port on which registry will be published.</Description>
       </Property>
@@ -262,7 +262,7 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
     <ProductSection ovf:class="management_portal" ovf:required="false">
       <Info>Management Portal Properties</Info>
       <Category>4. Management Portal Configuration</Category>
-      <Property ovf:key="port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="8282">
+      <Property ovf:key="management_portal_port" ovf:qualifiers="MinValue(1),MaxValue(65535)" ovf:type="int" ovf:userConfigurable="true" ovf:value="8282">
         <Label>4.1. Management Portal Port</Label>
         <Description>Specifies the port on which Management Portal will be published.</Description>
       </Property>

--- a/installer/build/build-ova.sh
+++ b/installer/build/build-ova.sh
@@ -82,7 +82,7 @@ url=$(gsutil ls -l "gs://vic-engine-builds" | grep -v TOTAL | grep vic_ | sort -
 setenv VICENGINE "$url"
 
 #set Harbor
-url=$(gsutil ls -l "gs://harbor-builds" | grep -v TOTAL | grep offline-installer | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+url=$(gsutil ls -l "gs://harbor-builds" | grep -v TOTAL | grep offline-installer | grep -v offline-installer-latest | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
 setenv HARBOR "$url"
 
 export BUILD_DCHPHOTON_VERSION="1.13"

--- a/installer/build/container/Dockerfile
+++ b/installer/build/container/Dockerfile
@@ -1,12 +1,14 @@
 FROM vmware/photon
 
 ENV GOVERSION=1.9.2
-ENV PATH=$PATH:/root/gsutil:/usr/local/go/bin
+ENV PATH=$PATH:/root/gsutil:/usr/local/go/bin:/usr/local/google-cloud-sdk/bin/
 
 RUN set -eux; \
     tdnf install -y make tar gzip python2 python-pip sed git \
     gawk docker gptfdisk e2fsprogs grub2 parted xz docker; \
-    curl -L'#' -k https://storage.googleapis.com/pub/gsutil.tar.gz | tar xzf - -C $HOME;  \
+    curl -L'#' -k https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-200.0.0-linux-x86_64.tar.gz  | tar xzf - -C /usr/local; \
+    mkdir -p /root/.gsutil/; \
+    /usr/local/google-cloud-sdk/install.sh --quiet; \
     curl -L'#' -k https://storage.googleapis.com/golang/go$GOVERSION.linux-amd64.tar.gz | tar xzf - -C /usr/local; \
     curl -o /usr/bin/jq -L'#' -k https://github.com/stedolan/jq/releases/download/jq-1.5/jq-linux64 && chmod +x /usr/bin/jq;
 

--- a/installer/build/scripts/harbor/configure_harbor.sh
+++ b/installer/build/scripts/harbor/configure_harbor.sh
@@ -115,9 +115,10 @@ configureHarborCfg ssl_cert $appliance_tls_cert
 configureHarborCfg ssl_cert_key $appliance_tls_key
 configureHarborCfg secretkey_path $data_dir
 
-# Set MySQL and Clair DB passwords on first boot
-configureHarborCfgOnce db_password "$(genPass)"
-configureHarborCfgOnce clair_db_password "$(genPass)"
+# Set Harbor DB and Clair DB passwords on first boot
+random_pwd=$(genPass)
+configureHarborCfgOnce db_password "$random_pwd"
+configureHarborCfgOnce clair_db_password "$random_pwd"
 
 setPortInYAML $harbor_compose_file "${REGISTRY_PORT}" "${NOTARY_PORT}"
 

--- a/installer/build/scripts/systemd/scripts/vic-appliance-environment.sh
+++ b/installer/build/scripts/systemd/scripts/vic-appliance-environment.sh
@@ -23,8 +23,8 @@ APPLIANCE_TLS_CERT="$(ovfenv -k appliance.tls_cert | sed -E ':a;N;$!ba;s/\r{0,1}
 APPLIANCE_TLS_PRIVATE_KEY="$(ovfenv -k appliance.tls_cert_key | sed -E ':a;N;$!ba;s/\r{0,1}\n//g')"
 APPLIANCE_TLS_CA_CERT="$(ovfenv -k appliance.ca_cert | sed -E ':a;N;$!ba;s/\r{0,1}\n//g')"
 
-ADMIRAL_PORT="$(ovfenv -k management_portal.port)"
-REGISTRY_PORT="$(ovfenv -k registry.port)"
+ADMIRAL_PORT="$(ovfenv -k management_portal.management_portal_port)"
+REGISTRY_PORT="$(ovfenv -k registry.registry_port)"
 NOTARY_PORT="$(ovfenv -k registry.notary_port)"
 FILESERVER_PORT="$(ovfenv -k appliance.config_port)"
 HOSTNAME=""

--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -214,7 +214,7 @@ function proceedWithUpgrade {
   fi
 
   log ""
-  log "Detected old appliance's version $ver as 1.2.0 or older."
+  log "Detected old appliance's version as $ver."
   log "Upgrade from this version is not a supported upgrade path."
   log "If the old appliance's version is not detected correctly, please contact VMware support."
   exit 1

--- a/installer/docs/BUILD.md
+++ b/installer/docs/BUILD.md
@@ -112,8 +112,8 @@ docker run -it --net=host -v $GOPATH/src/github.com/vmware/vic-product/installer
   --net:Network="VM Network" \
   --prop:appliance.root_pwd="password" \
   --prop:appliance.permit_root_login=True \
-  --prop:management_portal.port=8282 \
-  --prop:registry.port=443 \
+  --prop:management_portal.management_portal_port=8282 \
+  --prop:registry.registry_port=443 \
   /test-bin/$(ls -1t bin | grep "\.ova") \
   vi://$VC_USER:$VC_PASSWORD@$VC_IP/$VC_COMPUTE
 ```

--- a/installer/docs/BUILD.md
+++ b/installer/docs/BUILD.md
@@ -157,20 +157,37 @@ Make sure `DRONE_SERVER` and `DRONE_TOKEN` environment variables are set before 
 
 To promote existing successful CI build to staging (`vic-product-ova-builds` bucket):
 
-``
-$ drone deploy --param VICENGINE=<vic_engine_version> --param VIC_MACHINE_SERVER=<vic_machine_server> --param ADMIRAL=<admiral_tag> --param HARBOR=<harbor_version> vmware/vic-product <ci_build_number_to_promote> staging
-``
+```
+$ drone deploy --param VICENGINE=<vic_engine_version> \
+               --param VIC_MACHINE_SERVER=<vic_machine_server> \
+               --param ADMIRAL=<admiral_tag> \
+               --param HARBOR=<harbor_version> \
+               vmware/vic-product <ci_build_number_to_promote> staging
+```
 
 To promote existing successful CI build to release (`vic-product-ova-releases` bucket):
 
-``
-$ drone deploy --param VICENGINE=<vic_engine_version> --param VIC_MACHINE_SERVER=<vic_machine_server> --param ADMIRAL=<admiral_tag> --param HARBOR=<harbor_version> vmware/vic-product <ci_build_number_to_promote> release
-``
+```
+$ drone deploy --param VICENGINE=<vic_engine_version> \
+               --param VIC_MACHINE_SERVER=<vic_machine_server> \
+               --param ADMIRAL=<admiral_tag> \
+               --param HARBOR=<harbor_version> \
+               vmware/vic-product <ci_build_number_to_promote> release
+```
+
+Example:
+
+```
+$ drone deploy --param VICENGINE=https://storage.googleapis.com/vic-engine-releases/vic_v1.4.0.tar.gz \
+               --param VIC_MACHINE_SERVER=latest \
+               --param ADMIRAL=v1.4.0 \
+               --param HARBOR=https://storage.googleapis.com/harbor-releases/harbor-offline-installer-v1.5.0.tgz \
+               vmware/vic-product <ci_build_number_to_promote> release
+
+```
 
 `vic_engine_version` and `harbor_version` can be specified as a URL or a file in `cwd`, eg. 'https://storage.googleapis.com/vic-engine-releases/vic_1.2.1.tar.gz'
 
 `admiral_tag` and `vic_machine_server` should be specified as docker image revision tag, eg. 'latest'
 
 `ci_build_number_to_promote` is the drone build number which will be promoted
-
-## Troubleshooting

--- a/installer/docs/BUILD.md
+++ b/installer/docs/BUILD.md
@@ -155,13 +155,13 @@ Please note that you cannot trigger new CI builds manually, but have to promote 
 
 Make sure `DRONE_SERVER` and `DRONE_TOKEN` environment variables are set before executing these commands.
 
-To promote existing successful CI build to staging...
+To promote existing successful CI build to staging (`vic-product-ova-builds` bucket):
 
 ``
 $ drone deploy --param VICENGINE=<vic_engine_version> --param VIC_MACHINE_SERVER=<vic_machine_server> --param ADMIRAL=<admiral_tag> --param HARBOR=<harbor_version> vmware/vic-product <ci_build_number_to_promote> staging
 ``
 
-To promote existing successful CI build to release...
+To promote existing successful CI build to release (`vic-product-ova-releases` bucket):
 
 ``
 $ drone deploy --param VICENGINE=<vic_engine_version> --param VIC_MACHINE_SERVER=<vic_machine_server> --param ADMIRAL=<admiral_tag> --param HARBOR=<harbor_version> vmware/vic-product <ci_build_number_to_promote> release

--- a/installer/docs/RELEASE.md
+++ b/installer/docs/RELEASE.md
@@ -3,12 +3,14 @@
 All examples in this document assume the user's fork is at `origin` and `vmware/vic-product` is at
 `upstream`.
 
+
 ## Branching
 
 When the team is ready to build a release candidate, create a branch off of master based on the
-release version number. A tag for ongoing development should also be created at the commit after
-where the release branch begins. If there have been commits to master since the intended branch
-point, first create a tag for the release candidate, then create the branch from that tag.
+release version number. 
+
+A tag for ongoing development should also be created at the commit **after**
+the start of the release branch. The tagging procedure is documented in [Tagging](#Tagging). 
 
 ```
 git remote update
@@ -22,8 +24,11 @@ git push upstream
 Configure branch protection on Github to have the same protection as the master branch.
 `Protect this branch` and `Require pull request reviews before merging` should be set.
 
-Development should continue on master. Commits that need to be pulled into the release should be
-cherry picked into the release branch after they are merged into master.
+
+## Cherry picking
+
+Commits that need to be pulled into the release should be cherry picked into the release branch
+after they are merged into master.
 
 ```
 git remote update
@@ -38,12 +43,9 @@ git push upstream
 ## Tagging
 
 On the master branch, tag the commit for the first release candidate. On the
-following commit, tag `dev` for ongoing development.  For example, if the
+following commit, tag `dev` for ongoing development. For example, if the
 current release is `v1.2.0`, the first release candidate will be `v1.2.0-rc1` and
 the tag for ongoing development will be `v1.3.0-dev`.
-
-When the team is ready to release, tag the commit in the release branch (`v1.2.0`) and push the tag
-to Github.
 
 ```
 git remote update
@@ -52,14 +54,79 @@ git tag -a v1.2.0-rc1 aaaaaaa
 git push upstream v1.2.0-rc1
 ```
 
-Tag `dev` on the release branch after a release. For example, if `v1.2.0` was tagged on
-`/releases/1.2.0` and there is work for `v1.2.1`, on the following commit, tag `v1.2.1-dev`.
+If there is not yet a commit after the start of the release branch, create an empty commit after
+the commit for the release branch. This empty commit will be tagged for ongoing development on master.
+
+```
+# Create empty commit on master
+git remote update
+git checkout upstream/master
+git commit --allow-empty -m "v1.3.0-dev"
+git push upstream
+
+# Tag empty commit for ongoing development
+git remote update
+git checkout upstream/master
+git tag -a v1.3.0-dev bbbbbbb
+git pubsh upstream v1.3.0-dev
+```
+
+After the release candidate has passed QA and the team is ready to release, tag the commit in the
+release branch (`v1.2.0`) and push the tag to Github.
 
 ```
 git remote update
 git checkout upstream/releases/1.2.0
-git tag -a v1.2.1-dev bbbbbbb
+git tag -a v1.2.0 ccccccc
+git push upstream v1.2.0
+```
+
+### Point releases
+
+After a release, tag `dev` on the release branch for ongoing development.
+For example, if `v1.2.0` was tagged on `/releases/1.2.0` and there is work for `v1.2.1`, on the
+following commit, tag `v1.2.1-dev`.
+
+```
+git remote update
+git checkout upstream/releases/1.2.0
+git tag -a v1.2.1-dev ddddddd
 git push upstream v1.2.1-dev
+```
+
+
+## Github Releases
+
+After pushing the tag to Github, go to https://github.com/vmware/vic-product/releases/new
+
+Select the appropriate tag
+
+Release title follows form `vSphere Integrated Containers Appliance <tag>` (e.g. `vSphere Integrated Containers Appliance v1.2.0-rc1`)
+
+Description template for release candidates:
+```
+OVA will contain:
+Admiral v1.2.0-rc3
+Harbor harbor-offline-installer-v1.2.0-rc4.tgz
+VIC Engine vic_1.2.0-rc4.tar.gz
+VIC Machine Server digest aaaaaaa
+```
+
+If the release is a release candidate, mark `This is a pre-release`
+
+## OVA Releases
+
+Description template for release version of the OVA:
+```
+Admiral v1.2.0
+Harbor harbor-offline-installer-v1.2.0.tgz
+VIC Engine vic_1.2.0.tar.gz
+VIC Machine Server digest aaaaaaa
+
+ef6b71d98bb6650240008b5281e97bf8592d5fd726833883718f471ed665fc5b  vic-v1.2.0-aaaaaaaa.ova
+85eabdf7e58fed8c09e4f3c45b2caa974ae89a16  vic-v1.2.0-aaaaaaaa.ova
+ebc669f7b4cebf7501cf141e3b6fa2e3  vic-v1.2.0-aaaaaaaa.ova
+4741.43 MB
 ```
 
 
@@ -72,34 +139,3 @@ git checkout tags/v1.2.0
 
 Follow instructions in [How to build VIC Product OVA](BUILD.md)
 
-## Github Releases
-
-After pushing the tag to Github, go to https://github.com/vmware/vic-product/releases/new
-
-Select the appropriate tag
-
-Title for follows form `VIC Product <tag>` (`VIC Product v1.2.0-rc1`)
-
-Description template for release candidates:
-```
-OVA will contain:
-Admiral `v1.2.0-rc3`
-Harbor `harbor-offline-installer-v1.2.0-rc4.tgz`
-VIC Engine `vic_1.2.0-rc4.tar.gz`
-```
-
-If the release is a release candidate, mark `This is a pre-release`
-
-## OVA Releases
-
-Description template for release version of the OVA:
-```
-Admiral `v1.2.0`
-Harbor `harbor-offline-installer-v1.2.0.tgz`
-VIC Engine `vic_1.2.0.tar.gz`
-
-ef6b71d98bb6650240008b5281e97bf8592d5fd726833883718f471ed665fc5b  vic-v1.2.0-aaaaaaaa.ova
-85eabdf7e58fed8c09e4f3c45b2caa974ae89a16  vic-v1.2.0-aaaaaaaa.ova
-ebc669f7b4cebf7501cf141e3b6fa2e3  vic-v1.2.0-aaaaaaaa.ova
-4741.43 MB
-```

--- a/installer/docs/RELEASE.md
+++ b/installer/docs/RELEASE.md
@@ -101,41 +101,35 @@ After pushing the tag to Github, go to https://github.com/vmware/vic-product/rel
 
 Select the appropriate tag
 
-Release title follows form `vSphere Integrated Containers Appliance <tag>` (e.g. `vSphere Integrated Containers Appliance v1.2.0-rc1`)
+Release title follows form `vSphere Integrated Containers Appliance <tag>` (e.g. `vSphere Integrated Containers Appliance v1.4.0-rc3`)
 
-Description template for release candidates:
+Obtain artifact hashes from CI build output at the end of `unified-ova-build` step
+
+Obtain version information from `/etc/vmware/version`
+
+Description template for release candidates and releases:
+
+```````
+### [Download OVA](https://storage.googleapis.com/vic-product-ova-releases/vic-v1.4.0-rc3-4824-d99cbdb4.ova)
+Filesize: 
+SHA256:  
+SHA1: 
+MD5: 
+
+### OVA will contain:
 ```
-OVA will contain:
-Admiral v1.2.0-rc3
-Harbor harbor-offline-installer-v1.2.0-rc4.tgz
-VIC Engine vic_1.2.0-rc4.tar.gz
-VIC Machine Server digest aaaaaaa
+appliance=v1.4.0-rc3-4824-d99cbdb4
+harbor=harbor-offline-installer-v1.5.0-rc4.tgz
+engine=vic_v1.4.0-rc2.tar.gz
+admiral=vmware/admiral:vic_v1.4.0-rc4 45a773ffae33
+vic-machine-server=gcr.io/eminent-nation-87317/vic-machine-server:latest b3412e003674
 ```
+### [Changes from v1.3.1](https://github.com/vmware/vic-product/compare/v1.3.1...v1.4.0-rc3)
+
+```````
 
 If the release is a release candidate, mark `This is a pre-release`
 
-## OVA Releases
-
-Description template for release version of the OVA:
-```
-Admiral v1.2.0
-Harbor harbor-offline-installer-v1.2.0.tgz
-VIC Engine vic_1.2.0.tar.gz
-VIC Machine Server digest aaaaaaa
-
-ef6b71d98bb6650240008b5281e97bf8592d5fd726833883718f471ed665fc5b  vic-v1.2.0-aaaaaaaa.ova
-85eabdf7e58fed8c09e4f3c45b2caa974ae89a16  vic-v1.2.0-aaaaaaaa.ova
-ebc669f7b4cebf7501cf141e3b6fa2e3  vic-v1.2.0-aaaaaaaa.ova
-4741.43 MB
-```
-
-
-## Building Release
-
-```
-git fetch --all --tags --prune
-git checkout tags/v1.2.0
-```
+## Building Releases
 
 Follow instructions in [How to build VIC Product OVA](BUILD.md)
-

--- a/installer/fileserver/server.go
+++ b/installer/fileserver/server.go
@@ -142,7 +142,7 @@ func Init(conf *config) {
 
 	if ip, err := ip.FirstIPv4(ip.Eth0Interface); err == nil {
 		conf.serverHostname = getHostname(ovf, ip)
-		if port, ok := ovf.Properties["management_portal.port"]; ok {
+		if port, ok := ovf.Properties["management_portal.management_portal_port"]; ok {
 			conf.admiralPort = port
 		}
 	}

--- a/installer/fileserver/tasks.go
+++ b/installer/fileserver/tasks.go
@@ -74,7 +74,7 @@ func registerWithPSC(ctx context.Context) error {
 	if err != nil {
 		return err
 	}
-	admiralPort := ovf.Properties["management_portal.port"]
+	admiralPort := ovf.Properties["management_portal.management_portal_port"]
 
 	// Out of the box users
 	defCreateUsers, foundCreateUsers := ovf.Properties["default_users.create_def_users"]

--- a/installer/scripts/ci-build.sh
+++ b/installer/scripts/ci-build.sh
@@ -20,35 +20,53 @@ cd installer
 INSTALLER_DIR=$(pwd)
 OPTIONS=""
 
-echo "BRANCH = $DRONE_BRANCH"
+echo -e "BRANCH = $DRONE_BRANCH\nEVENT = $DRONE_BUILD_EVENT\nTAG = $DRONE_TAG\n"
 
-# set options
+# set options based on drone args, if present
 if [ -n "${ADMIRAL}" ]; then
   OPTIONS="--admiral $ADMIRAL"
-elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
-  admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1 | cut -d'_' -f2)
-  OPTIONS="--admiral $admiral_release"
 fi
-
 if [ -n "${HARBOR}" ]; then
   OPTIONS="$OPTIONS --harbor $HARBOR"
-elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
-  harbor_release=$(gsutil ls -l "gs://harbor-releases" | grep -v TOTAL | grep offline-installer | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
-  OPTIONS="$OPTIONS --harbor $harbor_release"
 fi
-
 if [ -n "${VICENGINE}" ]; then
   OPTIONS="$OPTIONS --vicengine $VICENGINE"
-elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
-  vicengine_release=$(gsutil ls -l "gs://vic-engine-releases" | grep -v TOTAL | grep vic_ | sort -k2 -r | (trap '' PIPE; head -1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
-  OPTIONS="$OPTIONS --vicengine $vicengine_release"
 fi
-
 if [ -n "${VIC_MACHINE_SERVER}" ]; then
   OPTIONS="$OPTIONS --vicmachineserver $VIC_MACHINE_SERVER"
-elif [[ "$DRONE_BRANCH" == *"releases/"* ]]; then
-  vicmachineserver_release="latest"
-  OPTIONS="$OPTIONS --vicmachineserver $vicmachineserver_release"
+fi
+
+# set release options if drone args not present
+if [[ ( "$DRONE_BUILD_EVENT" == "tag" && "$DRONE_TAG" != *"dev"* ) || "$DRONE_BRANCH" == *"releases/"* ]]; then
+  if [ -z "${ADMIRAL}" ]; then
+    admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1 | cut -d'_' -f2)
+    OPTIONS="--admiral $admiral_release"
+  fi
+  if [ -z "${HARBOR}" ]; then
+    harbor_release=$(gsutil ls -l "gs://harbor-releases" | grep -v TOTAL | grep offline-installer | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+    OPTIONS="$OPTIONS --harbor $harbor_release"
+  fi
+  if [ -z "${VICENGINE}" ]; then
+    vicengine_release=$(gsutil ls -l "gs://vic-engine-releases" | grep -v TOTAL | grep vic_ | sort -k2 -r | (trap '' PIPE; head -1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+    OPTIONS="$OPTIONS --vicengine $vicengine_release"
+  fi
+  if [ -z "${VIC_MACHINE_SERVER}" ]; then
+    # Listing container tags requires permissions
+    if [ -z "$(gcloud auth list --filter=status:ACTIVE --format='value(account)')" ]; then
+      if [ -z "${GS_TOKEN_KEY}" ]; then
+        echo "No google service account key found..."
+        exit 1
+      fi
+      echo "Attempting to login with google account service key"
+      KEY_FILE=".tmp.token"
+      echo "${GS_TOKEN_KEY}" > ${KEY_FILE}
+      gcloud auth activate-service-account --key-file ${KEY_FILE} || (echo "Login with service account key failed..." && exit 1)
+      rm -f ${KEY_FILE}
+    fi
+
+    vicmachineserver_release="$(gcloud container images list-tags gcr.io/eminent-nation-87317/vic-machine-server --filter='tags~.' | grep -v DIGEST | awk '{print $2}' | sed -rn 's/^(.*,)?(v([0-9]+\.){2}[0-9]+(-rc[0-9]+)?)(,.*)?$/\2/p' | head -n 1)"
+    OPTIONS="$OPTIONS --vicmachineserver $vicmachineserver_release"
+  fi
 fi
 
 echo "OPTIONS = $OPTIONS"


### PR DESCRIPTION
(Note: This _must_ be submitted with the "rebase & merge" option, _not_ "squash & merge".)

Cherry-pick a variety of work from `master` to `releases/1.4.1` to include in 1.4.1-rc1. This should be a series of independent PRs, but I'm posting this all at once to allow a quicker turn-around cycle.

Cherry picks:
 * 20bd476d from PR #1637
 * 7c07bfe0 from PR #1642
 * c7c1598b from PR #1685
 * 49623c76 from PR #1684
 * 6bbb3a7b from PR #1704
 * 914d6066 from PR #1693
 * 7a3d8471 from PR #1726

---

VIC Appliance Checklist:
- [x] Up to date with `releases/1.4.1` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist