### PR TITLE
Cherry-pick: Avoid running reconfigure_token twice

### DIFF
--- a/installer/build/scripts/systemd/units/reconfigure_token.service
+++ b/installer/build/scripts/systemd/units/reconfigure_token.service
@@ -8,6 +8,7 @@ After=network-online.target vic-appliance-wait-psc-config.service
 Type=oneshot
 ExecStart=/usr/bin/systemctl restart get_token.service
 ExecStartPost=/usr/bin/systemctl --no-block restart admiral harbor
+RemainAfterExit=yes
 
 [Install]
 WantedBy=psc-ready.target


### PR DESCRIPTION
Add `RemainAfterExit=yes` to prevent `reconfigure_token` from running twice during initialization.

(cherry picked from commit 30849e4)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: 30849e4
From PR:  #1840