### PR TITLE
Upgrade docker to 18.06 on Appliance and DCH

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -265,7 +265,7 @@ pipeline:
       - tests/bundle_dev_builds.sh
     when:
       repo: vmware/vic-product
-      event: [push, tag]
+      event: [push, tag,  pull_request]
       branch: [master, 'releases/*', 'feature/*', 'refs/tags/*']
       status: [success, failure]
 
@@ -322,7 +322,7 @@ pipeline:
     cache_control: 'public,max-age=3600'
     when:
       repo: vmware/vic-product
-      event: [push]
+      event: [push, pull_request]
       branch: [master]
       status: success
 

--- a/dinv/dch-photon-18.06/Dockerfile
+++ b/dinv/dch-photon-18.06/Dockerfile
@@ -1,0 +1,57 @@
+# Build certgen in separate container
+FROM golang:1.8 AS build-env
+# copy the non-version specific files first so version specific can overwrite
+ADD . /go/src/dinv
+ADD ./dch-photon-17.06/* /go/src/dinv/
+RUN cd /go/src/dinv && go get -v ./... && go build -o dinv && strip dinv
+
+# Build photon base image
+FROM photon:2.0 as base
+
+# Create temporary chroot environment
+ENV TEMP_CHROOT /temp_chroot
+
+RUN mkdir /data &&\
+    mkdir $TEMP_CHROOT &&\
+    mkdir -p $TEMP_CHROOT/var/lib/rpm &&\
+    tdnf install -y rpm &&\
+    rpm --root $TEMP_CHROOT/ --initdb &&\
+    rpm --root $TEMP_CHROOT --import /etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
+
+RUN echo "> Installing photon base system in chroot, killing output to avoid offending drone" &&\
+    tdnf --releasever 2.0 --installroot $TEMP_CHROOT/ --refresh install -y \
+    bash-4.4.12-3.ph2 \
+    photon-release-2.0-2.ph2 \
+    photon-repos-2.0-2.ph2 \
+    tdnf-1.2.3-4.ph2 \
+    docker-18.06.2-1.ph2 \
+    procps-ng-3.3.15-2.ph2 \
+    iptables-1.6.1-4.ph2 > /dev/null 2>&1
+
+RUN cp /etc/resolv.conf $TEMP_CHROOT/etc/
+RUN mkdir $TEMP_CHROOT/certs
+COPY --from=build-env /go/src/dinv/dinv $TEMP_CHROOT/
+
+# Cleanup
+RUN cd $TEMP_CHROOT && rm -rf usr/src/ && rm -rf home/* && rm -rf var/log/*
+
+# Build rootfs
+RUN cd $TEMP_CHROOT && cp -pr etc/skel/. root/.
+
+# Build container
+FROM scratch
+
+LABEL maintainer "yifengx@vmware.com"
+
+ENV TERM linux
+
+COPY --from=base /temp_chroot /
+
+EXPOSE 2375 2376
+
+VOLUME /certs
+VOLUME /var/lib/docker
+
+WORKDIR /
+
+ENTRYPOINT [ "/dinv" ]

--- a/installer/build/bootable/build-base.sh
+++ b/installer/build/bootable/build-base.sh
@@ -86,7 +86,7 @@ function set_base() {
     iproute2 iptables iputils \
     cdrkit xfsprogs sudo \
     lvm2 parted gptfdisk \
-    e2fsprogs docker-17.06.0-9.ph2 gzip \
+    e2fsprogs docker-18.06.2-1.ph2 gzip \
     net-tools logrotate sshpass
 
   log3 "installing package dependencies"


### PR DESCRIPTION
Upgrade docker to docker-18.06.2-1.ph2 on Appliance and DCH. This
version include patch for CVE-2019-5736.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
