### PR TITLE
Cherry-pick: Revise upgrade script to treat v1.4.0 like v1.3.x (#1869)

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -348,7 +348,7 @@ function moveDisks {
       govc device.remove -vm="$NEW_VM_NAME" "$disk"
     fi
     # Only remove log and database disks from 1.3.0 and greater
-    if [[ ( "$disk" =~ -2$ || "$disk" =~ -3$ ) && ( "$ver" == "$VER_1_3_0"  ||  "$ver" == "$VER_1_3_1" ) ]]; then
+    if [[ ( "$disk" =~ -2$ || "$disk" =~ -3$ ) && ( "$ver" != "$VER_1_2_1" ) ]]; then
       echo "Remove disk $disk from $NEW_VM_NAME"
       govc device.remove -vm="$NEW_VM_NAME" "$disk"
     fi
@@ -363,7 +363,7 @@ function moveDisks {
     exit 1
   fi
 
-  if [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ]; then
+  if [ "$ver" != "$VER_1_2_1" ]; then
     OLD_DB_DISK=$(govc vm.info -json "$OLD_VM_NAME" | jq -r ".VirtualMachines[].Layout.Disk[2].DiskFile[0]" | awk '{print $NF}')
     echo "OLD_DB_DISK: $OLD_DB_DISK"
     OLD_LOG_DISK=$(govc vm.info -json "$OLD_VM_NAME" | jq -r ".VirtualMachines[].Layout.Disk[3].DiskFile[0]" | awk '{print $NF}')
@@ -377,7 +377,7 @@ function moveDisks {
 
   log "Copying old data disk. Please wait."
   govc datastore.cp -ds "$OLD_DATASTORE" -ds-target "$NEW_DATASTORE" "$OLD_DATA_DISK" "$NEW_DATA_DISK" || ( log "Failed to copy data disk. Please try again. Exiting..." && exit 1)
-  if [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ]; then
+  if [ "$ver" != "$VER_1_2_1" ]; then
     log "Copying old database disk. Please wait."
     govc datastore.cp -ds "$OLD_DATASTORE" -ds-target "$NEW_DATASTORE" "$OLD_DB_DISK" "$NEW_DB_DISK" || ( log "Failed to copy database disk. Please try again. Exiting..." && exit 1)
     log "Copying old log disk. Please wait."
@@ -387,7 +387,7 @@ function moveDisks {
   # TODO rename to new version
   echo "Attaching migrated disks to new VIC appliance"
   govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_DATA_DISK" || (log "Failed to attach data disk" && exit 1)
-  if [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ]; then
+  if [ "$ver" != "$VER_1_2_1" ]; then
     govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_DB_DISK" || (log "Failed to attach database disk"  && exit 1)
     govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_LOG_DISK" || (log "Failed to attach log disk" && exit 1)
   fi


### PR DESCRIPTION
Because v1.2.1 had a different disk topology than v1.3.0 and later, it
requires a slightly different upgrade process. This was handled by
explicitly checking whether the "source" version is v1.3.0 or v1.3.1
and moving the new disks only in those cases.

We expect the disk topology to remain consistent until an intentional
change is made. Reverse the conditional logic to disable the v1.3.0+
logic only when the version is v1.2.1. (Upgrade from earlier versions
is unsupported, and an error is returned if attempted.)

This causes upgrade from v1.4.0 to behave like upgrade from v1.3.x and
ensures that support for upgrade from future v1.4.x patches can easily
be added without needing to update several places in this file.

(cherry picked from commit a9cb0c450b596f3d0df9585102b9c68e930d8168)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1868

Cherry picks: a9cb0c450b596f3d0df9585102b9c68e930d8168
From PR: #1869