### PR TITLE
Fix initramfs not installed to vmdk

### DIFF
--- a/installer/build/bootable/build-base.sh
+++ b/installer/build/bootable/build-base.sh
@@ -52,7 +52,6 @@ function set_base() {
     filesystem bash shadow coreutils findutils
 
   log3 "installing ${brprpl}systemd linux-esx tdnf ca-certificates sed gzip tar glibc${reset}"
-  tdnf install initramfs-1.0-9.113016321.ph1
   tdnf install --installroot "${rt}/" --refresh -y \
     systemd util-linux \
     pkgconfig dbus cpio\
@@ -61,7 +60,7 @@ function set_base() {
     gzip tar xz bzip2 \
     glibc iana-etc \
     ca-certificates \
-    curl which \
+    curl which initramfs-1.0-9.113016321.ph1 \
     krb5 motd procps-ng \
     bc kmod libdb
 


### PR DESCRIPTION
A mistake made before is installing initramfs to build machine.
It should be installed to the root file system of vmdk.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1969 
