### PR TITLE
Add diff to image for goimports error reporting

### DIFF
--- a/installer/build/container/Dockerfile
+++ b/installer/build/container/Dockerfile
@@ -4,7 +4,7 @@ ENV GOVERSION=1.9.2
 ENV PATH=$PATH:/root/gsutil:/usr/local/go/bin:/usr/local/google-cloud-sdk/bin/
 
 RUN set -eux; \
-    tdnf install -y make tar gzip python2 python-pip sed git \
+    tdnf install -y make tar gzip python2 python-pip sed git diff \
     gawk docker gptfdisk e2fsprogs grub2 parted xz docker; \
     curl -L'#' -k https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-200.0.0-linux-x86_64.tar.gz  | tar xzf - -C /usr/local; \
     mkdir -p /root/.gsutil/; \


### PR DESCRIPTION
Include diff in the vic-product-build image as it is required for use
by goimports to report errors. Without it, the build fails with a
confusing message if an import ordering issue exists:

    checking gofmt...
    computing diff: exec: "diff": executable file not found in $PATH
    Makefile:69: recipe for target 'gofmt' failed

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
   * N/A
- [ ] Considered impact to upgrade
   * N/A
- [ ] Tests passing
   * N/A
- [ ] Updated documentation
   * N/A
- [ ] Impact assessment checklist
   * N/A

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)