### PR TITLE
Clean up cache files

### DIFF
--- a/installer/build/scripts/provisioners/provision_fileserver.sh
+++ b/installer/build/scripts/provisioners/provision_fileserver.sh
@@ -66,3 +66,7 @@ ls -l ${FILES_DIR}
 # Write version files
 echo "engine=${BUILD_VICENGINE_FILE}" >> /data/version
 echo "engine=${BUILD_VICENGINE_FILE}" >> /etc/vmware/version
+
+# Clean up cache
+rm -f /etc/cache/${BUILD_VICENGINE_FILE}
+rm -f /etc/cache/${BUILD_VICUI_FILE}

--- a/installer/build/scripts/provisioners/provision_harbor.sh
+++ b/installer/build/scripts/provisioners/provision_harbor.sh
@@ -80,3 +80,6 @@ EOF
 # Write version files
 echo "harbor=${BUILD_HARBOR_FILE}" >> /data/version
 echo "harbor=${BUILD_HARBOR_FILE}" >> /etc/vmware/version
+
+# Clean up cache
+rm -f /etc/cache/${BUILD_HARBOR_FILE}

--- a/installer/build/scripts/systemd/scripts/load-docker-images.sh
+++ b/installer/build/scripts/systemd/scripts/load-docker-images.sh
@@ -25,12 +25,9 @@ if [[ ! -f /etc/vmware/firstboot ]]; then
 
   # Load harbor
   echo "Loading Harbor"
-  mkdir -p /tmp/harbor
-  harbor_file=$(ls /etc/cache | grep harbor)
-  cat /etc/cache/${BUILD_HARBOR_FILE} | tar xz -C /tmp/harbor
-  harbor_containers_bundle=$(find /tmp/harbor -size +20M -type f -regextype sed -regex ".*/harbor\..*\.t.*z$")
+  harbor_containers_bundle=$(find /var/tmp/harbor -size +20M -type f -regextype sed -regex ".*/harbor\..*\.t.*z$")
   docker load -i "$harbor_containers_bundle"
-  rm -r /tmp/harbor
+  rm -r /var/tmp/harbor
   rm -r /etc/cache
 
   echo "Loading Admiral"


### PR DESCRIPTION
Clean up cache files to reduce disk space of VIC appliance OVA.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #2326 

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
