### PR TITLE
Fix admiral overwriting other options

### DIFF
--- a/installer/scripts/ci-build.sh
+++ b/installer/scripts/ci-build.sh
@@ -44,7 +44,7 @@ if [[ ( "$DRONE_BUILD_EVENT" == "tag" && "$DRONE_TAG" != *"dev"* ) || "$DRONE_BR
   if [ -z "${ADMIRAL}" ]; then
     if [[ "$DRONE_BUILD_EVENT" == "tag" && "$DRONE_TAG" != *"dev"* ]]; then
       admiral_release=$(curl -s https://hub.docker.com/v2/repositories/vmware/admiral/tags/\?page\=1\&page_size\=250 | jq '.results[] | .name'| cut -d "\"" -f2 | grep '^vic_v' | head -n 1 | cut -d'_' -f2)
-      OPTIONS="--admiral $admiral_release"
+      OPTIONS="$OPTIONS --admiral $admiral_release"
     fi
   fi
   if [ -z "${HARBOR}" ]; then


### PR DESCRIPTION
Options passed to ci-build.sh will be overwrote by admiral when it
is a tag event.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
