### PR TITLE
Cherry-pick: Add missing right bracket to upgrade script (#1890)

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -176,7 +176,7 @@ function proceedWithUpgrade {
   checkUpgradeStatus "VIC Appliance" ${appliance_upgrade_status}
   local ver="$1"
 
-  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" || [ "$ver" == "$VER_1_4_1" ]; then
+  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ]; then
     log ""
     log "Detected old appliance's version as $ver."
 


### PR DESCRIPTION
The commit[1] to add upgrade support from 1.4.2 omitted a right
bracket. This mistake caused upgrade to fail from 1.4.0.

1 - e811e0afa23a2302f46a94b6b3b422918700ca28

(cherry picked from commit 10aa9d492576660c925a2a1ede5a649432792bba)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: 10aa9d492576660c925a2a1ede5a649432792bba
From PR: #1890