### PR TITLE
Update docker-compose.yml

### DIFF
--- a/tutorials/selenium/docker-compose.yml
+++ b/tutorials/selenium/docker-compose.yml
@@ -1,12 +1,12 @@
 version: '2.2'
 services:
   hub:
-    image: "selenium/hub"
+    image: "selenium/hub:3.13"
     ports:
       - "4444:4444"
   chrome:
     cpu_count: 1
-    image: "selenium/node-chrome"
+    image: "selenium/node-chrome:3.13"
     environment:
       - HUB_PORT_4444_TCP_ADDR=hub
       - HUB_PORT_4444_TCP_PORT=4444
@@ -19,7 +19,7 @@ services:
       - "5555"
   firefox:
     cpu_count: 1
-    image: "selenium/node-firefox"
+    image: "selenium/node-firefox:3.13"
     environment:
       - HOME=/home/seluser
       - HUB_PORT_4444_TCP_ADDR=hub


### PR DESCRIPTION
Lock the images to version 3.13

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
