### PR TITLE
Support tlsverify for dch-photon image

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -45,10 +45,14 @@ pipeline:
     environment:
       TERM: xterm
     secrets:
-    - github_automation_api_key
+      - github_automation_api_key
+      - harbor_ci_registry
+      - test_username
+      - test_password
     volumes:
       - '/dev:/dev'
       - '/var/run/docker.sock:/var/run/docker.sock'
+      - '/etc/docker:/etc/docker'
     commands:
       - 'docker ps'
       - 'dinv/ci.sh build'
@@ -65,10 +69,9 @@ pipeline:
     environment:
       TERM: xterm
     secrets:
-    - github_automation_api_key
-    secrets:
       - docker_user
       - docker_password
+      - github_automation_api_key
     volumes:
       - '/dev:/dev'
       - '/var/run/docker.sock:/var/run/docker.sock'
@@ -142,6 +145,7 @@ pipeline:
       GOPATH: /go
       SHELL: /bin/bash
     secrets:
+      - harbor_ci_registry
       - bridge_network
       - public_network
       - test_datastore

--- a/.drone.yml
+++ b/.drone.yml
@@ -44,6 +44,8 @@ pipeline:
     privileged: true
     environment:
       TERM: xterm
+    secrets:
+    - github_automation_api_key
     volumes:
       - '/dev:/dev'
       - '/var/run/docker.sock:/var/run/docker.sock'
@@ -62,6 +64,8 @@ pipeline:
     privileged: true
     environment:
       TERM: xterm
+    secrets:
+    - github_automation_api_key
     secrets:
       - docker_user
       - docker_password

--- a/dinv/dch-photon-1.12/main.go
+++ b/dinv/dch-photon-1.12/main.go
@@ -127,7 +127,7 @@ func main() {
 				}
 			}
 
-			dockerArgs = append(dockerArgs, "--tls", "--tlscacert=/certs/ca.crt", "--tlscert=/certs/docker.crt", "--tlskey=/certs/docker.key")
+			dockerArgs = append(dockerArgs, "--tlsverify", "--tlscacert=/certs/ca.crt", "--tlscert=/certs/docker.crt", "--tlskey=/certs/docker.key")
 		}
 	}
 

--- a/dinv/dch-photon-1.13/main.go
+++ b/dinv/dch-photon-1.13/main.go
@@ -120,7 +120,7 @@ func main() {
 				}
 			}
 
-			dockerArgs = append(dockerArgs, "--tls", "--tlscacert=/certs/ca.crt", "--tlscert=/certs/docker.crt", "--tlskey=/certs/docker.key")
+			dockerArgs = append(dockerArgs, "--tlsverify", "--tlscacert=/certs/ca.crt", "--tlscert=/certs/docker.crt", "--tlskey=/certs/docker.key")
 		}
 	}
 

--- a/dinv/dch-photon-17.06/main.go
+++ b/dinv/dch-photon-17.06/main.go
@@ -120,7 +120,7 @@ func main() {
 				}
 			}
 
-			dockerArgs = append(dockerArgs, "--tls", "--tlscacert=/certs/ca.crt", "--tlscert=/certs/docker.crt", "--tlskey=/certs/docker.key")
+			dockerArgs = append(dockerArgs, "--tlsverify", "--tlscacert=/certs/ca.crt", "--tlscert=/certs/docker.crt", "--tlskey=/certs/docker.key")
 		}
 	}
 

--- a/tests/resources/VCH-Util.robot
+++ b/tests/resources/VCH-Util.robot
@@ -47,11 +47,11 @@ Run VIC Machine Command
 
     Set Test VCH Variables
 
