### PR TITLE
fix vic product ci can not find 'New Container Host' title

### DIFF
--- a/tests/resources/page-objects/New-Container-Host-Modal-Util.robot
+++ b/tests/resources/page-objects/New-Container-Host-Modal-Util.robot
@@ -17,13 +17,13 @@ Documentation  This resource contains any keywords dealing with New Container Ho
 
 *** Variables ***
 # css locators
-${nch-title}  css=.modal-title
+${nch-title}  //div[contains(text(),'New Container Host')]
 ${nch-name}  id=name
 ${nch-url}  id=url
 ${nch-select-creds}  css=.dropdown-select button
 ${nch-dropdown-creds}  css=.dropdown-options li a
 ${nch-default-cert-option}  css=a[data-name=default-ca-cert]
-${nch-button-save}  css=.modal-footer .btn-primary
+${nch-button-save}  css=button.saveCluster-btn
 
 # expected text values
 ${nch-title-text}  New Container Host
@@ -31,7 +31,6 @@ ${nch-title-text}  New Container Host
 *** Keywords ***
 Verify New Container Host Modal
     Wait Until Element Is Visible  ${nch-title}  timeout=${EXPLICIT_WAIT}
-    Element Text Should Be  ${nch-title}  ${nch-title-text}
 
 Add New Container Host
     [Arguments]  ${name}  ${url}  ${creds}=${nch-default-cert-option}

--- a/tests/resources/page-objects/Verify-Certificate-Modal-Util.robot
+++ b/tests/resources/page-objects/Verify-Certificate-Modal-Util.robot
@@ -17,8 +17,8 @@ Documentation  This resource contains any keywords dealing with Verify Certifica
 
 *** Variables ***
 # css locators
-${vc-title}  css=.modal .modal .modal-title
-${vc-button-yes}  css=.modal .modal .btn-primary
+${vc-title}  css=.modal .modal-title
+${vc-button-yes}  css=.modal .btn-primary
 
 # expected text values
 ${vc-title-text}  Verify Certficate


### PR DESCRIPTION
this pr try to fix the ci build error, becasue the new container host ui changed from a dialog to current page.
The robot selector should also change.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
