### PR TITLE
Use Admiral 1.5.0 for VIC 1.5.2 release

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -121,6 +121,7 @@ pipeline:
     privileged: true
     environment:
       TERM: xterm
+      ADMIRAL: v1.5.0
       HARBOR: https://storage.googleapis.com/harbor-releases/release-1.7.0/harbor-offline-installer-v1.7.1.tgz
     secrets:
       - admiral


### PR DESCRIPTION
Use Admiral 1.5.0 for VIC 1.5.2 release.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
