### PR TITLE
Fix showing double prompts in terminal

### DIFF
--- a/dinv/dch-photon-17.06/Dockerfile
+++ b/dinv/dch-photon-17.06/Dockerfile
@@ -43,6 +43,8 @@ FROM scratch
 
 LABEL maintainer "fabio@vmware.com"
 
+ENV TERM linux
+
 COPY --from=base /temp_chroot /
 
 EXPOSE 2375 2376


### PR DESCRIPTION
The default terminal is xterm which causes double prompts shown after
every command is issued. Change it to linux.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
