### PR TITLE
Revert "Avoid running reconfigure_token twice (#1849)"

### DIFF
--- a/installer/build/scripts/systemd/units/reconfigure_token.service
+++ b/installer/build/scripts/systemd/units/reconfigure_token.service
@@ -8,7 +8,6 @@ After=network-online.target vic-appliance-wait-psc-config.service
 Type=oneshot
 ExecStart=/usr/bin/systemctl restart get_token.service
 ExecStartPost=/usr/bin/systemctl --no-block restart admiral harbor
-RemainAfterExit=yes
 
 [Install]
 WantedBy=psc-ready.target


### PR DESCRIPTION
This reverts commit 30849e4ab545ef351d63231b7542a7eb78aec7d1, which
breaks the "Re-initialize the vSphere Integrated Container Appliance"
operation on the "Getting Started" page.

For more information, see https://github.com/vmware/vic-product/pull/1840#issuecomment-401127179.

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)