### PR TITLE
Drop unused capabilities for containers

### DIFF
--- a/installer/build/scripts/admiral/start_admiral.sh
+++ b/installer/build/scripts/admiral/start_admiral.sh
@@ -25,6 +25,7 @@ admiral_xenon_opts="--publicUri=https://${OVA_VM_IP}:8282/ --bindAddress=0.0.0.0
 
 /usr/bin/docker run -p ${ADMIRAL_EXPOSED_PORT}:8282 \
   --name vic-admiral \
+  --cap-drop ALL \
   -v "$ADMIRAL_DATA_LOCATION:/var/admiral" \
   -v "$ADMIRAL_DATA_LOCATION/configs:/configs" \
   -v /storage/log/admiral:/admiral/log \

--- a/installer/build/scripts/vic-machine-server/vic-machine-server.service
+++ b/installer/build/scripts/vic-machine-server/vic-machine-server.service
@@ -12,7 +12,7 @@ EnvironmentFile=/etc/vmware/environment
 ExecStartPre=-/usr/bin/docker kill vic-machine-server
 ExecStartPre=-/usr/bin/docker rm -f vic-machine-server
 ExecStartPre=/etc/vmware/vic-machine-server/configure-vic-machine-server.sh
-ExecStart=/usr/bin/docker run --rm --user 10000:10000 --name vic-machine-server -v /storage/data/certs:/certs:ro -v /storage/log/vic-machine-server:/var/log/vic-machine-server -p ${VIC_MACHINE_SERVER_PORT}:443 vmware/vic-machine-server:ova
+ExecStart=/usr/bin/docker run --cap-drop ALL --cap-add NET_BIND_SERVICE --rm --name vic-machine-server -v /storage/data/certs:/certs:ro -v /storage/log/vic-machine-server:/var/log/vic-machine-server -p ${VIC_MACHINE_SERVER_PORT}:443 vmware/vic-machine-server:ova
 ExecStop=/usr/bin/docker stop vic-machine-server
 
 [Install]


### PR DESCRIPTION
Drop all capabilities of admiral.

Only enable NET_BIND_SERVICE capability of vic-machine-server.
Remove specifying UID option because it runs with non-root user
by default now.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #
