### PR TITLE
Cherry-pick: Prevent fileserver from being loaded in an iframe (#1907)

### DIFF
--- a/installer/lib/tls.go
+++ b/installer/lib/tls.go
@@ -19,12 +19,12 @@ import (
 	"net/http"
 )
 
-func GetTLSServer(addr string, mux *http.ServeMux, cert tls.Certificate) *http.Server {
+func GetTLSServer(addr string, handler http.Handler, cert tls.Certificate) *http.Server {
 	// forcing tls 1.1, cipher from https://github.com/denji/golang-tls#perfect-ssl-labs-score-with-go
 	// and https://wiki.mozilla.org/Security/TLS_Configurations#Go
 	return &http.Server{
 		Addr:    addr,
-		Handler: mux,
+		Handler: handler,
 		TLSConfig: &tls.Config{
 			MinVersion:               tls.VersionTLS11,
 			CurvePreferences:         []tls.CurveID{tls.CurveP521, tls.CurveP384, tls.CurveP256},


### PR DESCRIPTION
In order to protect the Getting Started page from being embedded in a
page controlled by an attacker, set the Content-Security-Policy header
to disallow rendering of the page within an iframe.

(cherry picked from commit a9f8389878bd164003ca33ded18ce3a53e2a86df)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: a9f8389878bd164003ca33ded18ce3a53e2a86df
From PR: #1907
