### PR TITLE
Cdinkens elasticsearch tutorial

### DIFF
--- a/tutorials/elasticsearch/Readme.md
+++ b/tutorials/elasticsearch/Readme.md
@@ -4,12 +4,12 @@
 
 2. This configuration will also provide an avenue for moving from non-containerized elasticsearch clusters to a fully containerized configuration. 
 
+**Please keep in mind that part of the 'magic' with this configuration is utilizing Named Volumes. Compose does not remove named volumes when performing docker-compose down. This is crucial to allowing the transition to container nodes.**
 ---
 The hosts referred to as **'log'**, **'elk-node1'**, **'elk-node2'** in this compose file are current elasticsearch nodes being prepped for containerization; Once the cluster has synchronized I will begin removing the 'old' nodes from allocation and subsequently from use for indexing/storage.
-
 
 The network referred to as **'vic-elastic'** is mapped to external dvSwitch portgroup **'elasticsearch'**
 
 _This configuration assumes that you are using static addressing and have already configured the necessary DNS entries for the elasticsearch nodes contained within this compose file._
 
-I will also be uploading a customized config based on: [ELK-Stack Compose file](https://github.com/vmware/vic-product/tree/master/tutorials/elk) which will be customized to match this compose file, which would allow the transition to complete from the 3-node elastic cluster
+I will also be uploading a customized config based on: [ELK-Stack Compose file](https://github.com/vmware/vic-product/tree/master/tutorials/elk) which will be customized to match this compose file, which would allow the complete transition from the 3-node elastic cluster that I uploaded, to the 3-node redundant ELK cluster linked in this paragraph.

--- a/tutorials/elasticsearch/Readme.md
+++ b/tutorials/elasticsearch/Readme.md
@@ -1,0 +1,15 @@
+# The purpose of this config is two-fold:
+
+1. To provide flexibility for elastic/server admins to bring up additional elasticsearch container nodes on VIC dvSwitch mapped subnets. 
+
+2. This configuration will also provide an avenue for moving from non-containerized elasticsearch clusters to a fully containerized configuration. 
+
+---
+The hosts referred to as **'log'**, **'elk-node1'**, **'elk-node2'** in this compose file are current elasticsearch nodes being prepped for containerization; Once the cluster has synchronized I will begin removing the 'old' nodes from allocation and subsequently from use for indexing/storage.
+
+
+The network referred to as **'vic-elastic'** is mapped to external dvSwitch portgroup **'elasticsearch'**
+
+_This configuration assumes that you are using static addressing and have already configured the necessary DNS entries for the elasticsearch nodes contained within this compose file._
+
+I will also be uploading a customized config based on: [ELK-Stack Compose file](https://github.com/vmware/vic-product/tree/master/tutorials/elk) which will be customized to match this compose file, which would allow the transition to complete from the 3-node elastic cluster

--- a/tutorials/elasticsearch/docker-compose.yml
+++ b/tutorials/elasticsearch/docker-compose.yml
@@ -1,0 +1,124 @@
+version: '2.2'
+services:
+  elk-cnode1:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+    command: |
+      sh -c 'sysctl -w vm.max_map_count=262144 && /usr/local/bin/docker-entrypoint.sh eswrapper'
+    environment:
+      - cluster.name=elasticsearch
+      - node.name=elk-cnode1
+      - discovery.type=zen
+      - "discovery.zen.ping.unicast.hosts=log,elk-cnode2,elk-cnode3,elk-node1,elk-node2"
+      - discovery.zen.minimum_master_nodes=1
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      #- ELASTIC_PASSWORD=changeme
+      - ALLOW_INSECURE_DEFAULT_TLS_CERT="true"
+
+    volumes:
+      - elastic-node1-data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+      - 9300:9300
+
+    
+    networks:
+        vic-elastic:
+          ipv4_address: 192.168.50.208
+    dns:
+      - 192.168.25.99
+      - 192.168.25.199
+    dns_search: domain.local
+    domainname: domain.local
+    hostname: elk-cnode1
+
+  elk-cnode2:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+    command: |
+      sh -c 'sysctl -w vm.max_map_count=262144 && /usr/local/bin/docker-entrypoint.sh eswrapper'
+    environment:
+      - cluster.name=elasticsearch
+      - node.name=elk-cnode2
+      - discovery.type=zen
+      - "discovery.zen.ping.unicast.hosts=log,elk-cnode1,elk-cnode3,elk-node1,elk-node2"
+      - discovery.zen.minimum_master_nodes=1
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      #- ELASTIC_PASSWORD=changeme
+      - ALLOW_INSECURE_DEFAULT_TLS_CERT="true"
+
+    volumes:
+      - elastic-node2-data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+      - 9300:9300
+
+    networks:
+        vic-elastic:
+          ipv4_address: 192.168.50.209
+
+    dns:
+      - 192.168.25.99
+      - 192.168.25.199
+    dns_search: domain.local
+    domainname: domain.local
+    hostname: elk-cnode2
+
+  elk-cnode3:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.2.3
+    command: |
+      sh -c 'sysctl -w vm.max_map_count=262144 && /usr/local/bin/docker-entrypoint.sh eswrapper'
+    environment:
+      - cluster.name=elasticsearch
+      - node.name=elk-cnode3
+      - discovery.type=zen
+      - "discovery.zen.ping.unicast.hosts=log,elk-cnode1,elk-cnode2,elk-node1,elk-node2"
+      - discovery.zen.minimum_master_nodes=1
+      - "ES_JAVA_OPTS=-Xms1g -Xmx1g"
+      #- ELASTIC_PASSWORD=changeme
+      - ALLOW_INSECURE_DEFAULT_TLS_CERT="true"
+
+    volumes:
+      - elastic-node3-data:/usr/share/elasticsearch/data
+    ports:
+      - 9200:9200
+      - 9300:9300
+
+    networks:
+        vic-elastic:
+          ipv4_address: 192.168.50.210
+
+    dns:
+      - 192.168.25.99
+      - 192.168.25.199
+    dns_search: domain.local
+    domainname: domain.local
+    hostname: elk-cnode3
+
+
+volumes:
+  elastic-node1-data:
+    name: elastic-node1-data
+    driver: vsphere
+    driver_opts:
+      capacity: 30GB
+  elastic-node2-data:
+    name: elastic-node2-data
+    driver: vsphere
+    driver_opts:
+      capacity: 30GB
+  elastic-node3-data:
+    name: elastic-node3-data
+    driver: vsphere
+    driver_opts:
+      capacity: 30GB
+
+networks:
+  vic-elastic:
+    external:
+      name: vic-elastic
+    ipam:
+      driver: default
+      config:
+      - subnet: 192.168.50.208/29
+        gateway: 192.168.50.1
+
+


### PR DESCRIPTION
VIC Appliance Checklist:
- [* ] Up to date with `master` branch

Also in Readme:
# The purpose of this config is two-fold:

1. To provide flexibility for elastic/server admins to bring up additional elasticsearch container nodes on VIC dvSwitch mapped subnets. 

2. This configuration will also provide an avenue for moving from non-containerized elasticsearch clusters to a fully containerized configuration. 

**Please keep in mind that part of the 'magic' with this configuration is utilizing Named Volumes. Compose does not remove named volumes when performing docker-compose down. This is crucial to allowing the transition to container nodes.**
---
The hosts referred to as **'log'**, **'elk-node1'**, **'elk-node2'** in this compose file are current elasticsearch nodes being prepped for containerization; Once the cluster has synchronized I will begin removing the 'old' nodes from allocation and subsequently from use for indexing/storage.

The network referred to as **'vic-elastic'** is mapped to external dvSwitch portgroup **'elasticsearch'**

_This configuration assumes that you are using static addressing and have already configured the necessary DNS entries for the elasticsearch nodes contained within this compose file._

I will also be uploading a customized config based on: [ELK-Stack Compose file](https://github.com/vmware/vic-product/tree/master/tutorials/elk) which will be customized to match this compose file, which would allow the complete transition from the 3-node elastic cluster that I uploaded, to the 3-node redundant ELK cluster linked in this paragraph.
