### PR TITLE
Redirect / to Admiral UI

### DIFF
--- a/installer/build/scripts/provisioners/provision_harbor.sh
+++ b/installer/build/scripts/provisioners/provision_harbor.sh
@@ -69,13 +69,13 @@ chmod 600 /data/harbor/harbor.cfg
 chmod -R 600 /etc/vmware/harbor/common
 
 # Redirect vic_appliance_address:443 to Admiral UI, see vic-product/2216
-LOCATION_REDIRECT='return 302 https://$$host:8282$$request_uri'
-NGINX_CONF='/etc/vmware/harbor/common/templates/nginx/nginx.https.conf'
-sed -i '/location \/ {/,/}/s/proxy_pass http:\/\/portal\//return 302 https:\/\/$$host:8282$$request_uri/' ${NGINX_CONF}
-if ! grep -q "${LOCATION_REDIRECT}"  ${NGINX_CONF} ; then
-  echo "Failed to modify location / in ${NGINX_CONF}"
-  exit 1
-fi
+CONF_DIR='/etc/vmware/harbor/common/templates/nginx/ext'
+mkdir -p ${CONF_DIR}
+cat << EOF > ${CONF_DIR}/harbor.https.vic.conf
+location ~ /$ {
+  return 302 https://\$\$host:8282\$\$request_uri;
+}
+EOF
 
 # Write version files
 echo "harbor=${BUILD_HARBOR_FILE}" >> /data/version


### PR DESCRIPTION
Harbor configure https://vic_appliance_address to harbor portal UI,
which is only right on standalone mode. In VIC, it should redirects
to Admiral UI. This fix overwrites the previous approach in PR 2239.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #2216 

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