-    ${output}=  Run Keyword If  ${certs}  Run  ${vic-machine} create --debug ${debug} --name=${vch-name} --target=%{TEST_URL} --thumbprint=${TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --appliance-iso=${appliance-iso} --bootstrap-iso=${bootstrap-iso} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --compute-resource=%{TEST_RESOURCE} --timeout %{VCH_TIMEOUT} --insecure-registry harbor.ci.drone.local --volume-store=%{TEST_DATASTORE}/${vch-name}-VOL:${vol} ${vicmachinetls} ${additional-args}
+    ${output}=  Run Keyword If  ${certs}  Run  ${vic-machine} create --debug ${debug} --name=${vch-name} --target=%{TEST_URL} --thumbprint=${TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --appliance-iso=${appliance-iso} --bootstrap-iso=${bootstrap-iso} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --compute-resource=%{TEST_RESOURCE} --timeout %{VCH_TIMEOUT} --insecure-registry %{HARBOR_CI_REGISTRY} --volume-store=%{TEST_DATASTORE}/${vch-name}-VOL:${vol} ${vicmachinetls} ${additional-args}
     Run Keyword If  ${certs}  Should Contain  ${output}  Installer completed successfully
     Return From Keyword If  ${certs}  ${output}
 
-    ${output}=  Run Keyword Unless  ${certs}  Run  ${vic-machine} create --debug ${debug} --name=${vch-name} --target=%{TEST_URL} --thumbprint=${TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --appliance-iso=${appliance-iso} --bootstrap-iso=${bootstrap-iso} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --compute-resource=%{TEST_RESOURCE} --timeout %{VCH_TIMEOUT} --insecure-registry harbor.ci.drone.local --volume-store=%{TEST_DATASTORE}/${vch-name}-VOL:${vol} --no-tlsverify ${additional-args}
+    ${output}=  Run Keyword Unless  ${certs}  Run  ${vic-machine} create --debug ${debug} --name=${vch-name} --target=%{TEST_URL} --thumbprint=${TEST_THUMBPRINT} --user=%{TEST_USERNAME} --password=%{TEST_PASSWORD} --image-store=%{TEST_DATASTORE} --appliance-iso=${appliance-iso} --bootstrap-iso=${bootstrap-iso} --bridge-network=%{BRIDGE_NETWORK} --public-network=%{PUBLIC_NETWORK} --compute-resource=%{TEST_RESOURCE} --timeout %{VCH_TIMEOUT} --insecure-registry %{HARBOR_CI_REGISTRY} --volume-store=%{TEST_DATASTORE}/${vch-name}-VOL:${vol} --no-tlsverify ${additional-args}
     Run Keyword Unless  ${certs}  Should Contain  ${output}  Installer completed successfully
     [Return]  ${output}
 

--- a/tests/test-cases/Group5-DCH/5-01-DCH.md
+++ b/tests/test-cases/Group5-DCH/5-01-DCH.md
@@ -1,0 +1,28 @@
+Test 5-01 - DCH
+=======
+
+# Purpose:
+To verify DCH tls/tlsverify parameters
+
+# Environment:
+This test requires that a:
+- vSphere server is running and available
+- Installed VIC appliance
+
+# Test Steps:
+1. Download VIC engine, if not already
+2. Install VCH
+3. Push dch-photon latest image to habor registry
+4. Deploy dch-photon container from habor registry with no-tls
+5. Deploy dch-photon container from habor registry with --tls
+6. Deploy dch-photon container from habor registry with --tlsverify
+7. Delete added VCH host from UI
+
+
+# Expected Outcome:
+* Step 4 Verify dch-photon container could be accessed from port 2375
+* Step 5 Verify dch-photon container could be accessed from port 2376 with --tls parameter
+* Step 5 Verify dch-photon container could not be accessed without certs
+* Step 7 VCH host is removed successfully
+
+#Possible Problems:

--- a/tests/test-cases/Group5-DCH/5-01-DCH.robot
+++ b/tests/test-cases/Group5-DCH/5-01-DCH.robot
@@ -19,27 +19,20 @@ Test Timeout  5 minutes
 Test Setup  Run Keyword  Setup Base State
 
 *** Variables ***
-${dinv-namespace} vmware
-${dinv-image-tag} 17.06
-${sample-image-name}  dch-photon
-${sample-image-tag}  test
+${harbor-ci-registry}  harbor.ci.drone.local
+${dinv-image-tag}  17.06
+${dinv-image-name}  dch-photon
+${harbor-image-name}  ${harbor-ci-registry}/${dinv-image-name}
+${harbor-image-tagged}  ${harbor-image-name}:${dinv-image-tag}
 
 *** Keywords ***
 Setup Base State
     Download VIC Engine If Not Already  %{OVA_IP}
-    ${vch-name}=  Install VCH  certs=${false}
-    # push dch-photon:17.06 image
-    ${harbor-image-name}=  Set Variable  %{OVA_IP}/${DEFAULT_HARBOR_PROJECT}/${sample-image-name}
-    ${harbor-image-tagged}=  Set Variable  ${harbor-image-name}:${sample-image-tag}
-    ${dinv-image-name}= Set Variable ${dinv-namespace}/${sample-image-name}:${dinv-image-tag}
-    Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${DEFAULT_LOCAL_DOCKER_ENDPOINT} tag ${dinv-image-name} ${harbor-image-tagged}
-    Log To Console  \n${dinv-image-name} tagged successfully
-    Push Docker Image To Harbor Registry  %{OVA_IP}  ${harbor-image-tagged}
 
 *** Test Cases ***
 Verify non-tls is enabled for dch-photon
-    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12375:2375 ${harbor-image-tagged}
-    Should Be Equal As Integers  ${rc}  0
+    ${vch-name}=  Install VCH  certs=${false}
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12375:2375 ${harbor-image-tagged}
     ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} ps
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
@@ -49,28 +42,32 @@ Verify non-tls is enabled for dch-photon
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Containers
 
+    [Teardown]  Cleanup VCH  ${vch-name}
+
 Verify tls enabled scenario for dch-photon
-    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12376:2376 ${harbor-image-tagged} --tls
-    Should Be Equal As Integers  ${rc}  0
+    ${vch-name}=  Install VCH  certs=${false}
+    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12376:2376 ${harbor-image-tagged} -tls
     ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} ps
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  --tls
+    Should Contain  ${output}  -tls
     # verify 12376 could be accessed with --tls to show docker info
     ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} -H ${VCH-IP}:12376 --tls info
     Should Be Equal As Integers  ${rc}  0
     Should Contain  ${output}  Containers
 
