### PR TITLE
Move appliance OS to photon 2.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -86,7 +86,7 @@ pipeline:
 
   unified-ova-build:
     group: build
-    image: 'gcr.io/eminent-nation-87317/vic-product-build:33e3b968'
+    image: 'gcr.io/eminent-nation-87317/vic-product-build'
     pull: true
     privileged: true
     environment:

--- a/installer/build/bootable/build-app.sh
+++ b/installer/build/bootable/build-app.sh
@@ -34,6 +34,7 @@ chage -I -1 -m 0 -M 99999 -E -1 root
 
 log3 "configuring ${brprpl}UTC${reset} timezone"
 ln --force --symbolic /usr/share/zoneinfo/UTC /etc/localtime
+
 log3 "configuring ${brprpl}en_US.UTF-8${reset} locale"
 /usr/bin/touch /etc/locale.conf
 /bin/echo "LANG=en_US.UTF-8" > /etc/locale.conf
@@ -93,9 +94,10 @@ echo -ne '' > /root/.bash_profile
 echo 'shopt -s histappend' >> /root/.bash_profile
 echo 'export PROMPT_COMMAND="history -a; history -c; history -r; $PROMPT_COMMAND"' >> /root/.bash_profile
 
-# Clear SSH host keys
+# Regenerate SSH host keys, or else sshd can not start successfully
 log3 "resetting ssh host keys"
 rm -f /etc/ssh/{ssh_host_dsa_key,ssh_host_dsa_key.pub,ssh_host_ecdsa_key,ssh_host_ecdsa_key.pub,ssh_host_ed25519_key,ssh_host_ed25519_key.pub,ssh_host_rsa_key,ssh_host_rsa_key.pub}
+/usr/bin/ssh-keygen -A
 
 # Zero out the free space to save space in the final image
 log3 "zero out free space"

