### PR TITLE
[WIP]Build OS packages from local yum repo

### DIFF
--- a/installer/build/bootable/build-base.sh
+++ b/installer/build/bootable/build-base.sh
@@ -35,13 +35,11 @@ function set_base() {
   mkdir -p "${rt}/etc/yum.repos.d/"
   rm /etc/yum.repos.d/{photon,photon-updates}.repo
   cp "${DIR}"/repo/*-remote.repo /etc/yum.repos.d/
-  # TODO: Use local yum repo in CI
-  # if [[ $DRONE_BUILD_NUMBER && $DRONE_BUILD_NUMBER > 0 ]]; then
-  #   mkdir -p /etc/yum.repos.d.old/
-  #   mv /etc/yum.repos.d/* /etc/yum.repos.d.old/
-  #   cp repo/*-local.repo /etc/yum.repos.d/
-  # fi
   cp -a /etc/yum.repos.d/ "${rt}/etc/"
+  if [[ $DRONE_BUILD_NUMBER && $DRONE_BUILD_NUMBER > 0 ]]; then
+    rm -f /etc/yum.repos.d/*
+    cp "${DIR}"/repo/*-local.repo /etc/yum.repos.d/
+  fi
   cp /etc/resolv.conf "${rt}/etc/"
 
   log3 "verifying yum and tdnf setup"

--- a/installer/build/bootable/repo/photon-local.repo
+++ b/installer/build/bootable/repo/photon-local.repo
@@ -1,5 +1,5 @@
 [photon]
 name=VMware Photon Linux 1.0(x86_64)
-baseurl=http://192.168.31.16/photon
+baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon
 gpgcheck=0
 enabled=1

--- a/installer/build/bootable/repo/photon-updates-local.repo
+++ b/installer/build/bootable/repo/photon-updates-local.repo
@@ -1,5 +1,5 @@
 [photon-updates]
 name=VMware Photon Linux 1.0(x86_64)
-baseurl=http://192.168.31.16/photon-updates
+baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon-updates
 gpgcheck=0
 enabled=1


### PR DESCRIPTION
To keep consistent with vic buld and control installed
package version, use local yum repository instead of
the remote one.

The local yum repo is updated with below image and
includes CVE-2018-3620 fix with linux 4.4.152-1.ph1.

gcr.io/eminent-nation-87317/local-repo:1.7

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Related: #1933, vmware/vic#8211
