### PR TITLE
Prevent fileserver from being loaded in an iframe

### DIFF
--- a/installer/lib/tls.go
+++ b/installer/lib/tls.go
@@ -19,12 +19,12 @@ import (
 	"net/http"
 )
 
-func GetTLSServer(addr string, mux *http.ServeMux, cert tls.Certificate) *http.Server {
+func GetTLSServer(addr string, handler http.Handler, cert tls.Certificate) *http.Server {
 	// forcing tls 1.1, cipher from https://github.com/denji/golang-tls#perfect-ssl-labs-score-with-go
 	// and https://wiki.mozilla.org/Security/TLS_Configurations#Go
 	return &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: handler,
 		TLSConfig: &tls.Config{
 			MinVersion:               tls.VersionTLS11,
 			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},


### PR DESCRIPTION
In order to protect the Getting Started page from being embedded in a page controlled by an attacker, set the Content-Security-Policy header to disallow rendering of the page within an iframe.

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
    * There are currently tests which interact with the Getting Started page using Selenium, but there doesn't seem to be a keyword to inspect the HTTP headers, so adding a test for this might be a large change.
- [x] Considered impact to upgrade
- [x] Tests passing
- [ ] Updated documentation
    * This does not seem like something we'd need to document.
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1512