### PR TITLE
Cherry-pick: Handle multiple lightweight tabs on a commit (#1858)

### DIFF
--- a/installer/Makefile
+++ b/installer/Makefile
@@ -30,7 +30,7 @@ GOLINT ?= $(GOPATH)/bin/golint$(BIN_ARCH)
 
 .PHONY: gas ova
 
-LDFLAGS := $(shell BUILD_NUMBER=${BUILD_NUMBER} $(BASE_DIR)/scripts/version-linker-flags.sh)
+LDFLAGS := $(shell BUILD_NUMBER=${BUILD_NUMBER} TAG=${TAG} $(BASE_DIR)/scripts/version-linker-flags.sh)
 
 ovfenv := $(BIN)/ovfenv
 vic-ova-ui := $(BIN)/vic-ova-ui

--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -27,7 +27,7 @@ ADMIRAL=""
 VICENGINE=""
 VIC_MACHINE_SERVER=""
 HARBOR=""
-TAG=$(git describe --abbrev=0 --tags) # e.g. `v0.9.0`
+TAG=${DRONE_TAG:-$(git describe --abbrev=0 --tags)} # e.g. `v0.9.0`
 REV=$(git rev-parse --short=8 HEAD)
 DRONE_BUILD_NUMBER=${DRONE_BUILD_NUMBER:-0}
 BUILD_OVA_REVISION="${TAG}-${DRONE_BUILD_NUMBER}-${REV}"
@@ -57,6 +57,7 @@ if [ "$step" == "ova-dev" ]; then
     -v /var/run/docker.sock:/var/run/docker.sock \
     -e DEBUG=${DEBUG} \
     -e BUILD_OVA_REVISION=${BUILD_OVA_REVISION} \
+    -e TAG=${TAG} \
     -e BUILD_NUMBER=${BUILD_NUMBER} \
     -e DRONE_BUILD_NUMBER=${DRONE_BUILD_NUMBER} \
     -e TERM -w ${ROOT_INSTALLER_WORK_DIR} \
@@ -65,6 +66,7 @@ elif [ "$step" == "ova-ci" ]; then
   echo "starting ci build..."
   export DEBUG=${DEBUG}
   export BUILD_OVA_REVISION=${BUILD_OVA_REVISION}
+  export TAG=${TAG}
   export BUILD_NUMBER=${BUILD_NUMBER}
   export DRONE_BUILD_NUMBER=${DRONE_BUILD_NUMBER}
   ./build/build-ova.sh $*

--- a/installer/scripts/version-linker-flags.sh
+++ b/installer/scripts/version-linker-flags.sh
@@ -15,7 +15,7 @@
 #
 
 echo "-s -w \
-    -X github.com/vmware/vic-product/installer/pkg/version.Version=`git describe --abbrev=0 --tags` \
+    -X github.com/vmware/vic-product/installer/pkg/version.Version=`${TAG}` \
     -X github.com/vmware/vic-product/installer/pkg/version.BuildNumber=\"${BUILD_NUMBER}\" \
     -X github.com/vmware/vic-product/installer/pkg/version.BuildDate=`date -u +%Y/%m/%d@%H:%M:%S` \
     -X github.com/vmware/vic-product/installer/pkg/version.GitCommit=`git rev-parse --short HEAD` \


### PR DESCRIPTION
The GitHub release process creates lightweight tags, which do not have
associated metadata such as date information. This causes git describe
to fall back to lexicographic ordering to break ties between candidate
tags when multiple exist on a given commit.

When building a new RC build to pick up a new RC build of a component,
we wind up with multiple tags on a single commit in vic-product (since
we simply need to do a new build of the same commit to pick up the new
build of the changed component).

When we are performing a tag build, we expect the corresponding tag to
be used— which may not always be the tag that would be selected by git
describe. Ensure we use the expected tag falling back to git describe
only if the $DRONE_TAG variable is not set.

This should preserve the current behavior for non-tag builds (and when
building outside of our CI/CD environment) and enable continued use of
lightweight tags (while we explore the impacts of using annotated tags
on our CI/CD logic).

(cherry picked from commit 0be2645752f85a89896463b6be90e232c39d50f5)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: 0be2645752f85a89896463b6be90e232c39d50f5
From PR: #1858