+    [Teardown]  Cleanup VCH  ${vch-name}
+
 Verify tlsverify enabled scenario for dch-photon
-    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12386:2376 ${harbor-image-tagged} --tlsverify
-    Should Be Equal As Integers  ${rc}  0
+    ${vch-name}=  Install VCH  certs=${false}
+    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12386:2376 ${harbor-image-tagged} -tlsverify
     ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} ps
     Log  ${output}
     Should Be Equal As Integers  ${rc}  0
-    Should Contain  ${output}  --tlsverify
-    # verify 12386 could be accessed with --tls to show docker info
+    Should Contain  ${output}  -tlsverify
+    # verify 12386 could not be accessed with --tls due to missing certs
     ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} -H ${VCH-IP}:12386 --tls info
     Should Be Equal As Integers  ${rc}  1
     Should Contain  ${output}  'bad certificate'
 
-    [Teardown] Cleanup VCH
+    [Teardown]  Cleanup VCH  ${vch-name}

--- a/tests/test-cases/Group5-DCH/5-01-DCH.robot
+++ b/tests/test-cases/Group5-DCH/5-01-DCH.robot
@@ -19,10 +19,9 @@ Test Timeout  5 minutes
 Test Setup  Run Keyword  Setup Base State
 
 *** Variables ***
-${harbor-ci-registry}  harbor.ci.drone.local
 ${dinv-image-tag}  17.06
 ${dinv-image-name}  dch-photon
-${harbor-image-name}  ${harbor-ci-registry}/${dinv-image-name}
+${harbor-image-name}  ${HARBOR_CI_REGISTRY}/${DEFAULT_HARBOR_PROJECT}/${dinv-image-name}
 ${harbor-image-tagged}  ${harbor-image-name}:${dinv-image-tag}
 
 *** Keywords ***
