### PR TITLE
Modify ways to identify host from css to xpath by host IP

### DIFF
--- a/tests/manual-test-cases/Group5-Interoperability-Tests/5-01-Distributed-Switch-No-Cluster.robot
+++ b/tests/manual-test-cases/Group5-Interoperability-Tests/5-01-Distributed-Switch-No-Cluster.robot
@@ -74,7 +74,8 @@ Distributed Switch Setup
     # Make sure we use correct datastore
     ${datastore}=  Get Name of First Local Storage For Host  @{esx_ips}[0]
     Set Environment Variable  TEST_DATASTORE  ${datastore}
+    Set Environment Variable  TEST_ESX  @{esx_ips}[0]
 
 *** Test Cases ***
 Test
-    Deploy OVA And Install UI Plugin And Run Regression Tests  5-01-TEST  vic-*.ova  %{TEST_DATASTORE}  %{BRIDGE_NETWORK}  %{PUBLIC_NETWORK}  %{TEST_USERNAME}  %{TEST_PASSWORD}
+    Deploy OVA And Install UI Plugin And Run Regression Tests  5-01-TEST  vic-*.ova  %{TEST_DATASTORE}  %{BRIDGE_NETWORK}  %{PUBLIC_NETWORK}  %{TEST_USERNAME}  %{TEST_PASSWORD}  %{TEST_ESX}

--- a/tests/resources/page-objects/Vsphere-VCH-Plugin-Util.robot
+++ b/tests/resources/page-objects/Vsphere-VCH-Plugin-Util.robot
@@ -174,8 +174,12 @@ Create VCH using UI And Set Docker Parameters
     # compute capacity
     Log To Console  Selecting compute resource...
     # if cluster is present
-    Wait Until Element Is Visible And Enabled  css=.clr-treenode-children clr-tree-node:nth-of-type(${tree-node}) .cc-resource
-    Click Button  css=.clr-treenode-children clr-tree-node:nth-of-type(${tree-node}) .cc-resource
+    # There're 2 types of tree-node, if it's a index number, locator will be defined by CSS, if it's a IP address, locator will be defined by xpath 
+    ${tree-node-len}=  Get Length  '${tree-node}'
+    ${host_locator}=  set variable if  ${tree-node-len}<5  css=.clr-treenode-children clr-tree-node:nth-of-type(${tree-node}) .cc-resource  xpath://clr-tree-node//button[contains(., '${tree-node}')]
+    Wait Until Element Is Enabled  ${host_locator}
+    Click Button  ${host_locator}
+
     Click Next Button
     # storage capacity
     Select Image Datastore  ${datastore}


### PR DESCRIPTION
Due to GUI design of listing VCHs was changed to sort by IP address, so script '5-01-Distributed-Switch-No-Cluster' failed to locating the wanted VCH, it wants a VCH with property 'datastore' named 'datastore1', it always at the head of VCH nodes.
After design changed, the position of this VCH may not be at the head of the list, so add a 'if condition' in keyword 'Create VCH using UI And Set Docker Parameters' to locate VCH index by '1' or IP address.

Fixes #2220
