### PR TITLE
Change vic-product CI run as sequential

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -22,6 +22,22 @@ pipeline:
       - 'git log -5'
       - 'git log -1 --pretty=oneline | grep "^${DRONE_COMMIT}" > /dev/null && echo ''Build matches'' || (git log -1 --pretty=oneline | grep "Merge ${DRONE_COMMIT}" > /dev/null && echo ''Build is of a merge commit'' || (echo ''Build does not match!'' && exit 1))'
 
+  wait-for-build:
+    image: 'gcr.io/eminent-nation-87317/vic-integration-test:1.48'
+    pull: true
+    environment:
+      BIN: bin
+      GOPATH: /go
+      SHELL: /bin/bash
+    secrets:
+      - drone_server
+      - drone_token
+      - test_url
+    commands:
+      - export TEST_URL_ARRAY="$TEST_URL"
+      - tests/wait_until_previous_builds_complete.sh
+
+
   check-org-membership:
     image: 'wdc-harbor-ci.eng.vmware.com/default-project/vic-integration-test:1.44'
     pull: true

--- a/tests/wait_until_previous_builds_complete.sh
+++ b/tests/wait_until_previous_builds_complete.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+# Copyright 2016 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+unit_test_array=($TEST_URL_ARRAY)
+numServers=${#unit_test_array[@]}
+DRONE_BUILD_NUMBER=${DRONE_BUILD_NUMBER:=0}
+prevBuildNumber=$(( $DRONE_BUILD_NUMBER-$numServers ))
+prevBuildStatus=`drone build info --format='{{.Status}}' vmware/vic-product $prevBuildNumber`
+echo prevBuildStatus $prevBuildStatus
+
+while [[ $prevBuildStatus == *"running"* ]]; do
+    echo "Waiting 5 minutes for build $prevBuildNumber to complete";
+    sleep 300;
+    prevBuildStatus=`drone build info --format='{{.Status}}' vmware/vic-product $prevBuildNumber`
+    echo prevBuildStatus $prevBuildStatus
+done
+exit 0


### PR DESCRIPTION
Hit failure when multi vic-product CI build run as parallel in Drone
Change to sequential for now
Revert it back to parallel when vic-product CI infra is ready
Address issue2260