### PR TITLE
Revert initramfs to latest version

### DIFF
--- a/installer/build/bootable/build-base.sh
+++ b/installer/build/bootable/build-base.sh
@@ -60,7 +60,7 @@ function set_base() {
     gzip tar xz bzip2 \
     glibc iana-etc \
     ca-certificates \
-    curl which initramfs-1.0-9.113016321.ph1 \
+    curl which initramfs \
     krb5 motd procps-ng \
     bc kmod libdb
 


### PR DESCRIPTION
Setting initramfs to an old version is a workaround
for missing dependency package in remote repository.
Revert this to install latest version since remote
repository fix this issue.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #
