### PR TITLE
Update upgrade scripts for 1.5.0

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -58,6 +58,7 @@ VER_1_4_0="v1.4.0"
 VER_1_4_1="v1.4.1"
 VER_1_4_2="v1.4.2"
 VER_1_4_3="v1.4.3"
+VER_1_4_4="v1.4.4"
 
 function usage {
     echo -e "Usage: $0 [args...]
@@ -81,7 +82,7 @@ function usage {
       [--appliance-username value]:    Username of the old appliance. (Ignored if --manual-disks is specified.)
       [--appliance-password value]:    Password of the old appliance. (Ignored if --manual-disks is specified.)
       [--appliance-target value]:      IP Address of the old appliance. (Ignored if --manual-disks is specified.)
-      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, or v1.4.3.
+      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, v1.4.3, or v1.4.4.
 
       [--destroy]:                     Destroy the old appliance after upgrade is finished. (Ignored if --manual-disks is specified.)
       [--manual-disks]:                Skip the automated govc disk migration.
@@ -227,7 +228,7 @@ function enableServicesStart {
   systemctl start harbor.service
 }
 
-### Valid upgrade paths to v1.4.4
+### Valid upgrade paths to v1.5.0
 #   v1.2.1 /data/version has "appliance=v1.2.1"
 #   v1.3.0 /storage/data/version has "appliance=v1.3.0-3033-f8cc7317"
 #   v1.3.1 /storage/data/version has "appliance=v1.3.1-3409-132fb13d"
@@ -235,12 +236,13 @@ function enableServicesStart {
 #   v1.4.1 /storage/data/version
 #   v1.4.2 /storage/data/version
 #   v1.4.3 /storage/data/version
+#   v1.4.4 /storage/data/version
 ###
 function proceedWithUpgrade {
   checkUpgradeStatus "VIC Appliance" ${appliance_upgrade_status}
   local ver="$1"
 
-  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ] || [ "$ver" == "$VER_1_4_2" ] || [ "$ver" == "$VER_1_4_3" ]; then
+  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ] || [ "$ver" == "$VER_1_4_2" ] || [ "$ver" == "$VER_1_4_3" ] || [ "$ver" == "$VER_1_4_4" ]; then
     log ""
     log "Detected old appliance's version as $ver."
 

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -108,7 +108,7 @@ function getApplianceVersion() {
   local VER_1_1_1="v1.1.1"
   local VER_1_2_0="v1.2.0"
   local VER_1_2_1="v1.2.1"
-  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1" "v1.4.2" "v1.4.3")
+  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1" "v1.4.2" "v1.4.3" "v1.4.4")
   local COPIED_DIR="$1"
   local ver=""
   local tag=""


### PR DESCRIPTION
Updates upgrade scripts to list 1.4.4 as a supported upgrade path.

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [x] Considered impact to upgrade
- [x] Tests passing
- [x] Updated documentation
- [x] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)
