### PR TITLE
Fix curl option to get http code

### DIFF
--- a/tests/resources/OVA-Util.robot
+++ b/tests/resources/OVA-Util.robot
@@ -160,7 +160,7 @@ Initialize OVA From API
 
     Log To Console  \nInitializing VIC appliance by API when API is available
     :FOR  ${i}  IN RANGE  30
-    \   ${rc}  ${out}=  Run And Return Rc And Output  curl -k -w "\%{http_code}\\n" --header "Content-Type: application/json" -X POST --data '{"target":"%{TEST_URL}:443","user":"%{TEST_USERNAME}","password":"%{TEST_PASSWORD}","externalpsc":"%{EXTERNAL_PSC}","pscdomain":"%{PSC_DOMAIN}"}' https://${ova-ip}:9443/register
+    \   ${rc}  ${out}=  Run And Return Rc And Output  curl -k -s -o /dev/null -w "\%{http_code}\\n" --header "Content-Type: application/json" -X POST --data '{"target":"%{TEST_URL}:443","user":"%{TEST_USERNAME}","password":"%{TEST_PASSWORD}","externalpsc":"%{EXTERNAL_PSC}","pscdomain":"%{PSC_DOMAIN}"}' https://${ova-ip}:9443/register
     \   Exit For Loop If  '200' in '''${out}'''
     \   Sleep  60s
     Log To Console  ${rc}
@@ -199,7 +199,7 @@ Wait For SSO Redirect
     [Arguments]  ${ova-ip}
     Log To Console  \nWaiting for SSO redirect to come up...
     :FOR  ${i}  IN RANGE  20
-    \   ${rc}  ${out}=  Run And Return Rc And Output  curl -k -w "\%{http_code}\\n" https://${ova-ip}:8282
+    \   ${rc}  ${out}=  Run And Return Rc And Output  curl -k -s -o /dev/null -w "\%{http_code}\\n" https://${ova-ip}:8282
     \   Exit For Loop If  '302' in '''${out}'''
     \   Sleep  3s
     Log To Console  ${rc}


### PR DESCRIPTION
The output text of curl includes numbers and sometimes http code
like number 200 or 302 is in it.

Use silent mode to get just http code from curl.

Fixes #1936