### PR TITLE
Fix backup Harbor database error

### DIFF
--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -76,7 +76,6 @@ function checkHarborPSCToken {
 
 function migrateHarborCfg {
   log "Back up harbor data to : ${harbor_backup}"
-  mkdir -p "${harbor_backup}"
   tar czf "${harbor_backup}/database.tar.gz" "${harbor_database}"
   tar czf "${harbor_backup}/data.tar.gz" "${harbor_data_mount}"
   log "harbor-migrator version: ${harbor_migrator_image}"
@@ -117,6 +116,12 @@ function runMigratorCmd {
 
 # https://github.com/goharbor/harbor/blob/master/docs/migration_guide.md
 function migrateHarbor {
+  major_ver=$(echo ${HARBOR_VER:1:3} | tr -d '.')
+  # Only upgrade harbor configure if VIC version >= 1.5.0
+  if [[ "${major_ver}" -ge 15 ]]; then
+    migrateHarborCfg
+    exit 0
+  fi
   if [ "$HARBOR_VER" == "$VER_1_2_1" ]; then
     harbor_old_database_dir="/storage/data/harbor"
     mkdir -p "${harbor_db_mount}"

--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -654,14 +654,8 @@ function main {
 
   log "\n-------------------------\nStarting Admiral Upgrade ${TIMESTAMP}\n"
   upgradeAdmiral
-  # Only upgrade harbor if VIC version is less than 1.5.0
-  major_ver=$(echo ${ver:1:3} | tr -d '.')
   log "\n-------------------------\nStarting Harbor Upgrade ${TIMESTAMP}\n"
-  if [[ "${major_ver}" -lt 15 ]]; then
-    upgradeHarbor "$ver"
-  else
-    migrateHarborCfg
-  fi
+  upgradeHarbor "$ver"
 
   setDataVersion
   writeTimestamp ${appliance_upgrade_status}


### PR DESCRIPTION
After copying disks from old appliance, vic-appliance.target is
started and dependent harbor.service start is also triggered. Although
stopping harbor.service is issued subsequently but harbor is not up
and it does not take effect. Backing up database files will fail if
DB container is up. Move function migrateHarborCfg into migrateHarbor
so stopping harbor.service is issued again right before backing up
operation.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #2360 

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
