### PR TITLE
Cherry-pick: Do not link disks when attaching during upgrade (#1889)

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -388,10 +388,10 @@ function moveDisks {
 
   # TODO rename to new version
   echo "Attaching migrated disks to new VIC appliance"
-  govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_DATA_DISK" || (log "Failed to attach data disk" && exit 1)
+  govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_DATA_DISK" -link=false || (log "Failed to attach data disk" && exit 1)
   if [ "$ver" != "$VER_1_2_1" ]; then
-    govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_DB_DISK" || (log "Failed to attach database disk"  && exit 1)
-    govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_LOG_DISK" || (log "Failed to attach log disk" && exit 1)
+    govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_DB_DISK" -link=false || (log "Failed to attach database disk"  && exit 1)
+    govc vm.disk.attach -vm="$NEW_VM_NAME" -ds "$NEW_DATASTORE" -disk "$NEW_LOG_DISK" -link=false || (log "Failed to attach log disk" && exit 1)
   fi
   log "Finished attaching migrated disks to new VIC appliance"
 


### PR DESCRIPTION
By default, govc vm.disk.attach "links" disks, which sets their disk
mode to independent. Disable this flag to ensure attached disks are
dependent disks, so that snapshots can be taken.

(cherry picked from commit f87e94f05ddad9f0047861f4358d90e8bf0a91e1)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: f87e94f05ddad9f0047861f4358d90e8bf0a91e1
From PR: #1889