### PR TITLE
Fix notary upgrade failure from harbor 1.4

### DIFF
--- a/installer/build/ova-manifest.json
+++ b/installer/build/ova-manifest.json
@@ -116,6 +116,11 @@
     "destination": "/etc/vmware/upgrade/util.sh"
   },
   {
+    "type": "file",
+    "source": "scripts/upgrade/notary-migration-fix.sh",
+    "destination": "/etc/vmware/upgrade/notary-migration-fix.sh"
+  },
+  {
     "type": "shell",
     "script": "scripts/provisioners/provision_admiral.sh"
   },

--- a/installer/build/scripts/upgrade/notary-migration-fix.sh
+++ b/installer/build/scripts/upgrade/notary-migration-fix.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+# Copyright 2019 VMware, Inc. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file contains patch for upgrading from Harbor 1.4 and below to Harbor 1.7.4.
+
+set -ex
+
+harbor_db_image=$(docker images goharbor/harbor-db --format "{{.Repository}}:{{.Tag}}")
+harbor_db_path="/storage/db/harbor/database/"
+
+launch_db() {
+    docker run -d --name fix-notary-migration -v ${harbor_db_path}:/var/lib/postgresql/data ${harbor_db_image} "postgres"
+}
+
+clean_db() {
+    docker stop fix-notary-migration
+    docker rm fix-notary-migration
+}
+
+wait_for_db_ready() {
+    set +e
+    TIMEOUT=12
+    while [ $TIMEOUT -gt 0 ]; do
+        docker exec fix-notary-migration pg_isready | grep "accepting connections"
+        if [ $? -eq 0 ]; then
+                break
+        fi
+        TIMEOUT=$((TIMEOUT - 1))
+        sleep 5
+    done
+    if [ $TIMEOUT -eq 0 ]; then
+        echo "Harbor DB cannot reach within one minute."
+        clean_db
+        exit 1
+    fi
+    set -e
+}
+
+fix_notary_server() {
+    docker exec fix-notary-migration psql -U postgres -d notaryserver -c "delete from schema_migrations where version > 2 and not exists(select column_name from information_schema.columns where table_name = 'schema_migrations' and column_name = 'dirty');"
+}
+
+fix_notary_signer() {
+    docker exec fix-notary-migration psql -U postgres -d notarysigner -c "delete from schema_migrations where version > 1 and not exists(select column_name from information_schema.columns where table_name = 'schema_migrations' and column_name = 'dirty');"
+}
+
+
+launch_db
+wait_for_db_ready
+fix_notary_server
+fix_notary_signer
+clean_db

--- a/installer/build/scripts/upgrade/upgrade-harbor.sh
+++ b/installer/build/scripts/upgrade/upgrade-harbor.sh
@@ -164,6 +164,10 @@ function migrateHarbor {
     sed -i -r "s/^$cfg_key\s*=/${MANAGED_KEY}\n$cfg_key =/g" $harbor_cfg
   done;
   chmod 600 ${harbor_cfg}
+  # Harbor below 1.5.0 need to run this patch for notary migration
+  if [[ "${major_ver}" -lt 14 ]]; then
+    /etc/vmware/upgrade/notary-migration-fix.sh
+  fi
 }
 
 # Upgrade entry point from upgrade.sh


### PR DESCRIPTION
Fix notary upgrade failure caused by migrating mysql to pqsl.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