--- a/installer/build/bootable/build-base.sh
+++ b/installer/build/bootable/build-base.sh
@@ -32,27 +32,37 @@ function set_base() {
   rpm --root "${rt}/" --import "${rt}/etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY"
 
   log3 "configuring ${brprpl}yum repos${reset}"
-  mkdir -p "${rt}/etc/yum.repos.d/"
-  rm /etc/yum.repos.d/{photon,photon-updates}.repo
-  cp "${DIR}"/repo/*-remote.repo /etc/yum.repos.d/
-  # TODO: Use local yum repo in CI
-  # if [[ $DRONE_BUILD_NUMBER && $DRONE_BUILD_NUMBER > 0 ]]; then
-  #   mkdir -p /etc/yum.repos.d.old/
-  #   mv /etc/yum.repos.d/* /etc/yum.repos.d.old/
-  #   cp repo/*-local.repo /etc/yum.repos.d/
-  # fi
-  cp -a /etc/yum.repos.d/ "${rt}/etc/"
+  cp -a /etc/yum.repos.d "${rt}/etc/"
+
+  log3 "configuring tdnf.conf"
+  cp "${DIR}"/repo/tdnf.conf "${rt}/tdnf.conf"
+  sed -i "s|\$ROOTFS|${rt}|g" "${rt}/tdnf.conf"
+
+  if [[ ${DRONE_BUILD_NUMBER} && ${DRONE_BUILD_NUMBER} > 0 ]]; then
+    log3 "Use local tdnf repo to install packages for CI build ${DRONE_BUILD_NUMBER}"
+    mv "${rt}/etc/yum.repos.d" "${rt}/etc/yum.repos.d.bak"
+    mkdir -p "${rt}/etc/yum.repos.d"
+    cp "${DIR}"/repo/*-local.repo "${rt}/etc/yum.repos.d"
+  fi
   cp /etc/resolv.conf "${rt}/etc/"
 
+  TDNF_OPTS="-c ${rt}/tdnf.conf --installroot ${rt}/ --refresh"
+  # baseurl is something like https://dl.bintray.com/vmware/photon_release_$releasever_$basearch.
+  # releasever in tdnf.conf does not render to baseurl in /etc/yum.repos.d/*.repo, so it is required
+  # to specify releasever as 2.0 when it is built from remote repo.
+  if [[ -z ${DRONE_BUILD_NUMBER} || ${DRONE_BUILD_NUMBER} -eq 0 ]]; then
+    TDNF_OPTS="$TDNF_OPTS --releasever 2.0"
+  fi
+
   log3 "verifying yum and tdnf setup"
-  tdnf repolist --refresh
+  tdnf ${TDNF_OPTS} repolist
 
   log3 "installing ${brprpl}filesystem bash shadow coreutils findutils${reset}"
-  tdnf install --installroot "${rt}/" --refresh -y \
+  tdnf ${TDNF_OPTS} install -y \
     filesystem bash shadow coreutils findutils
 
-  log3 "installing ${brprpl}systemd linux-esx tdnf ca-certificates sed gzip tar glibc${reset}"
-  tdnf install --installroot "${rt}/" --refresh -y \
+  log3 "installing ${brprpl}systemd linux-esx tdnf ca-certificates sed gzip tar glibc rpm${reset}"
+  tdnf ${TDNF_OPTS} install -y \
     systemd util-linux \
     pkgconfig dbus cpio\
     photon-release tdnf \
@@ -62,29 +72,37 @@ function set_base() {
     ca-certificates \
     curl which initramfs \
     krb5 motd procps-ng \
-    bc kmod libdb
+    bc kmod libdb rpm
 
-  log3 "installing ${brprpl}tzdata glibc-lang vim${reset}"
-  tdnf install --installroot "${rt}/" --refresh -y \
-    tzdata glibc-lang vim
+  log3 "installing ${brprpl}tzdata glibc-lang vim glibc-i18n${reset}"
+  tdnf ${TDNF_OPTS} install -y \
+    tzdata glibc-lang vim glibc-i18n
 
   log3 "installing system dependencies"
-  tdnf install --installroot "${rt}/" --refresh -y \
+  tdnf ${TDNF_OPTS} install -y \
     haveged ethtool gawk \
     socat git nfs-utils \
     cifs-utils ebtables \
     iproute2 iptables iputils \
     cdrkit xfsprogs sudo \
     lvm2 parted gptfdisk \
-    e2fsprogs docker-17.12.1-1.ph1 gzip \
+    e2fsprogs docker-17.06.0-8.ph2 gzip \
     net-tools logrotate sshpass
 
   log3 "installing package dependencies"
-  tdnf install --installroot "${rt}/" --refresh -y \
-    openjre python-pip
+  tdnf ${TDNF_OPTS} install -y \
+    openjre8 python-pip
 
   log3 "installing ${brprpl}root${reset}"
   cp -a "${src}/root/." "${rt}/"
+
+  rm -f "${rt}/tdnf.conf"
+
+  if [[ ${DRONE_BUILD_NUMBER} && ${DRONE_BUILD_NUMBER} > 0 ]]; then
+    log3 "reset tdnf repos to remote"
+    rm -rf "${rt}/etc/yum.repos.d"
+    mv "${rt}/etc/yum.repos.d.bak" "${rt}/etc/yum.repos.d"
+  fi
 }
 
 function usage() {
@@ -114,9 +132,3 @@ fi
 log2 "install OS to ${ROOT}"
 
 set_base "${DIR}" "${ROOT}"
-
-# TODO: Use local yum repo in CI
-# log3 "reset yum repos to remote"
-# REPOS=$(find ${IMG1ROOT}/etc/yum.repos.d/ | grep -E "*-remote.repo|*-local.repo")
-# [ -n "$REPOS" ] && echo $REPOS | while read repo; do rm $repo; done
-# cp repo/*-remote.repo "${IMG1ROOT}/etc/yum.repos.d/"

--- a/installer/build/bootable/repo/photon-local.repo
+++ b/installer/build/bootable/repo/photon-local.repo
@@ -1,5 +1,6 @@
-[photon]
-name=VMware Photon Linux 1.0(x86_64)
-baseurl=http://192.168.31.16/photon
-gpgcheck=0
+[photon-2.0]
+name=VMware WDC Photon Linux 2.0(x86_64)
+baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon
+gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
+gpgcheck=1
 enabled=1

--- a/installer/build/bootable/repo/photon-remote.repo
+++ b/installer/build/bootable/repo/photon-remote.repo
@@ -1,6 +1,0 @@
-[photon]
-name=VMware Photon Linux 1.0(x86_64)
-baseurl=https://vmware.bintray.com/photon_release_1.0_x86_64/
-gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
-gpgcheck=0
-enabled=1

--- a/installer/build/bootable/repo/photon-updates-local.repo
+++ b/installer/build/bootable/repo/photon-updates-local.repo
@@ -1,5 +1,6 @@
-[photon-updates]
-name=VMware Photon Linux 1.0(x86_64)
-baseurl=http://192.168.31.16/photon-updates
-gpgcheck=0
+[photon-updates-2.0]
+name=VMware WDC Photon Linux 2.0(x86_64) Updates
+baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon-updates
+gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
+gpgcheck=1
 enabled=1

--- a/installer/build/bootable/repo/photon-updates-remote.repo
+++ b/installer/build/bootable/repo/photon-updates-remote.repo
@@ -1,6 +1,0 @@
-[photon-updates]
-name=VMware Photon Linux 1.0(x86_64)
-baseurl=https://dl.bintray.com/vmware/photon_updates_1.0_x86_64
-gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
-gpgcheck=0
-enabled=1

--- a/installer/build/bootable/repo/tdnf.conf
+++ b/installer/build/bootable/repo/tdnf.conf
@@ -1,0 +1,16 @@
+[main]
+repodir=$ROOTFS/etc/yum.repos.d
+cachedir=$ROOTFS/var/cache/tdnf
+logfile=$ROOTFS/var/log/dnf.log
+basearch=x86_64
+releasever=2.0
+gpgcheck=1
+installonly_limit=3
+clean_requirements_on_remove=true
+keepcache=1
+debuglevel=1
+exactarch=1
+obsoletes=1
+
+# PUT YOUR REPOS HERE OR IN separate files named file.repo
+# in /etc/yum/repos.d

--- a/installer/build/build.sh
+++ b/installer/build/build.sh
@@ -65,7 +65,7 @@ if [ "$step" == "ova-dev" ]; then
     -e DRONE_BUILD_EVENT=${DRONE_BUILD_EVENT} \
     -e DRONE_DEPLOY_TO=${DRONE_DEPLOY_TO} \
     -e TERM -w ${ROOT_INSTALLER_WORK_DIR} \
-    gcr.io/eminent-nation-87317/vic-product-build:2ea9bdfd ./build/build-ova.sh $*
+    gcr.io/eminent-nation-87317/vic-product-build ./build/build-ova.sh $*
 elif [ "$step" == "ova-ci" ]; then
   echo "starting ci build..."
   export DEBUG=${DEBUG}

--- a/installer/build/container/Dockerfile
+++ b/installer/build/container/Dockerfile
@@ -1,11 +1,12 @@
-FROM vmware/photon
+FROM photon:2.0
 
 ENV GOVERSION=1.9.2
 ENV PATH=$PATH:/root/gsutil:/usr/local/go/bin:/usr/local/google-cloud-sdk/bin/
 
 RUN set -eux; \
+    tdnf erase -y toybox; \
     tdnf install -y make tar gzip python2 python-pip sed git diff \
-    gawk docker gptfdisk e2fsprogs grub2 parted xz docker; \
+    gawk docker gptfdisk e2fsprogs grub2 parted xz docker util-linux which findutils grub2-pc rpm; \
     curl -L'#' -k https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-200.0.0-linux-x86_64.tar.gz  | tar xzf - -C /usr/local; \
     mkdir -p /root/.gsutil/; \
     /usr/local/google-cloud-sdk/install.sh --quiet; \

--- a/installer/build/container/push.sh
+++ b/installer/build/container/push.sh
@@ -19,7 +19,7 @@ IMAGE="vic-product-build"
 REPO="gcr.io/eminent-nation-87317/"
 
 # `docker build` the build container
-docker build --pull --force-rm --no-cache -t "$IMAGE:$OVA_REV" -f build/container/Dockerfile .
+docker build --pull --force-rm --no-cache -t "$IMAGE:$OVA_REV" -f build/container/Dockerfile build/container
 
 # tag the build container with latest and a commit hash
 docker tag "$IMAGE:$OVA_REV" "$REPO$IMAGE:latest"


### PR DESCRIPTION
Use photon 2.0 image as build image.

Use local photon repository to install packages for CI build. Reset
remote repo afterward.

In photon 2.0, builtin toybox conflicts with many other packages
listed in Dockerfile. To avoid modify build scripts, remove toybox
and add packages for commands used to be provided by toybox.

locale-gen is broken in photon 2.0 so comment it out.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #2103 
