### PR TITLE
Consume the vic_dev tag of Admiral by default

### DIFF
--- a/installer/build/build-ova.sh
+++ b/installer/build/build-ova.sh
@@ -72,7 +72,7 @@ do
 done
 
 # set Admiral
-setenv ADMIRAL "dev"
+setenv ADMIRAL "vic_dev"
 
 # set vic-machine-server
 setenv VIC_MACHINE_SERVER "dev"


### PR DESCRIPTION
When building via Drone in response to `push` and `pull_request` events on the `master` branch, consume the `vic_dev` tag of Admiral instead of `dev`.

The Admiral team has indicated that this is the image `vic-product` is expected to use for builds from the `master` branch.

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
   * Unclear how to test.
- [ ] Considered impact to upgrade
   * Would only affect upgrade between recent builds from `master`.
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)