### PR TITLE
Fix Group9-VIC-UI test failure

### DIFF
--- a/tests/manual-test-cases/Group9-VIC-UI/9-2-VIC-UI-Uninstaller.robot
+++ b/tests/manual-test-cases/Group9-VIC-UI/9-2-VIC-UI-Uninstaller.robot
@@ -21,7 +21,7 @@ Suite Teardown  Run Keyword And Ignore Error  Nimbus Cleanup  ${list}
 *** Keywords *** 
 Uninstall OVA Setup
     Run Keyword  VIC UI OVA Setup
-    ${status}=  Install UI Plugin  %{OVA_IP}
+    ${status}=  Install UI Plugin  %{OVA_IP}  ${html5}
     Should Be Equal As Integers  ${status}  ${ok}
 
 *** Test Cases ***
@@ -40,8 +40,8 @@ Attempt To Uninstall With Wrong Vcenter Credentials
 Uninstall Successfully
     ${status}=  Remove UI Plugin  %{OVA_IP}  ${html5}
     Should Be Equal As Integers  ${status}  ${ok}
-    ${status}=  Remove UI Plugin  %{OVA_IP}  ${flex}
-    Should Be Equal As Integers  ${status}  ${ok}
+    #${status}=  Remove UI Plugin  %{OVA_IP}  ${flex}
+    #Should Be Equal As Integers  ${status}  ${ok}
 
 Attempt To Uninstall Plugin That Is Already Gone
     ${status}=  Run Keyword And Ignore Error  Remove UI Plugin  %{OVA_IP}  ${html5}


### PR DESCRIPTION
Comment out flex plugin uninstall case because flex installation
on vCenter 6.7 is not supported currently.