### PR TITLE
Added vicpassword to OVA registration API doc

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/ova_reg_api.md
+++ b/docs/user_doc/vic_vsphere_admin/ova_reg_api.md
@@ -2,7 +2,7 @@
 
 The vSphere Integrated Containers appliance provides an API that allows you to initialize the appliance after deployment without having to manually enter information in the appliance welcome page. This API helps you to automate the deployment of appliances without manual intervention.
 
-The appliance exposes the initialization API endpoint at https://<i>vic_appliance_address</i>:9443/register. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, 9443 is replaced with the appropriate port.
+The appliance exposes the initialization API endpoint at https://<i>vic_appliance_address</i>:9443/register. 
 
 **Prerequistes**
 
@@ -15,17 +15,19 @@ You deployed an instance of the vSphere Integrated Containers appliance without 
     vCenter Server with an embedded Platform Services Controller:<pre>{
   "target":"<i>vcenter_server_address</i>",
   "user":"<i>sso_administrator_account</i>",
-  "password":"<i>sso_administrator_password</i>"
-  "thumbprint":"<i>vc_thumbprint</i>"
+  "password":"<i>vcenter_sso_administrator_password</i>",
+  "thumbprint":"<i>vc_thumbprint</i>",
+  "vicpassword":"<i>vic_appliance_root_password</i>"
 }</pre>
 
     vCenter Server with an external Platform Services Controller:<pre>{
   "target":"<i>vcenter_server_address</i>",
   "user":"<i>sso_administrator_account</i>",
-  "password":"<i>sso_administrator_password</i>",
-  "thumbprint":"<i>vc_thumbprint</i>"
+  "password":"<i>vcenter_sso_administrator_password</i>",
+  "thumbprint":"<i>vc_thumbprint</i>",
   "externalpsc":"psc_address",
-  "pscdomain":"psc_domain"
+  "pscdomain":"psc_domain",
+  "vicpassword":"<i>vic_appliance_root_password</i>"
 }</pre> 
 
     **NOTE**: The initialization API does not include an option to skip the installation or upgrade of the vSphere Integrated Containers plug-in for the vSphere Client.
@@ -34,7 +36,7 @@ You deployed an instance of the vSphere Integrated Containers appliance without 
 
     Copy the command as shown, replacing <i>vic_appliance_address</i> with the address of the appliance.<pre>curl -k -w '%{http_code}' -d @payload.json https://<i>vic_appliance_address</i>:9443/register
 </pre>If successful, you see the message `operation complete
-200`. 
+200`. If the vSphere Integrated Containers appliance was configured to expose the file server on a different port, replace 9443 with the appropriate port.
 
 **Result**
 
@@ -50,5 +52,6 @@ Here is an example of a completed `payload.json` file:
   "password":"p@ssw0rd!",
   "thumbprint":"12:34:F3:B2:85:2F:F7:95:B3:1E:99:F4:FB:28:4E:E7:5E:E0:5B:33",
   "externalpsc":"psc1.mycompany.org",
-  "pscdomain":"vsphere.local"
+  "pscdomain":"vsphere.local",
+  "vicpassword":"<i>vic_appliance_root_password</i>"
 }</pre> 


### PR DESCRIPTION
Towards https://github.com/vmware/vic-product/issues/2160.

I will add the VIC password to the upgrade doc in a separate PR, because I have upgrade updates in progress in another branch.

@wjun is this OK? Thanks!