### PR TITLE
Fix test failures caused by Admiral UI changes

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -111,7 +111,7 @@ pipeline:
       status: success
 
   integration-test-ova-setup:
-    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.37'
+    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.48'
     pull: true
     privileged: true
     environment:
@@ -137,7 +137,7 @@ pipeline:
       status: success
 
   integration-test:
-    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.37'
+    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.48'
     pull: true
     privileged: true
     environment:
@@ -165,7 +165,7 @@ pipeline:
       status: success
 
   integration-test-ova-cleanup:
-    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.37'
+    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.48'
     pull: true
     environment:
       BIN: bin

--- a/tests/resources/Util.robot
+++ b/tests/resources/Util.robot
@@ -103,6 +103,7 @@ Set Browser Variables
     # UI tests variables
     Set Global Variable  ${FIREFOX_BROWSER}  firefox
     Set Global Variable  ${GRID_URL}  http://selenium-grid-hub:4444/wd/hub
+    Set Global Variable  ${EXPLICIT_WAIT_FOR_VCSSO_PAGE}  600
     Set Global Variable  ${EXPLICIT_WAIT}  30
     Set Global Variable  ${EXTRA_EXPLICIT_WAIT}  60
     Set Global Variable  ${PRIMARY_PORT}  8282

--- a/tests/resources/page-objects/Container-Hosts-Page-Util.robot
+++ b/tests/resources/page-objects/Container-Hosts-Page-Util.robot
@@ -24,8 +24,7 @@ ${ch-title}  css=.content-area .title
 ${ch-button-new-host}  css=.toolbar button
 ${ch-card-name}  css=.card-item .titleHolder div:nth-of-type(1)
 ${ch-card-status}  css=.card-item .status
-${ch-button-card-dropdown}  css=.card button.dropdown-toggle
-${ch-link-delete}  css=card > div > div.card-header > div > clr-dropdown > clr-dropdown-menu > button.dropdown-item.remove-cluster
+${ch-button-delete}  xpath://button[contains(text(),'Remove')]
 
 # expected text values
 ${ch-card-status-on}  ON
@@ -70,16 +69,14 @@ Add New Container Host And Verify Card
     Add New Container Host  ${vch-name}  ${VCH-URL}
     Verify VCH Card  ${vch-name}
 
-Delete VCH Card Using Dropdown Menu
+Delete VCH Card
     [Arguments]  ${card-name}
     Navigate To Container Hosts Page
     ${card-index}=  Get VCH Card Index  ${card-name}
-    @{dropdown-buttons}=  Get Webelements  ${ch-button-card-dropdown}
-    ${dropdown}=  Get From List  ${dropdown-buttons}  ${card-index}
-    Focus  ${dropdown}
-    Click Button  ${dropdown}
-    Focus  ${ch-link-delete}
-    Click Button  ${ch-link-delete}
+    @{remove-bottons}=  Get Webelements  ${ch-button-delete}
+    ${remove-button}=  Get From List  ${remove-bottons}  ${card-index}
+    Focus  ${remove-button}
+    Click Button  ${remove-button}
     Verify Modal for Remove Container Host
     Click Remove On Remove Container Host
     Verify Container Hosts Page

--- a/tests/resources/page-objects/New-Container-Host-Modal-Util.robot
+++ b/tests/resources/page-objects/New-Container-Host-Modal-Util.robot
@@ -20,9 +20,9 @@ Documentation  This resource contains any keywords dealing with New Container Ho
 ${nch-title}  //div[contains(text(),'New Container Host')]
 ${nch-name}  id=name
 ${nch-url}  id=url
-${nch-select-creds}  css=.dropdown-select button
-${nch-dropdown-creds}  css=.dropdown-options li a
-${nch-default-cert-option}  css=a[data-name=default-ca-cert]
+${nch-select-creds}  xpath://select[@data-name="cluster-create-credentials"]
+${nch-default-cert-option}  default-ca-cert
+${nch-no-selection}  xpath://option[contains(text(),'No selection')]
 ${nch-button-save}  css=button.saveCluster-btn
 
 # expected text values
