### PR TITLE
Cherry-pick: Remove erroneous backticks in linker flags (#1861)

### DIFF
--- a/installer/scripts/version-linker-flags.sh
+++ b/installer/scripts/version-linker-flags.sh
@@ -13,9 +13,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+set -e -o pipefail +h && [ -n "$DEBUG" ] && set -x
 
 echo "-s -w \
-    -X github.com/vmware/vic-product/installer/pkg/version.Version=`${TAG}` \
+    -X github.com/vmware/vic-product/installer/pkg/version.Version=${TAG} \
     -X github.com/vmware/vic-product/installer/pkg/version.BuildNumber=\"${BUILD_NUMBER}\" \
     -X github.com/vmware/vic-product/installer/pkg/version.BuildDate=`date -u +%Y/%m/%d@%H:%M:%S` \
     -X github.com/vmware/vic-product/installer/pkg/version.GitCommit=`git rev-parse --short HEAD` \


### PR DESCRIPTION
When replacing the tag command with an environment variable, the
surrounding backticks were not removed.

This was not caught during testing because the script did not return
a non-zero exit code, even though an error had occurred. Add a set
line to prevent similar errors from going undetected in the future.

(cherry picked from commit 658a40893d23a6184b41340118982f4321cc5be4)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: 658a40893d23a6184b41340118982f4321cc5be4
From PR: #1861