### PR TITLE
Removed note about FQDN

### DIFF
--- a/docs/user_doc/vic_app_dev/configure_docker_client.md
+++ b/docs/user_doc/vic_app_dev/configure_docker_client.md
@@ -75,8 +75,7 @@ This example configures a Linux Docker client so that you can log into vSphere I
 
 This example configures a Linux Docker client so that you can log into vSphere Integrated Containers Registry by using its IP address.
 
-**NOTE**: The current version of vSphere Integrated Containers uses the registry's IP address as the Subject Alternate Name when auto-generating certificates for vSphere Integrated Containers Registry. Consequently, when you run `docker login`, you must use the IP address of the registry rather than the FQDN. 
- 
+
 1. Copy the certificate file to the Linux machine on which you run the Docker client.
 2. Switch to `sudo` user.<pre>$ sudo su</pre>
 2. Create a subfolder in the Docker certificates folder, using the registry's IP address as the folder name.<pre>$ mkdir -p /etc/docker/certs.d/<i>registry_ip</i></pre>


### PR DESCRIPTION
Hi @stuclem , I removed the note on FQDN from https://vmware.github.io/vic-product/assets/files/html/1.1/vic_app_dev/configure_docker_client.html 
Should I remove the line _The Create Virtual Container Host wizard only accepts an IP address for the client network. You cannot specify an FQDN._ from https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/client_network.html?

Fixes #323 

