### PR TITLE
Remove building Flex Client Plugin

### DIFF
--- a/installer/build/scripts/provisioners/provision_fileserver.sh
+++ b/installer/build/scripts/provisioners/provision_fileserver.sh
@@ -46,13 +46,6 @@ sed -i "s/H5 Client Plugin for vSphere Integrated Containers Engine/vSphere Clie
 zip -9 -r ${VIC_BIN_ROOT}ui/plugin-packages/com.vmware.vic-${VIC_UI_VER_STRING}.zip ./*
 cd ${TMP_FOLDER}
 
-# update plugin-package.xml for Flex Client plugin
-echo "Updating description for Flex Client plugin to \"vSphere Client Plugin for vSphere Integrated Containers Engine (v${VIC_ENGINE_VER_STRING})\""
-cd ${VIC_BIN_ROOT}ui/vsphere-client-serenity/com.vmware.vic.ui-${VIC_UI_VER_STRING}
-sed -i "s/Flex Client Plugin for vSphere Integrated Containers Engine/vSphere Client Plugin for vSphere Integrated Containers Engine \(v${VIC_ENGINE_VER_STRING}\)/" plugin-package.xml 
-zip -9 -r ${VIC_BIN_ROOT}ui/vsphere-client-serenity/com.vmware.vic.ui-${VIC_UI_VER_STRING}.zip ./*
-cd ${TMP_FOLDER}
-
 echo "version from the vic-ui repo is:  ${VIC_UI_VER_STRING}"
 echo "version from vic-engine is:    ${VIC_ENGINE_VER_STRING}"
 


### PR DESCRIPTION
Flex Client Plugin is already removed from vic-ui and should be removed
from build script.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
