### PR TITLE
Specify artifacts to build OVA

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -84,6 +84,10 @@ pipeline:
     privileged: true
     environment:
       TERM: xterm
+      VICENGINE: https://storage.googleapis.com/vic-engine-releases/vic_v1.4.3.tar.gz
+      HARBOR: https://storage.googleapis.com/harbor-releases/release-1.5.0/harbor-offline-installer-latest.tgz
+      ADMIRAL: v1.4.3
+      VIC_MACHINE_SERVER: v1.4.3
     secrets:
       - admiral
       - build_admiral_release

--- a/installer/build/scripts/provisioners/provision_fileserver.sh
+++ b/installer/build/scripts/provisioners/provision_fileserver.sh
@@ -36,7 +36,7 @@ FULL_VER_STRING=$(echo "${BUILD_OVA_REVISION}" | sed -e 's/\-rc[[:digit:]]//g')
 MAJOR_MINOR_PATCH=$(echo $FULL_VER_STRING | awk -F- '{print $1}' | cut -c 2-)
 BUILD_NUMBER=$(echo $FULL_VER_STRING | awk -F- '{print $2}')
 VIC_ENGINE_VER_STRING=${MAJOR_MINOR_PATCH}.${BUILD_NUMBER}
-VIC_UI_VER_STRING=$(ls -l ${VIC_BIN_ROOT}ui/plugin-packages | grep '^d' | head -1 | awk '{print $9}' | awk -F- '{print $2}')
+VIC_UI_VER_STRING=$(ls -l ${VIC_BIN_ROOT}ui/plugin-packages | grep '^d' | head -1 | awk '{print $9}' | awk -F- '{print substr($0, index($0,$2))}')
 
 # update plugin-package.xml for H5 Client plugin
 echo "Updating description for H5 Client plugin to \"vSphere Client Plugin for vSphere Integrated Containers Engine (v${VIC_ENGINE_VER_STRING})"\"


### PR DESCRIPTION
Follow below rules to build 1.4.4 OVA:
1. Pack 1.4.3 vic and vic machine.
2. Pack 1.5.0 harbor. - using 1.5.4 version
3. Pack 1.4.3 admiral.
4. Pack vic-ui from 1.4.4 release branch.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #
