### PR TITLE
Add missing external psc information into register

### DIFF
--- a/installer/fileserver/routes/register.go
+++ b/installer/fileserver/routes/register.go
@@ -59,6 +59,8 @@ func RegisterHandler(resp http.ResponseWriter, req *http.Request) {
 		PSCConfig.Admin.User = r.User
 		PSCConfig.Admin.Password = r.Password
 		PSCConfig.Admin.Thumbprint = r.Thumbprint
+		PSCConfig.PscDomain = r.PSCDomain
+		PSCConfig.PscInstance = r.ExternalPSC
 		cancel, err := PSCConfig.Admin.VerifyLogin(op)
 		defer cancel()
 		if err != nil {


### PR DESCRIPTION
The register rest api does not read external psc information
from request, and always use vc information. There is no way
to use an external psc for registeration from api, such as
during upgrade without the fix.
