### PR TITLE
Clarified VIC Engine bundle version for plugins

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -25,7 +25,7 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
       - vSphere Integrated Containers 1.4.0: <pre>export VIC_BUNDLE=vic_v1.4.0.tar.gz</pre>
       - vSphere Integrated Containers 1.4.1 and 1.4.2: <pre>export VIC_BUNDLE=vic_v1.4.1.tar.gz</pre>
 
-    vSphere Integrated Containers 1.4.1 and 1.4.2 both use the `vic_v1.4.1.tar.gz` bundle.  You can check which version of the bundle your installation uses by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.
+    vSphere Integrated Containers 1.4.1 and 1.4.2 both use the `vic_v1.4.1.tar.gz` bundle. You can check which version of the bundle your installation uses by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.
 5. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.
 
     Copy and paste the following command as shown:<pre>curl -kL https://${VIC_ADDRESS}:9443/files/${VIC_BUNDLE} -o ${VIC_BUNDLE}</pre>If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.

--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -21,9 +21,11 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
 5. Set the following environment variables:
 
     - vSphere Integrated Containers appliance address:<pre>export VIC_ADDRESS=<i>vic_appliance_address</i></pre>
-    - vSphere Integrated Containers Engine bundle file:<pre>export VIC_BUNDLE=vic_v1.4.0.tar.gz</pre>
+    - vSphere Integrated Containers Engine bundle file:
+      - vSphere Integrated Containers 1.4.0: <pre>export VIC_BUNDLE=vic_v1.4.0.tar.gz</pre>
+      - vSphere Integrated Containers 1.4.1 and 1.4.2: <pre>export VIC_BUNDLE=vic_v1.4.1.tar.gz</pre>
 
-    If you have installed a different version of the appliance, update `1.4.0` to the appropriate version in the command above. You can see the correct version by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.
+    vSphere Integrated Containers 1.4.1 and 1.4.2 both use the `vic_v1.4.1.tar.gz` bundle.  You can check which version of the bundle your installation uses by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.
 5. Use `curl` to copy the vSphere Integrated Containers Engine binaries from the vSphere Integrated Containers appliance file server to the vCenter Server Appliance.
 
     Copy and paste the following command as shown:<pre>curl -kL https://${VIC_ADDRESS}:9443/files/${VIC_BUNDLE} -o ${VIC_BUNDLE}</pre>If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.

--- a/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/plugins_vcsa.md
@@ -36,9 +36,7 @@ The installer installs a basic plug-in for the Flex-based vSphere Web Client on 
 	2. Enter the IP address of the vCenter Server instance.
 	1. Enter the user name and password for the vCenter Server administrator account.
 	2. Enter **yes** if the vCenter Server certificate thumbprint is legitimate, and wait for the install process to finish. 
-10. When the installation finishes, stop and restart the services of your management clients.
-	1. Restart the HTML5 vSphere Client service.<pre>service-control --stop vsphere-ui && service-control --start vsphere-ui</pre>
-	2. Restart the Flex-based vSphere Web Client service.<pre>service-control --stop vsphere-client && service-control --start vsphere-client</pre>
+10. When the installation finishes, stop and restart the vSphere Client services.<pre>service-control --stop vsphere-ui && service-control --start vsphere-ui && service-control --stop vsphere-client && service-control --start vsphere-client</pre>
 11. Delete the vSphere Integrated Containers Engine binaries from the vCenter Server Appliance and close the SSH connection.
 	1. `cd ../../..`
 	2. `rm ${VIC_BUNDLE}`

--- a/docs/user_doc/vic_vsphere_admin/upgrade_h5_plugin_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/upgrade_h5_plugin_vcsa.md
@@ -40,8 +40,7 @@ If you have previous installations of the vSphere Client plug-ins for vSphere In
 
      **NOTE**: The Flex-based plug-in has no new features in this release. However, the upgrade script updates the metadata for the Flex-based client. Consequently, you must restart both of the HTML5 and Flex-based clients.    
 
-    - HTML5 vSphere Client: <pre>service-control --stop vsphere-ui && service-control --start vsphere-ui</pre>
-    - Flex-based vSphere Web Client:<pre>service-control --stop vsphere-client && service-control --start vsphere-client</pre>
+    <pre>service-control --stop vsphere-ui && service-control --start vsphere-ui && service-control --stop vsphere-client && service-control --start vsphere-client</pre>
 
 **What to Do Next**
 

--- a/docs/user_doc/vic_vsphere_admin/upgrade_h5_plugin_vcsa.md
+++ b/docs/user_doc/vic_vsphere_admin/upgrade_h5_plugin_vcsa.md
@@ -22,9 +22,11 @@ If you have previous installations of the vSphere Client plug-ins for vSphere In
 2. Set the following environment variables:
 
     - vSphere Integrated Containers appliance address:<pre>export VIC_ADDRESS=<i>vic_appliance_address</i></pre>
-    - vSphere Integrated Containers Engine bundle file:<pre>export VIC_BUNDLE=vic_v1.4.0.tar.gz</pre>
+    - vSphere Integrated Containers Engine bundle file:
+      - vSphere Integrated Containers 1.4.0: <pre>export VIC_BUNDLE=vic_v1.4.0.tar.gz</pre>
+      - vSphere Integrated Containers 1.4.1 and 1.4.2: <pre>export VIC_BUNDLE=vic_v1.4.1.tar.gz</pre>
 
-    If you are upgrading to a different version of the appliance, update `1.4.0` to the appropriate version in the command above. You can see the correct version by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.
+    vSphere Integrated Containers 1.4.1 and 1.4.2 both use the `vic_v1.4.1.tar.gz` bundle. You can check which version of the bundle your installation uses by going to https://<i>vic_appliance_address</i>:9443/files/ in a browser. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.
 4. Use `curl` to copy the new vSphere Integrated Containers Engine binaries from the file server in the upgraded vSphere Integrated Containers appliance to the vCenter Server Appliance.
 
     Copy and paste the following command as shown:<pre>curl -kL https://${VIC_ADDRESS}:9443/files/${VIC_BUNDLE} -o ${VIC_BUNDLE}</pre>If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.


### PR DESCRIPTION
Fixes https://github.com/vmware/vic-product/issues/1967. Clarifies which bundle to use for plug-in installation, and provides copy/pastable commands.
