### PR TITLE
Remove "-cert" from the image tag used in the create example

### DIFF
--- a/docs/user_doc/vic_app_dev/photon_cert_manual.md
+++ b/docs/user_doc/vic_app_dev/photon_cert_manual.md
@@ -19,7 +19,7 @@ To manually add the vSphere Integrated Containers CA certificate to  `dch-photon
 
     This example runs `dch-photon` behind a port mapping.
 
-    <pre>docker -H <i>vch_address</i>:2376 --tls create -it --name build-slave -p 12375:2375 <i>registry_address</i>/default-project/dch-photon:1.13-cert</pre>
+    <pre>docker -H <i>vch_address</i>:2376 --tls create -it --name build-slave -p 12375:2375 <i>registry_address</i>/default-project/dch-photon:1.13</pre>
     
 2. Create the required folder structure on your local machine.
 

--- a/docs/user_doc/vic_app_dev/photon_cert_manual.md
+++ b/docs/user_doc/vic_app_dev/photon_cert_manual.md
@@ -19,7 +19,7 @@ To manually add the vSphere Integrated Containers CA certificate to  `dch-photon
 
     This example runs `dch-photon` behind a port mapping.
 
-    <pre>docker -H <i>vch_address</i>:2376 --tls create -it --name build-slave -p 12375:2375 <i>registry_address</i>/default-project/dch-photon:1.13</pre>
+    <pre>docker -H <i>vch_address</i>:2376 --tls create --name build-slave -p 12375:2375 <i>registry_address</i>/default-project/dch-photon:1.13</pre>
     
 2. Create the required folder structure on your local machine.
 

--- a/docs/user_doc/vic_app_dev/photon_cert_manual.md
+++ b/docs/user_doc/vic_app_dev/photon_cert_manual.md
@@ -19,7 +19,7 @@ To manually add the vSphere Integrated Containers CA certificate to  `dch-photon
 
     This example runs `dch-photon` behind a port mapping.
 
-    <pre>docker -H <i>vch_address</i>:2376 --tls create --name build-slave -p 12375:2375 <i>registry_address</i>/default-project/dch-photon:1.13-cert</pre>
+    <pre>docker -H <i>vch_address</i>:2376 --tls create -it --name build-slave -p 12375:2375 <i>registry_address</i>/default-project/dch-photon:1.13-cert</pre>
     
 2. Create the required folder structure on your local machine.
 


### PR DESCRIPTION
The example is intended to be used with the default dch-photon image that comes with the VIC Appliance which has only the tag "1.13" by default. The "-cert" is not needed in this example and should be removed.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
