### PR TITLE
Remove the space in the custom certificates

### DIFF
--- a/installer/build/scripts/systemd/scripts/vic-appliance-tls.sh
+++ b/installer/build/scripts/systemd/scripts/vic-appliance-tls.sh
@@ -40,7 +40,12 @@ tls_ca_cert="${APPLIANCE_TLS_CA_CERT}"
 function formatCert {
   content=$1
   file=$2
-  echo "$content" | sed -r 's/(-{5}BEGIN [A-Z ]+-{5})/&\n/g; s/(-{5}END [A-Z ]+-{5})/\n&\n/g' | sed -r 's/.{64}/&\n/g; /^\s*$/d' | sed -r '/^$/d' > "$file"
+  # transfer the one line cert content into cert file pattern
+  # The cert pattern from HTML5 and Flex are different
+  # Flex transfers the cert content in one line with no space added
+  # HTML5 tansfers the cert content in one line with one space added
+  # also consider the cert chain scenarios
+  echo "$content" | sed -r 's/(-{5}BEGIN [A-Z ]+-{5})/&\n/g; s/(-{5}END [A-Z ]+-{5})/\n&\n/g' | sed -r 's/^ -/-/g' | sed -r '/(-{5}BEGIN [A-Z ]+-{5})/{n; s/ //g;}' | sed -r 's/.{64}/&\n/g; /^\s*$/d' | sed -r '/^$/d' > "$file"
 }
 
 # Check if private key is valid

--- a/tests/manual-test-cases/Group2-OVA-Features/2-05-Customized-Configurations.robot
+++ b/tests/manual-test-cases/Group2-OVA-Features/2-05-Customized-Configurations.robot
@@ -32,16 +32,58 @@ Setup VC With Static IP
     ${name}=  Evaluate  'vic-2-05-' + str(random.randint(1000,9999))  modules=random
     Nimbus Suite Setup  Create Simple VC Cluster With Static IP  ${name}
 
+Generate CA
+    ${rc}  ${out}=  Run And Return Rc And Output  openssl req -newkey rsa:1024 -nodes -sha256 -keyout ca.key -x509 -days 825 -out ca.crt -subj "/C=US/ST=CA/L=PA/O=VMW/OU=VIC/CN=Testing"
+    Log  ${rc}
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+    ${ca}=  OperatingSystem.Get File  ca.crt
+    # format ca.crt follow HTML5 pattern
+    ${ca}=  Replace String  ${ca}  \n  ${SPACE}
+    Set Suite Variable  ${ca}  ${ca}
+
+Generate OVA Certs
+    [Arguments]  ${ip}
+    ${rc}  ${out}=  Run And Return Rc And Output  openssl req -newkey rsa:1024 -nodes -keyout ova.key -subj "/C=US/ST=CA/L=PA/O=VMW/CN=*.eng.vmware.com" -out ova.csr
+    Log  ${rc}
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0
+    ${key}=  OperatingSystem.Get File  ova.key
+    Log  ${key}
+    # format ova.key follow HTML5 pattern
+    ${key}=  Replace String  ${key}  \n  ${SPACE}
+    Log  ${key}
+    Set Suite Variable  ${key}  ${key}
+
+    Create File  ext.conf  subjectAltName=IP:${ip}"
+    ${rc}  ${out}=  Run And Return Rc And Output  openssl x509 -req -days 825 -in ova.csr -CA ca.crt -CAkey ca.key -CAcreateserial -extfile ext.conf -out ova.crt
+    Log  ${rc}
+    Log  ${out}
+    Should Be Equal As Integers  ${rc}  0  
+    ${rc}  ${out}=  Run And Return Rc And Output  openssl x509 -in ova.crt -noout -text
+    Log  ${out}
+    ${certs}=  OperatingSystem.Get File  ova.crt
+    Log  ${certs}
+    # format ova.crt follow HTML5 pattern
+    ${certs}=  Replace String  ${certs}  \n  ${SPACE}
+    Log  ${certs}
+    Set Suite Variable  ${certs}  ${certs}
+
 *** Test Cases ***
+Generate CA and Certs
+    Generate CA
+    Generate OVA Certs  &{static}[ip]  
+
 Deploy OVA With Customized Configurations
     Log To Console  \nStarting test...
     
     Set Environment Variable  OVA_NAME  OVA-2-05-TEST
     Set Global Variable  ${OVA_USERNAME_ROOT}  root
     Set Global Variable  ${OVA_PASSWORD_ROOT}  e2eFunctionalTest
+    
     # install ova using static ip, remote syslog server TODO: ntp, proxy
-    Install And Initialize VIC Product OVA  vic-*.ova  %{OVA_NAME}  static-ip=&{static}[ip]  netmask=&{static}[netmask]  gateway=&{static}[gateway]  dns=${dns-nimbus}  searchpath=${searchpath-nimbus}  syslog_srv_host=${syslog_srv_host}  syslog_srv_protocol=${syslog_srv_protocol}  syslog_srv_port=${syslog_srv_port}
-
+    Install And Initialize VIC Product OVA  vic-*.ova  %{OVA_NAME}  ${certs}  ${key}  ${ca}  static-ip=&{static}[ip]  netmask=&{static}[netmask]  gateway=&{static}[gateway]  dns=${dns-nimbus}  searchpath=${searchpath-nimbus}  syslog_srv_host=${syslog_srv_host}  syslog_srv_protocol=${syslog_srv_protocol}  syslog_srv_port=${syslog_srv_port}
+    
 Verify Network
     # verify network details
     Verify OVA Network Information  %{OVA_IP}  ${OVA_USERNAME_ROOT}  ${OVA_PASSWORD_ROOT}  &{static}[ip]  &{static}[prefix]  &{static}[gateway]  ${dns-nimbus}  ${searchpath-nimbus}
@@ -64,3 +106,11 @@ Verify Syslog
     Should Match Regexp  ${out}  localhost admiral.* https://%{OVA_IP}:8282.*  msg="Log with Admiral tag"
     Should Match Regexp  ${out}  localhost adminserver  msg="Log with Harbor tag"
     Should Match Regexp  ${out}  localhost vic-machine-server  msg="Log with VIC Machine Server tag"
+
+Verify Custom Certs
+    Wait Until Keyword Succeeds  10x  15s  Verify VIC Appliance TLS Certificates  %{OVA_IP}  issuer=/C=US/ST=CA/L=PA/O=VMW/OU=VIC/CN=Testing
+    Set Global Variable  ${OVA_CERT_PATH}  /storage/data/harbor/ca_download
+    Set Global Variable  ${DEFAULT_LOCAL_DOCKER}  docker
+    Set Global Variable  ${DEFAULT_LOCAL_DOCKER_ENDPOINT}  unix:///var/run/docker.sock
+    Setup CA Cert for Harbor Registry  %{OVA_IP}
+    Wait Until Keyword Succeeds  12x  5s  Docker Login To Harbor Registry  %{OVA_IP}


### PR DESCRIPTION
The custom certificates loaded in vApp through HTML5, has the space in
every 64 chars. Those spaces need to be removed before adding '\n' for
every 64 chars in generating certs

Fix #2173 