### PR TITLE
Appliance Welcome page requires input of VIC appliance password

### DIFF
--- a/installer/fileserver/html/css/style.css
+++ b/installer/fileserver/html/css/style.css
@@ -57,3 +57,7 @@
 #feedback-link {
     max-width: inherit;
 }
+
+#login-body .form-group input {
+    width: 175px;
+}

--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -228,6 +228,10 @@
                                             <label for="pscDomain">External PSC Admin Domain</label>
                                             <input id="pscDomain" type="text" name="pscDomain" placeholder="vsphere.local">
                                         </div>
+                                        <div class="form-group">
+                                            <label for="user" class="required">VIC Appliance Password</label>
+                                            <input id="appliancePwd" type="password" name="appliancePwd" placeholder="Password" onkeyup="checkRegistryForm()" value="">
+                                        </div>
                                         Install UI Plugin <input id="needuiplugin" type="checkbox" name="needuiplugin" value="true" checked>
                                         <input id="thumbprint" type="hidden" name="thumbprint" placeholder="">
                                     </div>

--- a/installer/fileserver/html/js/index-handler.js
+++ b/installer/fileserver/html/js/index-handler.js
@@ -11,7 +11,7 @@ function getThumbprint(target,callback) {
 function checkRegistryForm() {
     var cansubmit = true;
 
-    if (document.getElementById('target').value.length == 0 || document.getElementById('user').value.length == 0 || document.getElementById('password').value.length == 0){
+    if (document.getElementById('target').value.length == 0 || document.getElementById('user').value.length == 0 || document.getElementById('password').value.length == 0 || document.getElementById('appliancePwd').value.length == 0){
         cansubmit = false;
     }
     

--- a/tests/resources/page-objects/Complete-Installation-Modal-Util.robot
+++ b/tests/resources/page-objects/Complete-Installation-Modal-Util.robot
@@ -22,7 +22,8 @@ ${cim-title}  css=#login-modal .modal-title
 ${cim-thumbprint-title}  css=#plugin-modal .modal-title
 ${cim-input-target}  id=target
 ${cim-input-user}  id=user
-${cim-input-password}  css=input[type=password]
+${cim-input-password}  id=password
+${cim-input-appliancePwd}  id=appliancePwd
 ${cim-button-continue}  id=login-submit
 ${cim-thumbprint-button-continue}  id=plugin-submit
 
@@ -46,7 +47,9 @@ Log In And Complete OVA Installation
     Input Text  ${cim-input-target}   %{TEST_URL}
     Input Text  ${cim-input-user}   %{TEST_USERNAME}
     Input Text  ${cim-input-password}   %{TEST_PASSWORD}
+    Input Text  ${cim-input-appliancePwd}  ${OVA_PASSWORD_ROOT}
     Click Button  ${cim-button-continue}
+    Sleep  1
     Verify Thumbprint Modal
     Click Button  ${cim-thumbprint-button-continue}
     Verify Complete Installation Message


### PR DESCRIPTION
fixed : vic-tasks-Appliance welcome page (9443) allows for external service interaction (HTTPS) without authentication #93
When re-initializing the VSPHERE integrated container appliance, Request to enter Vic appliance password
Signed-off-by: FangyuanCheng <fangyuanc@vmware.com>
