### PR TITLE
Use offline harbor-migrator image

### DIFF
--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -76,7 +76,8 @@ function checkHarborPSCToken {
 
 # Run the harbor migrator docker image
 function runMigratorCmd {
-  local migrator_image="goharbor/harbor-migrator:v1.7.0"
+  local migrator_image=$(docker images goharbor/harbor-migrator --format "{{.Repository}}:{{.Tag}}")
+  log "harbor-migrator version: ${migrator_image}"
 
   docker run -i \
     -e DB_USR=${DB_USER} \


### PR DESCRIPTION
Since goharbor images has been packed into ova, the upgrader should
use harbor-provided offline image so that upgrade can work without
network connectivity and also can avoid hard-coding image version

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
- [x] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
