### PR TITLE
Update out of date build script

### DIFF
--- a/installer/build/build-ova.sh
+++ b/installer/build/build-ova.sh
@@ -105,7 +105,7 @@ if [ -z "${HARBOR}" ]; then
 fi
 setenv HARBOR "$url"
 
-export BUILD_DCHPHOTON_VERSION="1.13"
+export BUILD_DCHPHOTON_VERSION="17.06"
 
 ENV_FILE="${CACHE}/installer.env"
 touch $ENV_FILE

--- a/installer/build/scripts/provisioners/provision_harbor.sh
+++ b/installer/build/scripts/provisioners/provision_harbor.sh
@@ -25,7 +25,7 @@ cp -p /var/tmp/harbor/harbor.cfg /data/harbor
 cp -pr /var/tmp/harbor/{prepare,common,docker-compose.yml,docker-compose.notary.yml,docker-compose.clair.yml} /etc/vmware/harbor
 
 # Get Harbor to Admiral data migration script
-curl -L"#" -o /etc/vmware/harbor/admiral_import https://raw.githubusercontent.com/vmware/harbor/master/tools/migration/import
+curl -L"#" -o /etc/vmware/harbor/admiral_import https://raw.githubusercontent.com/goharbor/harbor/master/tools/migration/db/tools/import
 chmod +x /etc/vmware/harbor/admiral_import
 
 function overrideDataDirectory {

--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -107,7 +107,7 @@ function runMigratorCmd {
   fi
 }
 
-# https://github.com/vmware/harbor/blob/master/docs/migration_guide.md
+# https://github.com/goharbor/harbor/blob/master/docs/migration_guide.md
 function migrateHarbor {
   if [ "$HARBOR_VER" == "$VER_1_2_1" ]; then
     harbor_old_database_dir="/storage/data/harbor"


### PR DESCRIPTION
Latest DCH is 17.06 so pack it into Harbor as a default image.

Harbor was moved from vmware/harbor to goharbor/harbor.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)
