### PR TITLE
Fix reminder logic for staging builds

### DIFF
--- a/installer/build/build-ova.sh
+++ b/installer/build/build-ova.sh
@@ -136,7 +136,7 @@ drone deploy --param VICENGINE=${BUILD_VICENGINE_URL:-} \\
              --param HARBOR=${BUILD_HARBOR_URL:-} \\
              vmware/vic-product ${DRONE_BUILD_NUMBER:-} staging
 EOF
-elif [ "deploy" == "${DRONE_BUILD_EVENT}" -a "staging" == "${DRONE_DEPLOY_TO}" ]; then
+elif [ "deployment" == "${DRONE_BUILD_EVENT}" -a "staging" == "${DRONE_DEPLOY_TO}" ]; then
     echo "--------------------------------------------------"
     echo "Command to release this tag staged build:"
     cat <<EOF


### PR DESCRIPTION
Update the conditional to use the correct value for DRONE_BUILD_EVENT.

The command is `drone deploy`, but the build event is "deployment".

This value is not documented in Drone's environment reference:
  http://readme.drone.io/usage/environment-reference/

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [x] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)