### PR TITLE
Cherry-pick: Fix reminder logic for staging builds (#1893)

### DIFF
--- a/installer/build/build-ova.sh
+++ b/installer/build/build-ova.sh
@@ -128,7 +128,7 @@ drone deploy --param VICENGINE=${BUILD_VICENGINE_URL:-} \\
              --param HARBOR=${BUILD_HARBOR_URL:-} \\
              vmware/vic-product ${DRONE_BUILD_NUMBER:-} staging
 EOF
-elif [ "deploy" == "${DRONE_BUILD_EVENT}" -a "staging" == "${DRONE_DEPLOY_TO}" ]; then
+elif [ "deployment" == "${DRONE_BUILD_EVENT}" -a "staging" == "${DRONE_DEPLOY_TO}" ]; then
     echo "--------------------------------------------------"
     echo "Command to release this tag staged build:"
     cat <<EOF


### PR DESCRIPTION
Update the conditional to use the correct value for DRONE_BUILD_EVENT.

The command is `drone deploy`, but the build event is "deployment".

This value is not documented in Drone's environment reference:
  http://readme.drone.io/usage/environment-reference/

(cherry picked from commit 9b6ab3f5bb97c85aeb6fd524141f20731803532f)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: 9b6ab3f5bb97c85aeb6fd524141f20731803532f
From PR: #1893
