### PR TITLE
Decrease validity period for generated certificates

### DIFF
--- a/installer/build/scripts/systemd/scripts/vic-appliance-tls.sh
+++ b/installer/build/scripts/systemd/scripts/vic-appliance-tls.sh
@@ -67,7 +67,7 @@ function genCert {
   if [ ! -e $ca_cert ] || [ ! -e $ca_key ]
   then
     openssl req -newkey rsa:4096 -nodes -sha256 -keyout $ca_key \
-      -x509 -days 1095 -out $ca_cert -subj \
+      -x509 -days 825 -out $ca_cert -subj \
       "/C=US/ST=California/L=Palo Alto/O=VMware, Inc./OU=Containers on vSphere/CN=Self-signed by VMware, Inc."
   fi
   openssl req -newkey rsa:4096 -nodes -sha256 -keyout $key \
@@ -82,7 +82,7 @@ function genCert {
   echo "Add subjectAltName $san to certificate"
   echo "$san" > $ext
 
-  openssl x509 -req -days 1095 -in $csr -CA $ca_cert -CAkey $ca_key -CAcreateserial -extfile $ext -out $cert
+  openssl x509 -req -days 825 -in $csr -CA $ca_cert -CAkey $ca_key -CAcreateserial -extfile $ext -out $cert
 
   echo "Creating certificate chain for $cert"
   cat $ca_cert >> $cert


### PR DESCRIPTION
Decrease the validity period for auto-generated SSL certificates from 1095 days (3 years) to 825 days (27 months). This has little impact on the product or its users, but avoids potentially confusing false
positives from vulnerability scanners like Qualys. (A maximum validity period of 825 days applies to DV and OV certificates issued by CAs.)

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
  * There does not seem to be a good way to test this.
- [x] Considered impact to upgrade
  * The negative impacts of regenerating certificates on users seem to outweigh any benefit to regenerating during upgrade.
- [ ] Tests passing
- [x] Updated documentation
   * n/a - Doesn't seem to be mentioned.
- [x] Impact assessment checklist