### PR TITLE
Disable reconfigure_token during upgrade

### DIFF
--- a/installer/build/scripts/upgrade/upgrade.sh
+++ b/installer/build/scripts/upgrade/upgrade.sh
@@ -203,8 +203,10 @@ function disableServicesStart {
   log "Disabling and stopping Admiral and Harbor"
   systemctl stop admiral.service
   systemctl stop harbor.service
+  systemctl stop reconfigure_token.path
   systemctl disable admiral.service
   systemctl disable harbor.service
+  systemctl disable reconfigure_token.path
 }
 
 # Enable Admiral and Harbor starting
@@ -212,8 +214,10 @@ function enableServicesStart {
   log "Enabling and starting Admiral and Harbor"
   systemctl enable admiral.service
   systemctl enable harbor.service
+  systemctl enable reconfigure_token.path
   systemctl start admiral.service
   systemctl start harbor.service
+  systemctl start reconfigure_token.path
 }
 
 ### Valid upgrade paths to v1.5.2


### PR DESCRIPTION
If reconfigure_token is enable, it restarts admiral and harbor
services whenever it detects psc-config.properties changed. During
upgrade the new appliance will register itself to PSC and regenerate
psc-config.properties so admiral and harbor are restarted even they
are disabled.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
