### PR TITLE
Pack dev version of Admiral

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -105,6 +105,7 @@ pipeline:
     privileged: true
     environment:
       TERM: xterm
+      ADMIRAL: dev
       HARBOR: https://storage.googleapis.com/harbor-releases/release-1.7.0/harbor-offline-installer-v1.7.0.tgz
     secrets:
       - admiral


### PR DESCRIPTION
Latest release build tag is v1.4.3 and we need to pack v1.5.0 into
VIC appliance. We should revert this change once v1.5.0 is tagged.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