@@ -67,7 +66,8 @@ Verify tlsverify enabled scenario for dch-photon
     Should Contain  ${output}  -tlsverify
     # verify 12386 could not be accessed with --tls due to missing certs
     ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} -H ${VCH-IP}:12386 --tls info
+    Log  ${output}
     Should Be Equal As Integers  ${rc}  1
-    Should Contain  ${output}  'bad certificate'
+    Should Contain  ${output}  --tlsverify
 
     [Teardown]  Cleanup VCH  ${vch-name}

--- a/tests/test-cases/Group5-DCH/5-01-DCH.robot
+++ b/tests/test-cases/Group5-DCH/5-01-DCH.robot
@@ -1,0 +1,76 @@
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License
+
+*** Settings ***
+Documentation  Test 5-01 DCH
+Resource  ../../resources/Util.robot
+Test Timeout  5 minutes
+Test Setup  Run Keyword  Setup Base State
+
+*** Variables ***
+${dinv-namespace} vmware
+${dinv-image-tag} 17.06
+${sample-image-name}  dch-photon
+${sample-image-tag}  test
+
+*** Keywords ***
+Setup Base State
+    Download VIC Engine If Not Already  %{OVA_IP}
+    ${vch-name}=  Install VCH  certs=${false}
+    # push dch-photon:17.06 image
+    ${harbor-image-name}=  Set Variable  %{OVA_IP}/${DEFAULT_HARBOR_PROJECT}/${sample-image-name}
+    ${harbor-image-tagged}=  Set Variable  ${harbor-image-name}:${sample-image-tag}
+    ${dinv-image-name}= Set Variable ${dinv-namespace}/${sample-image-name}:${dinv-image-tag}
+    Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${DEFAULT_LOCAL_DOCKER_ENDPOINT} tag ${dinv-image-name} ${harbor-image-tagged}
+    Log To Console  \n${dinv-image-name} tagged successfully
+    Push Docker Image To Harbor Registry  %{OVA_IP}  ${harbor-image-tagged}
+
+*** Test Cases ***
+Verify non-tls is enabled for dch-photon
+    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12375:2375 ${harbor-image-tagged}
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} ps
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  /dinv
+    # verify 12375 could be accessed without any certs to show docker info
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} -H ${VCH-IP}:12375 info
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Containers
+
+Verify tls enabled scenario for dch-photon
+    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12376:2376 ${harbor-image-tagged} --tls
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} ps
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  --tls
+    # verify 12376 could be accessed with --tls to show docker info
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} -H ${VCH-IP}:12376 --tls info
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  Containers
+
+Verify tlsverify enabled scenario for dch-photon
+    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12386:2376 ${harbor-image-tagged} --tlsverify
+    Should Be Equal As Integers  ${rc}  0
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} ps
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  0
+    Should Contain  ${output}  --tlsverify
+    # verify 12386 could be accessed with --tls to show docker info
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} -H ${VCH-IP}:12386 --tls info
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  'bad certificate'
+
+    [Teardown] Cleanup VCH

--- a/tests/test-cases/Group5-DCH/Testcases.md
+++ b/tests/test-cases/Group5-DCH/Testcases.md
@@ -1,0 +1,5 @@
+Group 5 - DCH
+=======
+
+
+[Test 5-01 - DCH](5-01-DCH.md)

--- a/tests/test-cases/TestGroups.md
+++ b/tests/test-cases/TestGroups.md
@@ -9,3 +9,5 @@ VIC Integration Test Suite
 [Group 3 - Admiral](Group3-Admiral/TestCases.md)
 
 [Group 4 - Harbor](Group4-Harbor/TestCases.md)
+
+[Group 5 - DCH](Group5-DCH/TestCases.md)


### PR DESCRIPTION
dcp-photon image could accept a parameter '--tlsverify', it means
tlsverify mode is enabled for docker deamon, but in current dcp-photon
image, it does not enable the tlsverify mode. This patch is validated
in my local env.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1903

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
