### PR TITLE
Mount nfs

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/vch_install_packages.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_install_packages.md
@@ -4,44 +4,9 @@ In certain circumstances, you might need to install a capability in the virtual 
 
 The VCH endpoint VM runs [Photon OS 2.0](https://vmware.github.io/photon/). Photon OS provides a package manager named Tiny DNF, or `tdnf`, that is the default means of installing packages. For information about Tiny DNF, see [Tiny DNF for Package Management](https://vmware.github.io/photon/assets/files/html/1.0-2.0/tdnf.html) in the *Photon OS Administration Guide*. 
 
-Before you can use Tiny DNF to install packages in the endpoint VM, you must run the `rpm --rebuilddb` command to rebuild the embedded database. To run `rpm --rebuilddb`, you must first modify the Photon OS configuration to satisfy certain dependencies that are not present in the VCH endpoint VM by default. If you do not successfully run `rpm --rebuilddb`, attempts to run certain Tiny DNF commands in the endpoint VM result in the following error:
-
-<pre>
-root@ [ ~ ]# tdnf info
-Error(1304) : Hawkey - I/O error
-</pre>
-
-**IMPORTANT**: Any changes that you make to the VCH endpoint VM, including installing packages, are non-persistent and are lost if the endpoint VM reboots.
-
-## Prerequisite
-
-- Enable SSH access to the VCH endpoint VM. For information about enabling SSH access, see [Debug Running Virtual Container Hosts](debug_vch.md).
-- Ensure that the VCH can access the Photon OS repositories at https://vmware.bintray.com/, either via the Internet or via a mirror on the local network.
-
-## Procedure
-
-1. Use SSH to connect to the VCH endpoint VM as `root` user.
-2. Open the Photon OS updates repository configuration file in a text editor.<pre>vi /etc/yum.repos.d/photon-updates-local.repo</pre>
-3.  Update the entry for the repository URL and save the change.<pre>baseurl=https://vmware.bintray.com/photon_updates_1.0_x86_64/</pre>
-4.  Open the Photon OS repository configuration file in a text editor.<pre>vi /etc/yum.repos.d/photon-local.repo</pre>
-5.  Update the entry for the repository URL and save the change.<pre>baseurl=https://vmware.bintray.com/photon_release_1.0_x86_64/</pre>
-6. Create a folder for `rpm` and initialize the `rpm` database.
-
-    1. `mkdir /root/rpm`
-    2. `rpm --root /root/rpm -initdb`
-7. Install the dependencies that Tiny DNF requires to install packages.<pre>tdnf --installroot /root/rpm --nogpgcheck install haveged systemd openssh iptables e2fsprogs procps-ng iputils iproute2 iptables net-tools sudo tdnf vim gzip lsof logrotate photon-release</pre>
-8. Copy the `/root/rpm/var/lib/rpm/Packages` file to the following location.<pre>cp /root/rpm/var/lib/rpm/Packages /var/lib/rpm/Packages</pre>
-9. Run the command to rebuild the database in the endpoint VM.<pre>rpm --rebuilddb</pre>
-3. Run a Tiny DNF command to test the reconfiguration.<pre>tdnf list installed</pre>The `tdnf list installed` command should display information about the installed packages. 
-
-## Result
-
-You can now use Tiny DNF to install new packages in the VCH endpoint VM.
-
 **IMPORTANT**: 
 
-- Any installations and configurations that you perform by using Tiny DNF in the endpoint VM do not persist if you reboot the endpoint VM.
-- Running `rpm --rebuilddb` results in an unpopulated database. Consequently, when you use Tiny DNF to install a package, it tries to install all of the dependencies for that package in the endpoint VM, even if those dependencies are already present.
+Any installations and configurations that you perform by using Tiny DNF in the endpoint VM do not persist if you reboot the endpoint VM.
 
 ## What to Do Next
 

--- a/docs/user_doc/vic_vsphere_admin/vch_mount_nfsshare.md
+++ b/docs/user_doc/vic_vsphere_admin/vch_mount_nfsshare.md
@@ -28,7 +28,7 @@ If you deploy VCHs that use NFS share points as volume stores, you can test  the
            `-1028 /usr/sbin/rpcbind -w
 Mar 06 16:15:17 Linux systemd[1]: Starting RPC Bind Service...
 Mar 06 16:15:17 Linux systemd[1]: Started RPC Bind Service.</pre>
-5. Mount the NFS share point in the VCH endpoint VM.<pre>mount -t nfs <i>nfs_sharepoint_url</i> -o vers=3</pre>For information about how to specify the NFS sharepoint URL, see the description of the `vic-machine create --volume-store` option in [Specify Volume Datastores](volume_stores.md#nfsoptions).
+5. Mount the NFS share point in the VCH endpoint VM.<pre>mount.nfs <i>nfs_sharepoint_url</i> -o vers=3</pre>For information about how to specify the NFS sharepoint URL, see the description of the `vic-machine create --volume-store` option in [Specify Volume Datastores](volume_stores.md#nfsoptions).
 
 ## Result
 

--- a/docs/user_doc/vic_vsphere_admin/volume_stores.md
+++ b/docs/user_doc/vic_vsphere_admin/volume_stores.md
@@ -142,6 +142,7 @@ You can also specify the URL, UID, and GID of a shared NFS mount point when you 
 - If your NFS server uses a different `anon` UID/GID to the default, you must specify the UID/GID in the `--volume-store` option. Configuring a VCH to use a different default `anon` UID/GID for NFS volume stores is not supported. For containers, the user that is running the process in the container needs to have the correct permissions on the mount to read and write.
 - vSphere Integrated Containers mounts NFS volumes as `root`. Consequently, if you specify a UID/GID, it must be valid for `root`. Additionally, if containers are to run as non-root users, the export of the volume must grant the correct permissions to the non-root users so that they can access the volume store.
 - For more information about the preceding points, see [About NFS Volume Stores and Permissions](#nfs_perms) above.
+- To test the connections to NFS share points, you can mount the NFS server from within the VCH endpoint VM. For more information, see [Mount an NFS Share Point in the VCH Endpoint VM](vch_mount_nfsshare.md).
 
 Use the label `default` to allow container developers to create anonymous volumes:
 


### PR DESCRIPTION
Hi @jitinkumar2018 and @stuclem 

I have made the following updates:
- Updated the mount command.
- Added a reference to testing the connection between the VCH and NFS server.
- Updated the _Install Packages in VCH_ topic. We no longer have to run the `rpm --rebuilddb` command to rebuild the embedded database before using Tiny DNF to install packages. 

Fixes #2455 and #2410 

Request your review. 

Thanks,
Vidya