### PR TITLE
[EXPERIMENT] See of RemainAfterExit=yes prevents reconfigure_token from running twice

### DIFF
--- a/installer/build/scripts/systemd/units/reconfigure_token.service
+++ b/installer/build/scripts/systemd/units/reconfigure_token.service
@@ -8,6 +8,7 @@ After=network-online.target vic-appliance-wait-psc-config.service
 Type=oneshot
 ExecStart=/usr/bin/systemctl restart get_token.service
 ExecStartPost=/usr/bin/systemctl --no-block restart admiral harbor
+RemainAfterExit=yes
 
 [Install]
 WantedBy=psc-ready.target

--- a/tests/common-ova/OVA-Cleanup.robot
+++ b/tests/common-ova/OVA-Cleanup.robot
@@ -27,4 +27,5 @@ Copy OVA Support Bundle
     Copy Support Bundle  %{OVA_IP}
 
 Teardown Common OVA
-    Cleanup VIC Product OVA  %{OVA_NAME}
+    Log Skipping cleanup of %{OVA_IP}
+


### PR DESCRIPTION
Like #1840, but on `master`.

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
