### PR TITLE
Cherry-Pick: Remove specifying nimbus location (#2022)

### DIFF
--- a/tests/resources/Nimbus-Util.robot
+++ b/tests/resources/Nimbus-Util.robot
@@ -502,7 +502,6 @@ Power Off Host
 Create Simple VC Cluster With Static IP
     [Arguments]  ${name}=vic-simple-vc-static-ip
     [Timeout]    110 minutes
-    Set Suite Variable  ${NIMBUS_LOCATION}  NIMBUS_LOCATION=wdc
     Run Keyword And Ignore Error  Nimbus Cleanup  ${list}  ${false}
     Log To Console  Create a new simple vc cluster with static ip support...
     ${out}=  Deploy Nimbus Testbed  %{NIMBUS_USER}  %{NIMBUS_PASSWORD}  spec=vic-simple-cluster-with-static.rb  args=--noSupportBundles --plugin testng --vcvaBuild ${VC_VERSION} --esxBuild ${ESX_VERSION} --testbedName vic-simple-cluster-with-static --runName ${name}


### PR DESCRIPTION
Remove nimbus location to get assigned location from nimbus.
This fix deliverables of esx build 5050593 not found in wdc.
This is crossport from vic #8256.

(cherry picked from commit c9b06a2537fed01c43bbc7bb5d42276e21c99e07)

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

