### PR TITLE
Updates for #1937 VM-Host Affinity option

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/vch_affinity_group.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_affinity_group.md
@@ -33,7 +33,7 @@ For more information about DRS affinity rules, see [Using DRS Affinity Rules](ht
                           
 ## vic-machine Option <a id="option"></a>
 
-This option is only available with the `vic-machine create` command. It is not available in the Create Virtual Container Host wizard in the vSphere Client.
+This option is available with the `vic-machine create` command and in the Advanced options of the Create Virtual Container Host wizard in the vSphere Client.
 
 `--affinity-vm-group`, no short name
 

--- a/docs/user_doc/vic_vsphere_admin/vch_compute.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_compute.md
@@ -13,6 +13,7 @@ When you deploy a virtual container host (VCH), you must select the compute reso
   - [Memory Shares](#memoryshares)
   - [Endpoint VM CPUs](#endpointcpu)
   - [Endpoint VM Memory](#endpointmemory)
+  - [VM-Host Affinity](#hostaffinity)
 - [What to Do Next](#whatnext)
 - [Example `vic-machine` Commands](#examples)
   - [Deploy to a vCenter Server Cluster with Multiple Datacenters and Datastores](#cluster)
@@ -229,6 +230,23 @@ The amount of memory for the VCH endpoint VM. Set this option to increase the am
 Specify a value in MB. If not specified, `vic-machine create` sets memory to 2048 MB.
 
 <pre>--endpoint-memory <i>amount_of_memory</i></pre>
+
+### VM-Host Affinity  <a id="hostaffinity"></a>
+Create a DRS VM group in vSphere for the VCH endpoint VM and its container VMs. Check this option to create a DRS group with the same name as the VCH. You can use the resulting VM group in DRS VM-Host affinity rules to restrict the set of hosts on which the VCH endpoint VM and its container VMs can run. 
+This option is available if you use 1.4.3 and later versions.
+
+#### Create VCH Wizard
+1. Expand **Advanced**.
+2. In  **VM-Host Affinity**, check the **Create a DRS VM Group for this VCH** checkbox to create a DRS group with the same name as the VCH. 
+
+#### vic-machine Option
+`--affinity-vm-group`, no short name
+
+The `--affinity-vm-group` option takes no arguments. You can only use this option when deploying a VCH to a cluster with DRS enabled.
+
+<pre>--affinity-vm-group</pre>
+
+For more information, see [Add Virtual Container Hosts to a DRS Affinity Group](vch_compute.md).
 
 ## What to Do Next <a id="whatnext"></a>
 


### PR DESCRIPTION
Added the VM-Host Affinity option to the Advanced Options of Create Virtual Container Host wizard. Previously, this was only possible via vic-machine. 

Modified: vch_affinity_group.md & vch_compute.md

Fixes #1937 

Hi @stuclem , can you please review the updates? 


