### PR TITLE
Add local socket monitoring for dch-photon

### DIFF
--- a/dinv/dch-photon-1.12/main.go
+++ b/dinv/dch-photon-1.12/main.go
@@ -128,6 +128,7 @@ func main() {
 		log.Debug("Let docker listen on all ips")
 		dockerArgs = append(dockerArgs, "-H", fmt.Sprintf("tcp://0.0.0.0:%d", port))
 	}
+	dockerArgs = append(dockerArgs, "-H", "unix:///var/run/docker.sock")
 
 	// Append insecure registry configuration if present
 	if insecureRegistry != "" {

--- a/dinv/main.go
+++ b/dinv/main.go
@@ -121,6 +121,7 @@ func main() {
 		log.Debug("Let docker listen on all ips")
 		dockerArgs = append(dockerArgs, "-H", fmt.Sprintf("tcp://0.0.0.0:%d", port))
 	}
+	dockerArgs = append(dockerArgs, "-H", "unix:///var/run/docker.sock")
 
 	// Append insecure registry configuration if present
 	if insecureRegistry != "" {

--- a/tests/test-cases/Group5-DCH/5-01-DCH.robot
+++ b/tests/test-cases/Group5-DCH/5-01-DCH.robot
@@ -106,3 +106,14 @@ Verify the certificate is not signed by nil when vic-ip is specified with FQDN
 
     [Teardown]  Cleanup VCH  ${vch-name}
 
+Verify local enabled scenario for dch-photon
+    ${vch-name}=  Install VCH  certs=${false}
+    ${rc}=  Run command and Return output  ${DEFAULT_LOCAL_DOCKER} ${VCH-PARAMS} run -d -p 12389:2376 ${harbor-image-tagged} -tls -local
+
+    # Verify 12389 could not be accessed with -local due to dockerd only monitors local unix socket
+    ${rc}  ${output}=  Run And Return Rc And Output  ${DEFAULT_LOCAL_DOCKER} -H ${VCH-IP}:12389 --tls ps
+    Log  ${output}
+    Should Be Equal As Integers  ${rc}  1
+    Should Contain  ${output}  Cannot connect to the Docker daemon at tcp://${VCH-IP}:12389
+
+    [Teardown]  Cleanup VCH  ${vch-name}


### PR DESCRIPTION
dinv has a parameter -local, when it is specified, the dch-photon
will start dockerd with unix:///var/run/docker.sock. When local is
not specified, the dockerd will be started with tcp://0.0.0.0:xxx.
This change will enable unix:///var/run/docker.sock always.

Fixes #7316
