### PR TITLE
Work around inexplicable pipe error during build

### DIFF
--- a/installer/build/build-ova.sh
+++ b/installer/build/build-ova.sh
@@ -82,7 +82,9 @@ url=$(gsutil ls -l "gs://vic-engine-builds" | grep -v TOTAL | grep vic_ | sort -
 setenv VICENGINE "$url"
 
 #set Harbor
+set +o pipefail
 url=$(gsutil ls -l "gs://harbor-builds" | grep -v TOTAL | grep offline-installer | grep -v offline-installer-latest | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+set -o pipefail
 setenv HARBOR "$url"
 
 export BUILD_DCHPHOTON_VERSION="1.13"


### PR DESCRIPTION
For some reason, `head -n1` is resulting in exit code 141 despite being protected by `trap '' PIPE`. This same pattern is used successfully in the preceding logic. It is not clear why we are seeing this issue now, or why trap is not behaving as expected.

Disabling pipefail for this line is acceptable because the build does not even use the results of this line on the release branch.

Note: This change should be reverted once the cause is understood.