### PR TITLE
Enable NTP configurable

### DIFF
--- a/installer/build/bootable/config/builder.ovf
+++ b/installer/build/bootable/config/builder.ovf
@@ -242,6 +242,10 @@ EVALUATION LICENSE. If You are licensing the Software for evaluation purposes, Y
         <Label>2.6. FQDN</Label>
         <Description>The fully qualified domain name of this VM. Leave blank if DHCP is desired.</Description>
       </Property>
+      <Property ovf:key="ntp" ovf:type="string" ovf:userConfigurable="true">
+        <Label>2.7. NTP Servers</Label>
+        <Description>The NTP server IP Addresses for this VM (space separated). Leave blank if DHCP is desired.</Description>
+      </Property>
     </ProductSection>
     <ProductSection ovf:class="registry" ovf:required="false">
       <Info>Registry Properties</Info>

--- a/installer/build/scripts/provisioners/system_settings.sh
+++ b/installer/build/scripts/provisioners/system_settings.sh
@@ -23,7 +23,7 @@ systemctl enable vic-appliance-load-docker-images.service
 systemctl enable vic-appliance-tls.service
 systemctl enable sshd_permitrootlogin.service
 systemctl enable getty@tty2.service
-systemctl enable ovf-network.service ova-firewall.service
+systemctl enable ovf-network.service ova-firewall.service ovf-ntp.service
 
 # Enable systemd component services
 systemctl enable get_token.timer reconfigure_token.path psc-ready.target

--- a/installer/build/scripts/systemd/scripts/ntp-config.sh
+++ b/installer/build/scripts/systemd/scripts/ntp-config.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/bash
+# Copyright 2018 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+time_conf_file=/etc/systemd/timesyncd.conf
+
+ntp="$(ovfenv --key network.ntp | sed 's/,/ /g' | tr -s ' ')"
+
+if [[ -n $ntp ]]; then
+cat <<EOF | tee ${time_conf_file}
+[Time]
+NTP=$ntp
+EOF
+systemctl restart systemd-timesyncd.service
+fi

--- a/installer/build/scripts/systemd/scripts/vic-appliance-environment.sh
+++ b/installer/build/scripts/systemd/scripts/vic-appliance-environment.sh
@@ -44,6 +44,7 @@ NETWORK_NETMASK0="$(ovfenv --key network.netmask0)"
 NETWORK_GATEWAY="$(ovfenv --key network.gateway)"
 NETWORK_DNS="$(ovfenv --key network.DNS | sed 's/,/ /g' | tr -s ' ')"
 NETWORK_SEARCHPATH="$(ovfenv --key network.searchpath)"
+NETWORK_NTP="$(ovfenv --key network.ntp | sed 's/,/ /g' | tr -s ' ')"
 
 function detectHostname() {
   HOSTNAME=$(hostnamectl status --static) || true
@@ -119,6 +120,7 @@ echo "Using hostname: ${HOSTNAME}"
   echo "NETWORK_NETMASK0=${NETWORK_NETMASK0}";
   echo "NETWORK_GATEWAY=${NETWORK_GATEWAY}";
   echo "NETWORK_DNS=${NETWORK_DNS}";
+  echo "NETWORK_NTP=${NETWORK_NTP}";
   echo "NETWORK_SEARCHPATH=${NETWORK_SEARCHPATH}";
 } > ${ENV_FILE}
 

--- a/installer/build/scripts/systemd/units/ovf-ntp.service
+++ b/installer/build/scripts/systemd/units/ovf-ntp.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=NTP customization based on user provided parameter
+Requires=network-online.target
+After=network-online.target
+
+[Service]
+Type=oneshot
+ExecStart=/etc/vmware/ntp-config.sh
+
+[Install]
+WantedBy=vic-appliance-ready.target

--- a/installer/build/scripts/systemd/units/vic-appliance-environment.service
+++ b/installer/build/scripts/systemd/units/vic-appliance-environment.service
@@ -1,8 +1,8 @@
 [Unit]
 Description=VIC Appliance Environment
 Documentation=https://github.com/vmware/vic-product
