### PR TITLE
Only migrate Harbor configuration

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -656,9 +656,11 @@ function main {
   upgradeAdmiral
   # Only upgrade harbor if VIC version is less than 1.5.0
   major_ver=$(echo ${ver:1:3} | tr -d '.')
+  log "\n-------------------------\nStarting Harbor Upgrade ${TIMESTAMP}\n"
   if [[ "${major_ver}" -lt 15 ]]; then
-    log "\n-------------------------\nStarting Harbor Upgrade ${TIMESTAMP}\n"
     upgradeHarbor "$ver"
+  else
+    migrateHarborCfg
   fi
 
   setDataVersion


### PR DESCRIPTION
From VIC 1.5.0 Harbor handles db migration by itself so only
configuration migration is required for upgrade.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
