### PR TITLE
Increase vic password length in init page

### DIFF
--- a/installer/fileserver/routes/index.go
+++ b/installer/fileserver/routes/index.go
@@ -27,7 +27,7 @@ import (
 )
 
 const inValidVICPwd = "VIC appliance password is incorrect." // #nosec
-const vicPwdMaxLength = 30
+const vicPwdMaxLength = 128
 
 // IndexHTMLOptions contains fields for html templating in index.html
 type IndexHTMLOptions struct {


### PR DESCRIPTION
To be consisent to OVA installer.

Fixes #2443 