### PR TITLE
Use Harbor 1.7.0 RC1 for VIC 1.5.0

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -91,6 +91,7 @@ pipeline:
     privileged: true
     environment:
       TERM: xterm
+      HARBOR: https://storage.googleapis.com/harbor-releases/release-1.7.0/harbor-offline-installer-v1.7.0-rc1.tgz
     secrets:
       - admiral
       - build_admiral_release


### PR DESCRIPTION
Pack Harbor 1.7.0 RC1 artifact into VIC 1.5.0.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)
