### PR TITLE
Update links in Getting Started page to point to 1.5 docs

### DIFF
--- a/installer/fileserver/html/index.html
+++ b/installer/fileserver/html/index.html
@@ -54,7 +54,7 @@
                             Containers Appliance</h1>
                         </div>
                         <div class="col-xs text-right">
-                            <a href="https://vmware.github.io/vic-product/assets/files/html/1.4/" target="_blank" title="Documentation" class="btn btn-primary mx-1">Documentation</a>
+                            <a href="https://vmware.github.io/vic-product/assets/files/html/1.5/" target="_blank" title="Documentation" class="btn btn-primary mx-1">Documentation</a>
                         </div>                      
                     </div>
                     <div class="row flex-items-xs-center mx-0">
@@ -72,7 +72,7 @@
                                         </div>
                                         <div class="card-footer">
                                             <a class="btn btn-sm btn-link" href="{{ .AdmiralAddr }}" target="_blank">Open</a>
-                                            <a class="btn btn-sm btn-link" target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_cloud_admin/">Read more</a>
+                                            <a class="btn btn-sm btn-link" target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_cloud_admin/">Read more</a>
                                         </div>
                                     </div>
                                 </div>
@@ -85,8 +85,8 @@
                                             <div class="card-text">
                                                 These tasks are usually performed by the vSphere admin.
                                                 <ol>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/deploy_vch.html">Deploy VCHs</a></li>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/vch_admin.html">Manage VCHs</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_vsphere_admin/deploy_vch.html">Deploy VCHs</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_vsphere_admin/vch_admin.html">Manage VCHs</a></li>
                                                 </ol>
                                             </div>
                                         </div>
@@ -101,12 +101,12 @@
                                             <div class="card-text">
                                                 These tasks are usually performed by the Cloud or DevOps admins.
                                                 <ol>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_cloud_admin/configure_system.html">Configure the management portal</a></li>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_cloud_admin/create_projects.html">Create projects</a></li>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_cloud_admin/add_users.html">Add users</a></li>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_cloud_admin/vchs_and_mgmt_portal.html">Add hosts to the management portal</a></li>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_cloud_admin/add_repos_in_portal.html">Add registries to the management portal</a></li>
-                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_app_dev/run_dev_project.html">Run projects and provision containers</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_cloud_admin/configure_system.html">Configure the management portal</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_cloud_admin/create_projects.html">Create projects</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_cloud_admin/add_users.html">Add users</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_cloud_admin/vchs_and_mgmt_portal.html">Add hosts to the management portal</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_cloud_admin/add_repos_in_portal.html">Add registries to the management portal</a></li>
+                                                	<li><a target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_app_dev/run_dev_project.html">Run projects and provision containers</a></li>
                                                 </ol>
                                             </div>
                                         </div>
@@ -133,7 +133,7 @@
                                     </div>
                                     <div class="card-footer">
                                         <a class="btn btn-sm btn-link" href="{{ .FileserverAddr }}" target="_blank">Download</a>
-                                        <a class="btn btn-sm btn-link" target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/deploy_vch.html">Read more</a>
+                                        <a class="btn btn-sm btn-link" target="_blank" href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_vsphere_admin/deploy_vch.html">Read more</a>
                                     </div>
                                 </div>
                             </div>
@@ -168,7 +168,7 @@
                                                         this certificate or cancel
                                                         if the thumbprint is not valid
                                                 </p>
-                                                <a href="https://vmware.github.io/vic-product/assets/files/html/1.4/vic_vsphere_admin/obtain_thumbprint.html" target="_blank" class="btn btn-link" >Read more...</a>
+                                                <a href="https://vmware.github.io/vic-product/assets/files/html/1.5/vic_vsphere_admin/obtain_thumbprint.html" target="_blank" class="btn btn-link" >Read more...</a>
                                             </div>
                                             <div class="modal-footer">
                                                 <button class="btn btn-outline" type="button" onclick="window.location.href='/?login=true'">Cancel</button>


### PR DESCRIPTION
11 links of main page and 1 link of pop-up page,
All changed are made in `installer/fileserver/html/index.html`, and I've manually tested these links

VIC Appliance Checklist:
- [y] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [y] Updated documentation
- [ ] Impact assessment checklist

Fixes #2212 

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
