### PR TITLE
Update upgrade scripts for 1.4.3

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -55,6 +55,7 @@ VER_1_3_0="v1.3.0"
 VER_1_3_1="v1.3.1"
 VER_1_4_0="v1.4.0"
 VER_1_4_1="v1.4.1"
+VER_1_4_2="v1.4.2"
 
 function usage {
     echo -e "Usage: $0 [args...]
@@ -78,7 +79,7 @@ function usage {
       [--appliance-username value]:    Username of the old appliance.
       [--appliance-password value]:    Password of the old appliance.
       [--appliance-target value]:      IP Address of the old appliance.
-      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, or v1.4.1.
+      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, v1.4.1, or v1.4.2.
 
       [--destroy]:                     Destroy the old appliance after upgrade is finished.
       [--manual-disks]:                Skip the automated govc disk migration.
@@ -171,12 +172,13 @@ function enableServicesStart {
 #   v1.3.1 /storage/data/version has "appliance=v1.3.1-3409-132fb13d"
 #   v1.4.0 /storage/data/version
 #   v1.4.1 /storage/data/version
+#   v1.4.2 /storage/data/version
 ###
 function proceedWithUpgrade {
   checkUpgradeStatus "VIC Appliance" ${appliance_upgrade_status}
   local ver="$1"
 
-  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ]; then
+  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ] || [ "$ver" == "$VER_1_4_2" ]; then
     log ""
     log "Detected old appliance's version as $ver."
 

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -108,7 +108,7 @@ function getApplianceVersion() {
   local VER_1_1_1="v1.1.1"
   local VER_1_2_0="v1.2.0"
   local VER_1_2_1="v1.2.1"
-  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1")
+  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1" "v1.4.2")
   local COPIED_DIR="$1"
   local ver=""
   local tag=""


### PR DESCRIPTION
Updates upgrade scripts to list 1.4.2 as a supported upgrade path.

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
   * N/A
- [x] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
   * N/A
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)