### PR TITLE
Disable password autocomplete during initialization

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -218,7 +218,7 @@
                                         <div class="form-group">
                                             <label for="user" class="required">vCenter Server credentials</label>
                                             <input id="user" type="text" name="user" placeholder="username@domain.local" onkeyup="checkRegistryForm()" value="">
-                                            <input id="password" type="password" name="password" placeholder="Password" onkeyup="checkRegistryForm()" value="">
+                                            <input id="password" type="password" name="password" placeholder="Password" autocomplete="off" onkeyup="checkRegistryForm()" value="">
                                         </div>
                                         <div class="form-group">
                                             <label for="psc">External PSC Instance</label>


### PR DESCRIPTION
While this setting is ignored by many modern browsers, its absence can still cause problems when obtaining PCI compliance.

---

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [x] Considered impact to upgrade
- [ ] Tests passing
- [x] Updated documentation
   * n/a - Doesn't seem to be mentioned.
- [x] Impact assessment checklist