### PR TITLE
Fix quoting of registration payload in upgrade.sh

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -97,8 +97,8 @@ function callPluginUpgradeEndpoint {
   local vc='{"target":"'"${VCENTER_TARGET}"'","user":"'"${VCENTER_USERNAME}"'","password":"'"${VCENTER_PASSWORD}"'","thumbprint":"'"${VCENTER_FINGERPRINT}"'"}'
   local vc_info='{"target":"'"${VCENTER_TARGET}"'","user":"'"${VCENTER_USERNAME}"'","thumbprint":"'"${VCENTER_FINGERPRINT}"'"}'
   local plugin='{"preset":"'"${preset}"'","force":true}'
-  local payload='{"vc":"${vc}","plugin":"${plugin}"}'
-  local payload_info='{"vc":"${vc_info}","plugin":"${plugin}"}'
+  local payload='{"vc":'"${vc}"',"plugin":'"${plugin}"'}'
+  local payload_info='{"vc":'"${vc_info}"',"plugin":'"${plugin}"'}'
   echo "register payload - ${payload_info}" >> $upgrade_log_file 2>&1
   /usr/bin/curl \
     -k \


### PR DESCRIPTION
Because both the `payload` and `payload_info` variables were quoted with
single quotes, expressions were not being expanded.

Correct the quoting to properly print the JSON object; wrap constant
portions of the JSON with single quotes and expressions with double.

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
   * I don't see a good way to do this, unfortunately.
- [x] Considered impact to upgrade
- [x] Tests passing
- [x] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes: #2050 (see https://github.com/vmware/vic-product/issues/2050#issuecomment-420404212 for results of testing)