@@ -36,8 +36,9 @@ Add New Container Host
     [Arguments]  ${name}  ${url}  ${creds}=${nch-default-cert-option}
     Input Text  ${nch-name}  ${name}
     Input Text  ${nch-url}  ${url}
-    Click Button  ${nch-select-creds}
-    Click Link  ${creds}
+    Wait Until Element Is Visible  ${nch-no-selection}  timeout=${EXPLICIT_WAIT}
+    Click Element  ${nch-select-creds}
+    Select From List By Label  ${nch-select-creds}  ${creds}
     Click Button  ${nch-button-save}
     Verify Modal for Verify Certificate
     Click Yes On Verify Certificate

--- a/tests/resources/page-objects/VC-Single-Sign-On-Util.robot
+++ b/tests/resources/page-objects/VC-Single-Sign-On-Util.robot
@@ -33,7 +33,7 @@ Navigate To VC UI Home Page
 Login On Single Sign-On Page
     [Tags]  secret
     Log To Console  Login into single sign-on...
-    Wait Until Element Is Visible  ${vcsso-image-title}  timeout=${EXPLICIT_WAIT}
+    Wait Until Element Is Visible  ${vcsso-image-title}  timeout=${EXPLICIT_WAIT_FOR_VCSSO_PAGE}
     Input Text  ${vcsso-username}  %{TEST_USERNAME}
     Input Text  ${vcsso-password}  %{TEST_PASSWORD}
     Click Button  ${vcsso-button-login}

--- a/tests/test-cases/Group2-Getting-Started/2-01-Getting-Started.robot
+++ b/tests/test-cases/Group2-Getting-Started/2-01-Getting-Started.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 2-01 Getting Started
 Resource  ../../resources/Util.robot
-Test Timeout  5 minutes
+Test Timeout  20 minutes
 Test Setup  Open Firefox Browser
 Test Teardown  Close All Browsers
 

--- a/tests/test-cases/Group3-Admiral/3-01-Admiral-UI.robot
+++ b/tests/test-cases/Group3-Admiral/3-01-Admiral-UI.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 3-01 Admiral UI
 Resource  ../../resources/Util.robot
-Test Timeout  5 minutes
+Test Timeout  20 minutes
 Test Setup  Run Keyword  Setup Base State
 Test Teardown  Close All Browsers
 
@@ -48,5 +48,5 @@ Add VCH to default project and create a container
     Provision And Verify New Container  ${busybox-docker-image-name}  ${busybox-docker-image-tag}  ${sample-command-exit}  ${cp-card-status-stopped}
     Unselect Containers Page Iframe
 
-    Delete VCH Card Using Dropdown Menu  ${vch-name}
+    Delete VCH Card  ${vch-name}
     [Teardown]  Cleanup VCH And Teardown  ${vch-name}

--- a/tests/test-cases/Group4-Harbor/4-01-Harbor.robot
+++ b/tests/test-cases/Group4-Harbor/4-01-Harbor.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 4-01 Harbor
 Resource  ../../resources/Util.robot
-Test Timeout  5 minutes
+Test Timeout  20 minutes
 Test Setup  Run Keyword  Setup Base State
 Test Teardown  Close All Browsers
 

--- a/tests/test-cases/Group5-DCH/5-01-DCH.robot
+++ b/tests/test-cases/Group5-DCH/5-01-DCH.robot
@@ -15,7 +15,7 @@
 *** Settings ***
 Documentation  Test 5-01 DCH
 Resource  ../../resources/Util.robot
-Test Timeout  5 minutes
+Test Timeout  20 minutes
 Test Setup  Run Keyword  Setup Base State
 
 *** Variables ***


### PR DESCRIPTION
Rectify element locators according to below changes in UI:
1.Credentials dropdown list was changed to select.
2.Remove link was moved out of "Options" dropdown list.

Wait up to maximun 10 minutes for Admiral UI ready so we
don't need to retry failed tests.

Increase test timeout to 20 minutes since UI could not be
ready in 5 minutes.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #
