### PR TITLE
read me document will open another tab page

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -168,7 +168,7 @@
                                                         this certificate or cancel
                                                         if the thumbprint is not valid
                                                 </p>
-                                                <a href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/obtain_thumbprint.html" class="btn btn-link" >Read more...</a>
+                                                <a href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/obtain_thumbprint.html" target="_blank" class="btn btn-link" >Read more...</a>
                                             </div>
                                             <div class="modal-footer">
                                                 <button class="btn btn-outline" type="button" onclick="window.location.href='/?login=true'">Cancel</button>


### PR DESCRIPTION
Signed-off-by: Meina Zhou <meinaz@vmware.com>
In thumbprint page. click "Read more link" will redirect to a new page, which is not good for ux point of view. 
Fixes #

add target attribute to open url in new tab. 