### PR TITLE
Cherry-pick: Remove page link to install vSphere client plugin (#2003)

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -85,7 +85,6 @@
                                             <div class="card-text">
                                                 These tasks are usually performed by the vSphere admin.
                                                 <ol>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/install_vic_plugin.html">Install vSphere Client plug-ins on vCenter Server</a></li>
                                                 	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/deploy_vch.html">Deploy VCHs</a></li>
                                                 	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/vch_admin.html">Manage VCHs</a></li>
                                                 </ol>


### PR DESCRIPTION
VIC appliance UI plugin is registered automatically during
initialization, so there is no need to direct users to the
document link to install manually any more.

(cherry picked from commit d75808f3205dc5332e0f1555eb7d8143705841c6)

Fixes #1942 

Cherry picks: d75808f3205dc5332e0f1555eb7d8143705841c6
From PR: #2003 
