### PR TITLE
Move DinV to Photon OS 2.0

### DIFF
--- a/dinv/README.md
+++ b/dinv/README.md
@@ -26,7 +26,7 @@ With this quickstart configuration, the DinV container is not saved and communic
 
 ## Configuration
 
-The DinV container is distributed prevalently through the Docker Hub, as of this writing, two versions of the engine are available: 1.13 and 1.12, versions can be used as a tag for the container (e.g. `vmware/dch-photon:1.12`).
+The DinV container is distributed prevalently through the Docker Hub, as of this writing, three versions of the engine are available: 1.13, 1.12 and 17.06, versions can be used as a tag for the container (e.g. `vmware/dch-photon:1.12`).
 
 When the container is run with the `-h` or `--help` flag, the help is shown and the container will quit without starting docker engine.
 

--- a/dinv/ci.sh
+++ b/dinv/ci.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-set -e
+set -e && [ -n "$DEBUG" ] && set -x
 
 function changeset {
   case "$DRONE_BUILD_EVENT" in

--- a/dinv/dch-photon-17.06/Dockerfile
+++ b/dinv/dch-photon-17.06/Dockerfile
@@ -6,7 +6,7 @@ ADD ./dch-photon-17.06/* /go/src/dinv/
 RUN rm /go/src/dinv/dch-photon-1.12/main.go && cd /go/src/dinv && go get -v ./... && go build -o dinv && strip dinv
 
 # Build photon base image
-FROM photon:1.0 as base
+FROM photon:2.0 as base
 
 # Create temporary chroot environment
 ENV TEMP_CHROOT /temp_chroot
@@ -14,21 +14,19 @@ ENV TEMP_CHROOT /temp_chroot
 RUN mkdir /data &&\
     mkdir $TEMP_CHROOT &&\
     mkdir -p $TEMP_CHROOT/var/lib/rpm &&\
+    tdnf install -y rpm &&\
     rpm --root $TEMP_CHROOT/ --initdb &&\
     rpm --root $TEMP_CHROOT --import /etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 
 RUN echo "> Installing photon base system in chroot, killing output to avoid offending drone" &&\
-    tdnf --releasever 1.0 --installroot $TEMP_CHROOT/ --refresh install -y \
-    bash-4.3.30-9.ph1 \
-    coreutils-8.25-2.ph1 \
-    filesystem-1.0-10.ph1 \
-    photon-release-1.0-6.ph1 \
-    photon-repos-1.0-4.ph1 \
-    tdnf-1.1.0-1.ph1 \
-    docker-17.06.0-3.ph1 \
-    openssl-1.0.2o-2.ph1 \
-    procps-ng-3.3.11-4.ph1 \
-    iptables-1.6.0-6.ph1 > /dev/null 2>&1
+    tdnf --releasever 2.0 --installroot $TEMP_CHROOT/ --refresh install -y \
+    bash-4.4.12-3.ph2 \
+    photon-release-2.0-2.ph2 \
+    photon-repos-2.0-2.ph2 \
+    tdnf-1.2.3-4.ph2 \
+    docker-17.06.0-8.ph2 \
+    procps-ng-3.3.15-2.ph2 \
+    iptables-1.6.1-4.ph2 > /dev/null 2>&1
 
 RUN cp /etc/resolv.conf $TEMP_CHROOT/etc/
 RUN mkdir $TEMP_CHROOT/certs


### PR DESCRIPTION
Only docker 17.06 is available in Photon 2.0 repositoy, DCH 1.12 and
1.13 images will remain with Photon OS 1.0.

Set a DEBUG flag to CI build script for troubleshooting.


VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #2104 