### PR TITLE
Updated password length

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -46,7 +46,7 @@ You can also deploy the vSphere Integrated Containers Appliance using the `ovfto
 
 3. On the **Customize template** page, expand **Appliance Configuration**.
 
-    - Set the root password for the appliance VM. Setting the root password for the appliance is mandatory. The root password cannot exceed 30 characters. In vSphere Integrated Containers 1.5.3 and later versions, the password cannot exceed 128 characters.
+    - Set the root password for the appliance VM. Setting the root password for the appliance is mandatory. In vSphere Integrated Containers 1.5.3 and later versions, the root password cannot exceed 128 characters. In earlier versions, the root password cannot exceed 30 characters.  
     - Optionally uncheck the **Permit Root Login** checkbox.
   
     **IMPORTANT**: You require SSH access to the vSphere Integrated Containers appliance to perform upgrades. You can also use SSH access in exceptional cases that you cannot handle through standard remote management or CLI tools. Only use SSH to access the appliance when instructed to do so in the documentation, or under the guidance of VMware GSS.

--- a/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
+++ b/docs/user_doc/vic_vsphere_admin/deploy_vic_appliance.md
@@ -46,7 +46,7 @@ You can also deploy the vSphere Integrated Containers Appliance using the `ovfto
 
 3. On the **Customize template** page, expand **Appliance Configuration**.
 
-    - Set the root password for the appliance VM. Setting the root password for the appliance is mandatory. The root password cannot exceed 30 characters.
+    - Set the root password for the appliance VM. Setting the root password for the appliance is mandatory. The root password cannot exceed 30 characters. In vSphere Integrated Containers 1.5.3 and later versions, the password cannot exceed 128 characters.
     - Optionally uncheck the **Permit Root Login** checkbox.
   
     **IMPORTANT**: You require SSH access to the vSphere Integrated Containers appliance to perform upgrades. You can also use SSH access in exceptional cases that you cannot handle through standard remote management or CLI tools. Only use SSH to access the appliance when instructed to do so in the documentation, or under the guidance of VMware GSS.


### PR DESCRIPTION
Updated https://vmware.github.io/vic-product/assets/files/html/latest/vic_vsphere_admin/deploy_vic_appliance.html to say that VIC 1.5.3 and later versions have a limit of 128 characters.
Fixes #2447 

@stuclem , can you please review this?

Thanks,
Vidya


