### PR TITLE
Revert "Specify components for 1.5.1 release"

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -121,10 +121,6 @@ pipeline:
     privileged: true
     environment:
       TERM: xterm
-      ADMIRAL: v1.5.0
-      VICUI: https://storage.googleapis.com/vic-ui-releases/vic_ui_v1.5.0.tar.gz
-      VICENGINE: https://storage.googleapis.com/vic-engine-releases/vic_v1.5.0.tar.gz
-      VIC_MACHINE_SERVER: v1.5.0
       HARBOR: https://storage.googleapis.com/harbor-releases/release-1.7.0/harbor-offline-installer-v1.7.1.tgz
     secrets:
       - admiral


### PR DESCRIPTION
This reverts commit 791d25d5ec9daf7caf053ec6312e45115a339d2c. We
should get latest components in master branch.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
