### PR TITLE
Fix docker login harbor failure

### DIFF
--- a/installer/build/scripts/provisioners/provision_harbor.sh
+++ b/installer/build/scripts/provisioners/provision_harbor.sh
@@ -72,7 +72,7 @@ chmod -R 600 /etc/vmware/harbor/common
 CONF_DIR='/etc/vmware/harbor/common/templates/nginx/ext'
 mkdir -p ${CONF_DIR}
 cat << EOF > ${CONF_DIR}/harbor.https.vic.conf
-location ~ /$ {
+location ~ ^/$ {
   return 302 https://\$host:8282\$request_uri;
 }
 EOF


### PR DESCRIPTION
Docker login fails because wrong route in nigix configuration.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
