### PR TITLE
Support upgrade from 1.5.0 and 1.5.1

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -61,6 +61,7 @@ VER_1_4_2="v1.4.2"
 VER_1_4_3="v1.4.3"
 VER_1_4_4="v1.4.4"
 VER_1_5_0="v1.5.0"
+VER_1_5_1="v1.5.1"
 
 function usage {
     echo -e "Usage: $0 [args...]
@@ -85,7 +86,7 @@ function usage {
       [--appliance-username value]:    Username of the old appliance. (Ignored if --manual-disks is specified.)
       [--appliance-password value]:    Password of the old appliance. (Ignored if --manual-disks is specified.)
       [--appliance-target value]:      IP Address of the old appliance. (Ignored if --manual-disks is specified.)
-      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, v1.4.3, v1.4.4 or v1.5.0.
+      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, v1.4.3, v1.4.4, v1.5.0 or v1.5.1.
 
       [--destroy]:                     Destroy the old appliance after upgrade is finished. (Ignored if --manual-disks is specified.)
       [--manual-disks]:                Skip the automated govc disk migration.
@@ -215,7 +216,7 @@ function enableServicesStart {
   systemctl start harbor.service
 }
 
-### Valid upgrade paths to v1.5.1
+### Valid upgrade paths to v1.5.2
 #   v1.2.1 /data/version has "appliance=v1.2.1"
 #   v1.3.0 /storage/data/version has "appliance=v1.3.0-3033-f8cc7317"
 #   v1.3.1 /storage/data/version has "appliance=v1.3.1-3409-132fb13d"
@@ -225,12 +226,13 @@ function enableServicesStart {
 #   v1.4.3 /storage/data/version
 #   v1.4.4 /storage/data/version
 #   v1.5.0 /storage/data/version
+#   v1.5.1 /storage/data/version
 ###
 function proceedWithUpgrade {
   checkUpgradeStatus "VIC Appliance" ${appliance_upgrade_status}
   local ver="$1"
 
-  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ] || [ "$ver" == "$VER_1_4_2" ] || [ "$ver" == "$VER_1_4_3" ] || [ "$ver" == "$VER_1_4_4" ] || [ "$ver" == "$VER_1_5_0" ]; then
+  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ] || [ "$ver" == "$VER_1_4_2" ] || [ "$ver" == "$VER_1_4_3" ] || [ "$ver" == "$VER_1_4_4" ] || [ "$ver" == "$VER_1_5_0" ] || [ "$ver" == "$VER_1_5_1" ]; then
     log ""
     log "Detected old appliance's version as $ver."
 

--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -60,6 +60,7 @@ VER_1_4_1="v1.4.1"
 VER_1_4_2="v1.4.2"
 VER_1_4_3="v1.4.3"
 VER_1_4_4="v1.4.4"
+VER_1_5_0="v1.5.0"
 
 function usage {
     echo -e "Usage: $0 [args...]
@@ -84,7 +85,7 @@ function usage {
       [--appliance-username value]:    Username of the old appliance. (Ignored if --manual-disks is specified.)
       [--appliance-password value]:    Password of the old appliance. (Ignored if --manual-disks is specified.)
       [--appliance-target value]:      IP Address of the old appliance. (Ignored if --manual-disks is specified.)
-      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, v1.4.3, or v1.4.4.
+      [--appliance-version value]:     Version of the old appliance. v1.2.1, v1.3.0, v1.3.1, v1.4.0, v1.4.1, v1.4.2, v1.4.3, v1.4.4 or v1.5.0.
 
       [--destroy]:                     Destroy the old appliance after upgrade is finished. (Ignored if --manual-disks is specified.)
       [--manual-disks]:                Skip the automated govc disk migration.
@@ -214,7 +215,7 @@ function enableServicesStart {
   systemctl start harbor.service
 }
 
-### Valid upgrade paths to v1.5.0
+### Valid upgrade paths to v1.5.1
 #   v1.2.1 /data/version has "appliance=v1.2.1"
 #   v1.3.0 /storage/data/version has "appliance=v1.3.0-3033-f8cc7317"
 #   v1.3.1 /storage/data/version has "appliance=v1.3.1-3409-132fb13d"
@@ -223,12 +224,13 @@ function enableServicesStart {
 #   v1.4.2 /storage/data/version
 #   v1.4.3 /storage/data/version
 #   v1.4.4 /storage/data/version
+#   v1.5.0 /storage/data/version
 ###
 function proceedWithUpgrade {
   checkUpgradeStatus "VIC Appliance" ${appliance_upgrade_status}
   local ver="$1"
 
-  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ] || [ "$ver" == "$VER_1_4_2" ] || [ "$ver" == "$VER_1_4_3" ] || [ "$ver" == "$VER_1_4_4" ]; then
+  if [ "$ver" == "$VER_1_2_1" ] || [ "$ver" == "$VER_1_3_0" ] || [ "$ver" == "$VER_1_3_1" ] || [ "$ver" == "$VER_1_4_0" ] || [ "$ver" == "$VER_1_4_1" ] || [ "$ver" == "$VER_1_4_2" ] || [ "$ver" == "$VER_1_4_3" ] || [ "$ver" == "$VER_1_4_4" ] || [ "$ver" == "$VER_1_5_0" ]; then
     log ""
     log "Detected old appliance's version as $ver."
 
@@ -650,8 +652,12 @@ function main {
 
   log "\n-------------------------\nStarting Admiral Upgrade ${TIMESTAMP}\n"
   upgradeAdmiral
-  log "\n-------------------------\nStarting Harbor Upgrade ${TIMESTAMP}\n"
-  upgradeHarbor "$ver"
+  # Only upgrade harbor if VIC version is less than 1.5.0
+  major_ver=$(echo ${ver:1:3} | tr -d '.')
+  if [[ "${major_ver}" -lt 15 ]]; then
+    log "\n-------------------------\nStarting Harbor Upgrade ${TIMESTAMP}\n"
+    upgradeHarbor "$ver"
+  fi
 
   setDataVersion
   writeTimestamp ${appliance_upgrade_status}

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -108,7 +108,7 @@ function getApplianceVersion() {
   local VER_1_1_1="v1.1.1"
   local VER_1_2_0="v1.2.0"
   local VER_1_2_1="v1.2.1"
-  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1" "v1.4.2" "v1.4.3" "v1.4.4" "v1.5.0")
+  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1" "v1.4.2" "v1.4.3" "v1.4.4" "v1.5.0" "v1.5.1")
   local COPIED_DIR="$1"
   local ver=""
   local tag=""

--- a/installer/build/scripts/upgrade/util.sh
+++ b/installer/build/scripts/upgrade/util.sh
@@ -108,7 +108,7 @@ function getApplianceVersion() {
   local VER_1_1_1="v1.1.1"
   local VER_1_2_0="v1.2.0"
   local VER_1_2_1="v1.2.1"
-  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1" "v1.4.2" "v1.4.3" "v1.4.4")
+  local VALID_VER=($VER_1_2_1 "v1.3.0" "v1.3.1" "v1.4.0" "v1.4.1" "v1.4.2" "v1.4.3" "v1.4.4" "v1.5.0")
   local COPIED_DIR="$1"
   local ver=""
   local tag=""


### PR DESCRIPTION
Allow upgrade appliance from 1.5.0 and 1.5.1.
Skip harbor upgarde if the appliance version is lower than 1.5.0.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
