### PR TITLE
Note - VIC 1.5.2 & later don't support Flex client

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -26,7 +26,9 @@ If you need to deploy multiple appliances, you can use the initialization API to
 - If you intend to use a custom certificate for the vSphere Integrated Containers appliance, verify that the certificate meets the criteria described in [vSphere Integrated Containers Appliance Certificate Requirements](appliance_cert_reqs.md).
 - If you use vCenter Server 6.7 update 1 or later, you can use the HTML5 vSphere Client to deploy the appliance. If you use an older version of vCenter Server, you must use the Flex-based vSphere Web Client to deploy the appliance. You cannot deploy OVA files from versions of the HTML5 vSphere Client that pre-date vCenter Server 6.7 update 1. 
 
-    **NOTE**: Versions of the HTML5 client that pre-date 6.7 update 1 do not prevent you from deploying OVA files and deployment appears to succeed. However, the resulting appliance [does not function correctly due to an issue with the HTML5 client](ts_reg_doesnt_start.md). This issue is fixed in version 6.7 update 1 of the vSphere Client. 
+    **NOTE**: Versions of the HTML5 client that pre-date 6.7 update 1 do not prevent you from deploying OVA files and deployment appears to succeed. However, the resulting appliance [does not function correctly due to an issue with the HTML5 client](ts_reg_doesnt_start.md). This issue is fixed in version 6.7 update 1 of the vSphere Client.
+    
+    vSphere Integrated Containers 1.5.2 and later versions do not include the Flex-based vSphere Web Client.
 
 ## Procedure 1: Deploy the OVA
 

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -16,6 +16,8 @@ By default, the vSphere Integrated Containers plug-in for the vSphere Client is 
 - A plug-in for the HTML5 vSphere Client on vCenter Server 6.5 and 6.7. The HTML5 plug-in allows you to to deploy and interact with virtual container hosts (VCHs) directly in the vSphere Client.
 - A basic informational plug-in for the Flex-based vSphere Web Client on vCenter Server 6.0. 
 
+    **NOTE**: vSphere Integrated Containers 1.5.2 and later versions do not include the Flex-based vSphere Web Client.
+
 If you need to deploy multiple appliances, you can use the initialization API to initialize appliances without manual intervention. For information about the initialization API, see [Initialize the Appliance by Using the Initialization API](ova_reg_api.md).
 
 ## Prerequisites
@@ -27,8 +29,6 @@ If you need to deploy multiple appliances, you can use the initialization API to
 - If you use vCenter Server 6.7 update 1 or later, you can use the HTML5 vSphere Client to deploy the appliance. If you use an older version of vCenter Server, you must use the Flex-based vSphere Web Client to deploy the appliance. You cannot deploy OVA files from versions of the HTML5 vSphere Client that pre-date vCenter Server 6.7 update 1. 
 
     **NOTE**: Versions of the HTML5 client that pre-date 6.7 update 1 do not prevent you from deploying OVA files and deployment appears to succeed. However, the resulting appliance [does not function correctly due to an issue with the HTML5 client](ts_reg_doesnt_start.md). This issue is fixed in version 6.7 update 1 of the vSphere Client.
-    
-    vSphere Integrated Containers 1.5.2 and later versions do not include the Flex-based vSphere Web Client.
 
 ## Procedure 1: Deploy the OVA
 

--- a/docs/user_doc/vic_vsphere_admin/vch_admin_client.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_admin_client.md
@@ -4,5 +4,7 @@ vSphere Integrated Containers provides a plug-in for the HTML5 vSphere Client on
 
 vSphere Integrated Containers also provides a basic informational plug-in for the Flex-based vSphere Web Client on vCenter Server 6.0.  
 
+**NOTE**: vSphere Integrated Containers 1.5.2 and later versions do not include the Flex-based vSphere Web Client.
+
 * [View All VCH and Container Information](access_h5_ui.md)
 * [View Individual VCH and Container Information](vch_portlet_ui.md)

--- a/docs/user_doc/vic_vsphere_admin/vch_portlet_ui.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_portlet_ui.md
@@ -12,6 +12,8 @@ After you have installed the client plug-in for vSphere Integrated Containers, y
   - The vSphere Integrated Containers plug-in for the HTML5 vSphere Client plug-in is available in vSphere 6.5 and 6.7.
   - The vSphere Integrated Containers plug-in for the Flex-based vSphere  Web Client is available in vSphere 6.0.
 
+**NOTE**: vSphere Integrated Containers 1.5.2 and later versions do not include the Flex-based vSphere Web Client.
+
 ## Procedure
 
 1. Log in to the vSphere Client.


### PR DESCRIPTION
Hi @stuclem ,

I added a note to say that VIC 1.5.2 and later versions don't include the Flex client.
Do I have to add the note in all topics that mention the Flex client?

Fixes #2429 

Thanks,
Vidya
