### PR TITLE
Cherry-pick: Integrate pre-tag components in release builds (#1961) 

### DIFF
--- a/installer/docs/BUILD.md
+++ b/installer/docs/BUILD.md
@@ -144,9 +144,58 @@ VIC Product build is auto-triggered from the successful completion of the follow
 There is also a separate build for [VIC UI](https://ci.vcna.io/vmware/vic-ui) which publishes the [artifact](https://console.cloud.google.com/storage/browser/vic-ui-builds) consumed by VIC Engine builds. VIC Engine publishes vic engine artifacts and vic machine server image.
 Harbor build publishes harbor installer and Admiral build publishes admiral image. All these artifacts are published to Google cloud except Admiral image which is published to Docker hub.
 
-For every auto-triggered build, by default, VIC Product consumes the latest artifacts from [vic engine](https://storage.googleapis.com/vic-engine-builds) and [harbor](https://storage.googleapis.com/harbor-builds) buckets, recent `dev` tagged images for [admiral](https://hub.docker.com/r/vmware/admiral/) and [vic machine server](https://console.cloud.google.com/gcr/images/eminent-nation-87317/GLOBAL/vic-machine-server?project=eminent-nation-87317&gcrImageListsize=50) and publishes [OVA artifact](https://storage.googleapis.com/vic-product-ova-builds) after successful build and test.
+### Dependency Relationship
 
-Refer to the next section `Staging and Release` on how to build OVA with specific dependent component versions.
+The version of each dependency VIC Product consumes varies based on the type of build being performed.
+
+| Admiral                 | `master`                                                | `releases/*`                                            |
+| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
+|`pull_request`           | [image][a] tagged with `vic_dev`                        | latest [image][a] that has a tag beginning with `vic_v` |
+|`push`                   | [image][a] tagged with `vic_dev`                        | latest [image][a] that has a tag beginning with `vic_v` |
+|`tag` (containing `dev`) | [image][a] tagged with `vic_dev`                        | latest [image][a] that has a tag beginning with `vic_v` |
+|`tag` (other)            | latest [image][a] that has a tag beginning with `vic_v` | latest [image][a] that has a tag beginning with `vic_v` |
+|`deployment`             | manually specified                                      | manually specified                                      |
+
+| Harbor                  | `master`                                                | `releases/*`                                            |
+| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
+|`pull_request`           | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]       |
+|`push`                   | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]       |
+|`tag` (containing `dev`) | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]       |
+|`tag` (other)            | latest build published to [`harbor-releases`][hr]       | latest build published to [`harbor-releases`][hr]       |
+|`deployment`             | manually specified                                      | manually specified                                      |
+
+| Engine                  | `master`                                                | `releases/*`                                            |
+| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
+|`pull_request`           | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-releases`][vr]   |
+|`push`                   | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-releases`][vr]   |
+|`tag` (containing `dev`) | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-releases`][vr]   |
+|`tag` (other)            | latest build published to [`vic-engine-releases`][vr]   | latest build published to [`vic-engine-releases`][vr]   |
+|`deployment`             | manually specified                                      | manually specified                                      |
+
+| `vic-machine-server`    | `master`                                                | `releases/*`                                            |
+| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
+|`pull_request`           | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with a version number        |
+|`push`                   | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with a version number        |
+|`tag` (containing `dev`) | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with a version number        |
+|`tag` (other)            | latest [image][vms] tagged with a version number        | latest [image][vms] tagged with a version number        |
+|`deployment`             | manually specified                                      | manually specified                                      |
+
+[a]:https://hub.docker.com/r/vmware/admiral/
+[hb]:https://storage.googleapis.com/harbor-builds
+[hr]:https://storage.googleapis.com/harbor-releases
+[vb]:https://storage.googleapis.com/vic-engine-builds
+[vr]:https://storage.googleapis.com/vic-engine-releases
+[vms]:https://console.cloud.google.com/gcr/images/eminent-nation-87317/GLOBAL/vic-machine-server?project=eminent-nation-87317&gcrImageListsize=50
+
+The OVA artifact is published to:
+ * [`vic-product-ova-builds`](https://storage.googleapis.com/vic-product-ova-builds) after successful build and test following `push` to `master`
+ * [`vic-product-ova-builds/releases/*`](https://storage.googleapis.com/vic-product-ova-builds) after successful build and test following `push` to `releases/*`
+ * [`vic-product-ova-builds`](https://storage.googleapis.com/vic-product-ova-builds) after successful build and test following creation of a `tag`
+ * [`vic-product-ova-builds`](https://storage.googleapis.com/vic-product-ova-builds) after successful build and test following `deployment` to `staging`
+ * [`vic-product-ova-releases`](https://storage.googleapis.com/vic-product-ova-releases) after successful build and test following `deployment` to `release`
+ * [`vic-product-failed-builds`](https://storage.googleapis.com/vic-product-failed-builds) after a failure building or testing
+
+Refer to the next section `Staging and Release` on how to build OVA with specific dependent component versions ("manually specified").
 
 ## Staging and Release
 

--- a/installer/docs/BUILD.md
+++ b/installer/docs/BUILD.md
@@ -148,37 +148,37 @@ Harbor build publishes harbor installer and Admiral build publishes admiral imag
 
 The version of each dependency VIC Product consumes varies based on the type of build being performed.
 
-| Admiral                 | `master`                                                | `releases/*`                                            |
-| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
-|`pull_request`           | [image][a] tagged with `vic_dev`                        | latest [image][a] that has a tag beginning with `vic_v` |
-|`push`                   | [image][a] tagged with `vic_dev`                        | latest [image][a] that has a tag beginning with `vic_v` |
-|`tag` (containing `dev`) | [image][a] tagged with `vic_dev`                        | latest [image][a] that has a tag beginning with `vic_v` |
-|`tag` (other)            | latest [image][a] that has a tag beginning with `vic_v` | latest [image][a] that has a tag beginning with `vic_v` |
-|`deployment`             | manually specified                                      | manually specified                                      |
+| Admiral                 | `master`                                                | `releases/*`                                                   |
+| -----------------------:| ------------------------------------------------------- | -------------------------------------------------------------- |
+|`pull_request`           | [image][a] tagged with `vic_dev`                        | [image][a] tagged with `vic_dev`                               |
+|`push`                   | [image][a] tagged with `vic_dev`                        | [image][a] tagged with `vic_dev`                               |
+|`tag` (containing `dev`) | [image][a] tagged with `vic_dev`                        | [image][a] tagged with `vic_dev`                               |
+|`tag` (other)            | latest [image][a] that has a tag beginning with `vic_v` | latest [image][a] that has a tag beginning with `vic_v`        |
+|`deployment`             | manually specified                                      | manually specified                                             |
 
-| Harbor                  | `master`                                                | `releases/*`                                            |
-| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
-|`pull_request`           | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]       |
-|`push`                   | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]       |
-|`tag` (containing `dev`) | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]       |
-|`tag` (other)            | latest build published to [`harbor-releases`][hr]       | latest build published to [`harbor-releases`][hr]       |
-|`deployment`             | manually specified                                      | manually specified                                      |
+| Harbor                  | `master`                                                | `releases/*`                                                   |
+| -----------------------:| ------------------------------------------------------- | -------------------------------------------------------------- |
+|`pull_request`           | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]              |
+|`push`                   | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]              |
+|`tag` (containing `dev`) | the build from [`harbor-builds/master.stable`][hb]      | latest build published to [`harbor-releases`][hr]              |
+|`tag` (other)            | latest build published to [`harbor-releases`][hr]       | latest build published to [`harbor-releases`][hr]              |
+|`deployment`             | manually specified                                      | manually specified                                             |
 
-| Engine                  | `master`                                                | `releases/*`                                            |
-| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
-|`pull_request`           | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-releases`][vr]   |
-|`push`                   | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-releases`][vr]   |
-|`tag` (containing `dev`) | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-releases`][vr]   |
-|`tag` (other)            | latest build published to [`vic-engine-releases`][vr]   | latest build published to [`vic-engine-releases`][vr]   |
-|`deployment`             | manually specified                                      | manually specified                                      |
+| Engine                  | `master`                                                | `releases/*`                                                   |
+| -----------------------:| ------------------------------------------------------- | -------------------------------------------------------------- |
+|`pull_request`           | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-builds/releases/*`][vb] |
+|`push`                   | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-builds/releases/*`][vb] |
+|`tag` (containing `dev`) | latest build published to [`vic-engine-builds`][vb]     | latest build published to [`vic-engine-builds/releases/*`][vb] |
+|`tag` (other)            | latest build published to [`vic-engine-releases`][vr]   | latest build published to [`vic-engine-releases`][vr]          |
+|`deployment`             | manually specified                                      | manually specified                                             |
 
-| `vic-machine-server`    | `master`                                                | `releases/*`                                            |
-| -----------------------:| ------------------------------------------------------- | ------------------------------------------------------- |
-|`pull_request`           | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with a version number        |
-|`push`                   | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with a version number        |
-|`tag` (containing `dev`) | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with a version number        |
-|`tag` (other)            | latest [image][vms] tagged with a version number        | latest [image][vms] tagged with a version number        |
-|`deployment`             | manually specified                                      | manually specified                                      |
+| `vic-machine-server`    | `master`                                                | `releases/*`                                                   |
+| -----------------------:| ------------------------------------------------------- | -------------------------------------------------------------- |
+|`pull_request`           | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with the release's version number   |
+|`push`                   | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with the release's version number   |
+|`tag` (containing `dev`) | [image][vms] tagged with `dev`                          | latest [image][vms] tagged with the release's version number   |
+|`tag` (other)            | latest [image][vms] tagged with a version number        | latest [image][vms] tagged with a version number               |
+|`deployment`             | manually specified                                      | manually specified                                             |
 
 [a]:https://hub.docker.com/r/vmware/admiral/
 [hb]:https://storage.googleapis.com/harbor-builds

--- a/installer/scripts/ci-build.sh
+++ b/installer/scripts/ci-build.sh
@@ -39,16 +39,23 @@ fi
 # set release options if drone args not present
 if [[ ( "$DRONE_BUILD_EVENT" == "tag" && "$DRONE_TAG" != *"dev"* ) || "$DRONE_BRANCH" == *"releases/"* ]]; then
   if [ -z "${ADMIRAL}" ]; then
-    admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1 | cut -d'_' -f2)
-    OPTIONS="--admiral $admiral_release"
+    if [[ "$DRONE_BUILD_EVENT" == "tag" && "$DRONE_TAG" != *"dev"* ]]; then
+      admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1 | cut -d'_' -f2)
+      OPTIONS="--admiral $admiral_release"
+    fi
   fi
   if [ -z "${HARBOR}" ]; then
     harbor_release=$(gsutil ls -l "gs://harbor-releases" | grep -v TOTAL | grep offline-installer | sort -k2 -r | (trap '' PIPE; head -n1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
     OPTIONS="$OPTIONS --harbor $harbor_release"
   fi
   if [ -z "${VICENGINE}" ]; then
-    vicengine_release=$(gsutil ls -l "gs://vic-engine-releases" | grep -v TOTAL | grep vic_ | sort -k2 -r | (trap '' PIPE; head -1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
-    OPTIONS="$OPTIONS --vicengine $vicengine_release"
+    if [[ "$DRONE_BUILD_EVENT" != "tag" || "$DRONE_TAG" == *"dev"* ]]; then
+      bucket="gs://vic-engine-builds/$DRONE_BRANCH"
+    else
+      bucket="gs://vic-engine-releases"
+    fi
+    vicengine_release=$(gsutil ls -l "$bucket" | grep -v TOTAL | grep vic_ | sort -k2 -r | (trap '' PIPE; head -1) | xargs | cut -d ' ' -f 3 | sed 's/gs:\/\//https:\/\/storage.googleapis.com\//')
+    OPTIONS="$OPTIONS --vicengine ${vicengine_release:?Unable to find an appropriate VIC Engine build. Is '"'$DRONE_BRANCH'"' a valid vmware/vic branch?}"
   fi
   if [ -z "${VIC_MACHINE_SERVER}" ]; then
     # Listing container tags requires permissions
@@ -64,8 +71,14 @@ if [[ ( "$DRONE_BUILD_EVENT" == "tag" && "$DRONE_TAG" != *"dev"* ) || "$DRONE_BR
       rm -f ${KEY_FILE}
     fi
 
-    vicmachineserver_release="$(gcloud container images list-tags gcr.io/eminent-nation-87317/vic-machine-server --filter='tags~.' | grep -v DIGEST | awk '{print $2}' | sed -rn 's/^(.*,)?(v([0-9]+\.){2}[0-9]+(-rc[0-9]+)?)(,.*)?$/\2/p' | head -n 1)"
-    OPTIONS="$OPTIONS --vicmachineserver $vicmachineserver_release"
+    if [[ "$DRONE_BUILD_EVENT" != "tag" || "$DRONE_TAG" == *"dev"* ]]; then
+      version="v${DRONE_BRANCH#releases/}-.*"
+    else
+      version="v([0-9]+\.){2}[0-9]+(-rc[0-9]+)?"
+    fi
+
+    vicmachineserver_release="$(gcloud container images list-tags gcr.io/eminent-nation-87317/vic-machine-server --filter='tags~.' | grep -v DIGEST | awk '{print $2}' | sed -rn 's/^(.*,)?('"${version}"')(,.*)?$/\2/p' | head -n 1)"
+    OPTIONS="$OPTIONS --vicmachineserver ${vicmachineserver_release:?Unable to find an appropriate vic-machine-server image. Is '"'$DRONE_BRANCH'"' a valid vmware/vic branch?}"
   fi
 fi
 

--- a/tests/resources/page-objects/New-Container-Host-Modal-Util.robot
+++ b/tests/resources/page-objects/New-Container-Host-Modal-Util.robot
@@ -17,13 +17,13 @@ Documentation  This resource contains any keywords dealing with New Container Ho
 
 *** Variables ***
 # css locators
-${nch-title}  css=.modal-title
+${nch-title}  //div[contains(text(),'New Container Host')]
 ${nch-name}  id=name
 ${nch-url}  id=url
 ${nch-select-creds}  css=.dropdown-select button
 ${nch-dropdown-creds}  css=.dropdown-options li a
 ${nch-default-cert-option}  css=a[data-name=default-ca-cert]
-${nch-button-save}  css=.modal-footer .btn-primary
+${nch-button-save}  css=button.saveCluster-btn
 
 # expected text values
 ${nch-title-text}  New Container Host
@@ -31,7 +31,6 @@ ${nch-title-text}  New Container Host
 *** Keywords ***
 Verify New Container Host Modal
     Wait Until Element Is Visible  ${nch-title}  timeout=${EXPLICIT_WAIT}
-    Element Text Should Be  ${nch-title}  ${nch-title-text}
 
 Add New Container Host
     [Arguments]  ${name}  ${url}  ${creds}=${nch-default-cert-option}

--- a/tests/resources/page-objects/Verify-Certificate-Modal-Util.robot
+++ b/tests/resources/page-objects/Verify-Certificate-Modal-Util.robot
@@ -17,8 +17,8 @@ Documentation  This resource contains any keywords dealing with Verify Certifica
 
 *** Variables ***
 # css locators
-${vc-title}  css=.modal .modal .modal-title
-${vc-button-yes}  css=.modal .modal .btn-primary
+${vc-title}  css=.modal .modal-title
+${vc-button-yes}  css=.modal .btn-primary
 
 # expected text values
 ${vc-title-text}  Verify Certficate


### PR DESCRIPTION
Consuming only tagged components in non-dev tag builds ensures that
our release candidates and releases include only the expected, stable,
version of each component.

Consuming those same tagged components in push and pull_request builds
is beneficial because it maintains consistency between builds leading
up to a tag build and the tag build itself.

However, this has a significant disadvantage: it means that components
being developed on release branches concurrently are not continuously
integrated; the first time integration occurs is when RC1 is tagged.

To allow testing of OVA builds sooner, we can consume new versions of
components more aggressively for pull_request builds, push builds, and
dev tag builds.

For Admiral, we will consume the same vic_dev tag consumed on master.

For the VIC engine .tar.gz and vic-machine-server container image, we
consume the latest build from the corresponding release branch. Note
that we assume that the version number of the OVA is the same as the
version number of VIC. To produce a release where this assumption is
not not valid (e.g., a patch release of VIC product where the version
of VIC itself is not changed), the script could be modified directly
on the release branch to hard-code the appropriate VIC version.

(cherry picked from commit 9af80bf)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

Cherry picks: 9af80bf
From PR: #1961