-Requires=ovf-network.service network-online.target
-After=ovf-network.service network-online.target
+Requires=ovf-network.service network-online.target ovf-ntp.service
+After=ovf-network.service network-online.target ovf-ntp.service
 
 [Service]
 Type=oneshot

--- a/installer/build/scripts/systemd/units/vic-appliance-ready.target
+++ b/installer/build/scripts/systemd/units/vic-appliance-ready.target
@@ -11,8 +11,8 @@ After=vic-appliance-tls.service
 Requires=network-online.target systemd-resolved.service systemd-timesyncd.service
 After=network-online.target systemd-resolved.service systemd-timesyncd.service
 
-Requires=ovf-network.service ova-firewall.service
-After=ovf-network.service ova-firewall.service
+Requires=ovf-network.service ova-firewall.service ovf-ntp.service
+After=ovf-network.service ova-firewall.service ovf-ntp.service
 
 [Install]
 WantedBy=vic-appliance.target

--- a/installer/ovatools/vic-ova-ui/main.go
+++ b/installer/ovatools/vic-ova-ui/main.go
@@ -122,7 +122,7 @@ func main() {
 	}
 
 	netHeader := "Network Status:\n\nSettings with 'MATCH' indicate the system network \nconfiguration matches the OVF network configuration.\n\n"
-	netInfo := fmt.Sprintf("%s\nDNS: %s\n\nIP: %s\n\nGateway: %s\n", netHeader, netstat.GetDNSStatus(), netstat.GetIPStatus(), netstat.GetGatewayStatus())
+	netInfo := fmt.Sprintf("%s\nDNS: %s\n\nIP: %s\n\nGateway: %s\n\nNTP: %s\n", netHeader, netstat.GetDNSStatus(), netstat.GetIPStatus(), netstat.GetGatewayStatus(), netstat.GetNTPStatus())
 	netInfo = fmt.Sprintf("%s\n\n\nPress the left arrow key to view service info...", netInfo)
 
 	// yellow := ui.ColorRGB(4, 4, 1)

--- a/installer/ovatools/vic-ova-ui/network_status.go
+++ b/installer/ovatools/vic-ova-ui/network_status.go
@@ -39,6 +39,19 @@ func (nstat *NetworkStatus) GetDNSStatus() string {
 	return nstat.addressPresenceExec(dnsExpected, command)
 }
 
+func (nstat *NetworkStatus) GetNTPStatus() string {
+	ntpExpected := strings.FieldsFunc(nstat.ovfProps["network.ntp"],
+		func(char rune) bool { return char == ',' || char == ' ' })
+
+	var command string
+	if len(ntpExpected) == 0 {
+		command = `systemctl status systemd-timesyncd.service | grep Status | awk -F'[()]' '{print $2}'`
+	} else {
+		command = `cat /etc/systemd/timesyncd.conf | grep -v '^#' | grep 'NTP=' | awk -F'=' '{print $2}' | tr ' ' '\n'`
+	}
+	return nstat.addressPresenceExec(ntpExpected, command)
+}
+
 func (nstat *NetworkStatus) GetIPStatus() string {
 	ipsExpected := strings.FieldsFunc(nstat.ovfProps["network.ip0"],
 		func(char rune) bool { return char == ',' || char == ' ' })

--- a/installer/ovatools/vic-ova-ui/network_status.go
+++ b/installer/ovatools/vic-ova-ui/network_status.go
@@ -47,7 +47,7 @@ func (nstat *NetworkStatus) GetNTPStatus() string {
 	if len(ntpExpected) == 0 {
 		command = `systemctl status systemd-timesyncd.service | grep Status | awk -F'[()]' '{print $2}'`
 	} else {
-		command = `cat /etc/systemd/timesyncd.conf | grep -v '^#' | grep 'NTP=' | awk -F'=' '{print $2}' | tr ' ' '\n'`
+		command = `grep -v '^#' /etc/systemd/timesyncd.conf | grep 'NTP=' | awk -F'=' '{print $2}' | tr ' ' '\n'`
 	}
 	return nstat.addressPresenceExec(ntpExpected, command)
 }


### PR DESCRIPTION
Allow user to specify NTP servers from VIC appliance deployment
wizard.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #1390 

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
