### PR TITLE
[EXPERIMENTAL] Skip cleanup on master

### DIFF
--- a/tests/common-ova/OVA-Cleanup.robot
+++ b/tests/common-ova/OVA-Cleanup.robot
@@ -27,4 +27,5 @@ Copy OVA Support Bundle
     Copy Support Bundle  %{OVA_IP}
 
 Teardown Common OVA
-    Cleanup VIC Product OVA  %{OVA_NAME}
+    Log  Skipping cleanup of %{OVA_IP}
+


### PR DESCRIPTION
This is a dummy PR on `master` which skips cleanup after running CI.