### PR TITLE
Remove specifying selenium screenshots directory

### DIFF
--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -29,7 +29,7 @@ Resource  Docker-Util.robot
 Resource  Nimbus-Util.robot
 Resource  VM-Util.robot
 Resource  VIC-UI-Util.robot
-Library  Selenium2Library  timeout=30  implicit_wait=15  run_on_failure=Capture Page Screenshot  screenshot_root_directory=test-screenshots
+Library  Selenium2Library  timeout=30  implicit_wait=15  run_on_failure=Capture Page Screenshot
 # UI page object utils
 Resource  page-objects/Getting-Started-Page-Util.robot
 Resource  page-objects/Complete-Installation-Modal-Util.robot


### PR DESCRIPTION
By default root screenshots are saved to the same directory
as logs, which is easy to archive together with logs. So
remove specifying root screenshots directory.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #
