### PR TITLE
Print file size and checksums before publishing

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -229,7 +229,9 @@ pipeline:
       - 'echo "Passed build will have artifact at https://storage.googleapis.com/vic-product-ova-builds/$TMP"'
       - 'echo "Renaming build artifact to $TMP..."'
       - 'mv vic-*.ova ../../bundle/$TMP'
-      - 'ls -l ../../bundle'
+      - 'cd ../../bundle'
+      - 'ls -l'
+      - 'echo "--------------------------------------------------"; stat --printf="Filesize (%n) = %s\n" $TMP; sha256sum --tag $TMP; sha1sum --tag $TMP; md5sum --tag $TMP'
     when:
       repo: vmware/vic-product
       event: [push, tag]
@@ -247,7 +249,9 @@ pipeline:
       - 'echo "Passed build will have artifact at https://storage.googleapis.com/vic-product-ova-builds/$TMP"'
       - 'echo "Renaming build artifact to $TMP..."'
       - 'mv vic-*.ova ../../bundle/$TMP'
-      - 'ls -l ../../bundle'
+      - 'cd ../../bundle'
+      - 'ls -l'
+      - 'echo "--------------------------------------------------"; stat --printf="Filesize (%n) = %s\n" $TMP; sha256sum --tag $TMP; sha1sum --tag $TMP; md5sum --tag $TMP'
     when:
       repo: vmware/vic-product
       event: [deployment]
@@ -265,7 +269,9 @@ pipeline:
       - 'TMP=$(echo vic-*.ova)'
       - 'echo "Passed build will have artifact at https://storage.googleapis.com/vic-product-ova-releases/$TMP"'
       - 'mv vic-*.ova ../../bundle/'
-      - 'ls -l ../../bundle'
+      - 'cd ../../bundle'
+      - 'ls -l'
+      - 'echo "--------------------------------------------------"; stat --printf="Filesize (%n) = %s\n" $TMP; sha256sum --tag $TMP; sha1sum --tag $TMP; md5sum --tag $TMP'
     when:
       repo: vmware/vic-product
       event: [deployment]

--- a/installer/docs/RELEASE.md
+++ b/installer/docs/RELEASE.md
@@ -111,10 +111,10 @@ Description template for release candidates and releases:
 
 ```````
 ### [Download OVA](https://storage.googleapis.com/vic-product-ova-releases/vic-v1.4.0-rc3-4824-d99cbdb4.ova)
-Filesize: 
-SHA256:  
-SHA1: 
-MD5: 
+Filesize (vic-v1.4.0-rc3-4824-d99cbdb4.ova) = ...
+SHA256 (vic-v1.4.0-rc3-4824-d99cbdb4.ova) = ...
+SHA1 (vic-v1.4.0-rc3-4824-d99cbdb4.ova) = ...
+MD5 (vic-v1.4.0-rc3-4824-d99cbdb4.ova) = ...
 
 ### OVA will contain:
 ```


### PR DESCRIPTION
As documented in `installer/docs/RELEASE.md`, our process is to include filesize and checksum information when publishing a release on GitHub.

Output that information in a structured way during the build process to ensure that accurate information can be easily posted.

Include this output for all published builds to allow integrity to be verified in all cases.

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [x] Considered impact to upgrade
- [x] Tests passing
- [x] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)