### PR TITLE
Cherry-pick: Publish artifacts from release branches separately (#1908)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -226,7 +226,8 @@ pipeline:
       - 'mkdir bundle'
       - 'cd installer/bin'
       - 'TMP=$(echo "$(ls -1t | grep "\.ova")" | sed "s/-/-dev-/")'
-      - 'echo "Passed build will have artifact at https://storage.googleapis.com/vic-product-ova-builds/$TMP"'
+      - 'if [ "${DRONE_BUILD_EVENT}" == "push" ] && [ "${DRONE_BRANCH}" != "master" ]; then FOLDER=${DRONE_BRANCH} ; fi'
+      - 'echo "Passed build will have artifact at https://storage.googleapis.com/vic-product-ova-builds/${FOLDER}${FOLDER:+/}${TMP}"'
       - 'echo "Renaming build artifact to $TMP..."'
       - 'mv vic-*.ova ../../bundle/$TMP'
       - 'cd ../../bundle'
@@ -279,19 +280,51 @@ pipeline:
       branch: ['releases/*', 'refs/tags/*']
       status: [success, failure]
 
-  publish-gcs-builds:
+  publish-gcs-master-builds-push:
     image: 'victest/drone-gcs:1'
     pull: true
     secrets:
       - google_key
     source: bundle
-    target: vic-product-ova-builds
+    target: vic-product-ova-builds/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic-product
-      event: [push, tag]
+      event: [push]
+      branch: [master]
+      status: success
+
+  publish-gcs-release-builds-push:
+    image: 'victest/drone-gcs:1'
+    pull: true
+    secrets:
+      - google_key
+    source: bundle
+    target: vic-product-ova-builds/${DRONE_BRANCH}/
+    acl:
+      - 'allUsers:READER'
+    cache_control: 'public,max-age=3600'
+    when:
+      repo: vmware/vic-product
+      event: [push]
+      branch: ['releases/*']
+      status: success
+
+  publish-gcs-builds-tag:
+    image: 'victest/drone-gcs:1'
+    pull: true
+    secrets:
+      - google_key
+    source: bundle
+    target: vic-product-ova-builds/
+    acl:
+      - 'allUsers:READER'
+    cache_control: 'public,max-age=3600'
+    when:
+      repo: vmware/vic-product
+      event: [tag]
       branch: [master, 'releases/*', 'refs/tags/*']
       status: success
 
@@ -301,7 +334,7 @@ pipeline:
     secrets:
       - google_key
     source: bundle
-    target: vic-product-ova-builds
+    target: vic-product-ova-builds/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'
@@ -318,7 +351,7 @@ pipeline:
     secrets:
       - google_key
     source: bundle
-    target: vic-product-ova-releases
+    target: vic-product-ova-releases/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'
@@ -335,7 +368,7 @@ pipeline:
     secrets:
       - google_key
     source: bundle
-    target: vic-product-failed-builds
+    target: vic-product-failed-builds/
     acl:
       - 'allUsers:READER'
     cache_control: 'public,max-age=3600'


### PR DESCRIPTION
Because builds from all branches are written to the same directory,
it is difficulty to pick up the right build to test against different
release branches.

Publish artifacts from release branches into sub-directories of a
releases directory, so scenario test of a release branch can select
the last build artifact under the subdirectory for testing.

Add release branch, build number and artifact url as parameter so
scenario test script can pick up build artifact according to their
combination.


Cherry picks: 1c8c783df7ed912fa035f2134956e8a9d173c1dc
From PR: #1908

