### PR TITLE
Cherry-pick: Improve and deduplicate slack notifications (#1983)

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -378,26 +378,13 @@ pipeline:
       branch: [master, 'releases/*', 'refs/tags/*']
       status: failure
 
-  notify-slack-on-fail:
-    image: plugins/slack
-    secrets:
-      - source: slack_url
-        target: slack_webhook
-    username: drone
-    template: "Build {{ build.link }} failed from the event {{ build.event }} by {{ lowercase build.author }}.\n"
-    when:
-      repo: vmware/vic-product
-      event: [push, tag, deployment]
-      branch: [master, 'releases/*', 'refs/tags/*']
-      status: [failure]
-
   notify-slack:
     image: plugins/slack
     secrets:
       - source: product_slack_url
         target: slack_webhook
     username: drone
-    template: "Build '{{ build.link }}' completed with a '{{ build.status }}' status from the event '{{ build.event }}' by '{{ lowercase build.author }}'\n"
+    template: '{{#equal build.event "push"}}Push to `{{build.branch}}`{{/equal}}{{#equal build.event "pull_request"}}Pull request #{{build.pull}}{{/equal}}{{#equal build.event "tag"}}Tag ({{build.tag}}){{/equal}}{{#equal build.event "deployment"}}{{#equal build.deployTo "staging"}}Staging{{/equal}}{{#equal build.deployTo "release"}}Release{{/equal}}{{/equal}} build <{{build.link}}|{{repo.owner}}/{{repo.name}}#{{build.number}}> {{#success build.status}}succeeded{{else}}{{#failure build.status}}failed{{else}}completed with status {{build.status}}{{/failure}}{{/success}}.{{#failure build.status}} Latest commit <https://github.com/{{repo.owner}}/{{repo.name}}/commit/{{build.commit}}|{{build.commit}}> by <https://github.com/{{lowercase build.author}}|{{lowercase build.author}}>.{{/failure}}'
     when:
       repo: vmware/vic-product
       event: [push, tag, deployment]
@@ -410,11 +397,11 @@ pipeline:
       - source: product_slack_url
         target: slack_webhook
     username: drone
-    template: "The latest version of VIC OVA has been released, find the build here: https://console.cloud.google.com/storage/browser/vic-product-ova-releases\n"
+    template: ':mega: Version {{build.tag}} of the VIC OVA has been {{#equal build.deployTo "staging"}}staged{{/equal}}{{#equal build.deployTo "release"}}released{{/equal}}. {{#equal build.deployTo "staging"}}Proof-read{{/equal}}{{#equal build.deployTo "release"}}Read{{/equal}} the <https://github.com/vmware/vic-product/releases/tag/{{build.tag}}|release notes> or <https://storage.googleapis.com/vic-product-ova-{{#equal build.deployTo "staging"}}builds/vic-stage{{/equal}}{{#equal build.deployTo "release"}}releases/vic{{/equal}}-{{build.tag}}-{{build.number}}-{{truncate build.commit 8}}.ova|download the build>.'
     when:
       repo: vmware/vic-product
       event: [deployment]
-      environment: [release]
+      environment: [staging, release]
       branch: ['releases/*', 'refs/tags/*']
       status: [success]
 


### PR DESCRIPTION
Leverage the drone-slack plugin's template functionality to provide
more useful notifications about completed builds. Reduce duplication
between pipeline steps for successful and failed builds.

(cherry picked from commit 21bd1034ecb3121c55a3085a6507dabadcab610b)

---

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Cherry picks: 21bd1034ecb3121c55a3085a6507dabadcab610b
From PR: #1983