### PR TITLE
Publish artifacts from release branches separately

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -226,7 +226,8 @@ pipeline:
       - 'mkdir bundle'
       - 'cd installer/bin'
       - 'TMP=$(echo "$(ls -1t | grep "\.ova")" | sed "s/-/-dev-/")'
-      - 'echo "Passed build will have artifact at https://storage.googleapis.com/vic-product-ova-builds/$TMP"'
+      - 'if [ "${DRONE_BUILD_EVENT}" == "push" ] && [ "${DRONE_BRANCH}" != "master" ]; then FOLDER=${DRONE_BRANCH} ; fi'
+      - 'echo "Passed build will have artifact at https://storage.googleapis.com/vic-product-ova-builds/${FOLDER}${FOLDER:+/}${TMP}"'
       - 'echo "Renaming build artifact to $TMP..."'
       - 'mv vic-*.ova ../../bundle/$TMP'
       - 'cd ../../bundle'
@@ -279,19 +280,51 @@ pipeline:
       branch: ['releases/*', 'refs/tags/*']
       status: [success, failure]
 
-  publish-gcs-builds:
+  publish-gcs-master-builds-push:
     image: 'victest/drone-gcs:1'
     pull: true
     secrets:
       - google_key
     source: bundle
-    target: vic-product-ova-builds
+    target: vic-product-ova-builds/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic-product
-      event: [push, tag]
+      event: [push]
+      branch: [master]
+      status: success
+
+  publish-gcs-release-builds-push:
+    image: 'victest/drone-gcs:1'
+    pull: true
+    secrets:
+      - google_key
+    source: bundle
+    target: vic-product-ova-builds/${DRONE_BRANCH}/
+    acl:
+      - 'allUsers:READER'
+    cache_control: 'public,max-age=3600'
+    when:
+      repo: vmware/vic-product
+      event: [push]
+      branch: ['releases/*']
+      status: success
+
+  publish-gcs-builds-tag:
+    image: 'victest/drone-gcs:1'
+    pull: true
+    secrets:
+      - google_key
+    source: bundle
+    target: vic-product-ova-builds/
+    acl:
+      - 'allUsers:READER'
+    cache_control: 'public,max-age=3600'
+    when:
+      repo: vmware/vic-product
+      event: [tag]
       branch: [master, 'releases/*', 'refs/tags/*']
       status: success
 
@@ -301,7 +334,7 @@ pipeline:
     secrets:
       - google_key
     source: bundle
-    target: vic-product-ova-builds
+    target: vic-product-ova-builds/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'
@@ -318,7 +351,7 @@ pipeline:
     secrets:
       - google_key
     source: bundle
-    target: vic-product-ova-releases
+    target: vic-product-ova-releases/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'
@@ -335,7 +368,7 @@ pipeline:
     secrets:
       - google_key
     source: bundle
-    target: vic-product-failed-builds
+    target: vic-product-failed-builds/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'


### PR DESCRIPTION
Because builds from all branches are written to the same directory,
it is difficulty to pick up the right build to test against different
release branches.

Publish artifacts from release branches into sub-directories of a
releases directory, so nightly test of a release branch can select the
last build artifact under the subdirectory for testing.

Tags builds are published to a "tags" directory.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
