### PR TITLE
Updating OSL to including info of fixing the CVE-2019-1147

### DIFF
--- a/installer/fileserver/files/open_source_license.txt
+++ b/installer/fileserver/files/open_source_license.txt
@@ -10,10 +10,10 @@ vSphere Integrated Containers 1.5.3 GA
 
 This product is licensed to you under the Apache License version 2.0 
 (the "License"). You may not use this product except in compliance 
-with the License. 
+with the License.
 
 						Apache License
-                     Version 2.0, January 2004
+                    Version 2.0, January 2004
                   http://www.apache.org/licenses/
 
 TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
@@ -593,12 +593,12 @@ SECTION 2: Apache License, V2.0
 SECTION 3: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
 
    >>> bzip2-1.0.6-8.ph2
-   >>> curl-7.59.0-6.ph2
+   >>> curl-7.59.0-7.ph2
    >>> expat-2.2.4-1.ph2
    >>> iana-etc-2.30-2.ph2
    >>> iputils-20151218-4.ph2
-   >>> krb5-1.16-2.ph2
-   >>> libarchive-3.3.1-3.ph2
+   >>> krb5-1.17-1.ph2
+   >>> libarchive-3.3.1-4.ph2
    >>> libcap-2.25-7.ph2
    >>> libdb-5.3.28-1.ph2
    >>> libevent-2.1.8-1.ph2
@@ -611,20 +611,20 @@ SECTION 3: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
    >>> libtirpc-1.0.1-8.ph2
    >>> linux-pam-1.3.0-1.ph2
    >>> ncurses-6.0-14.ph2
-   >>> openssh-7.5p1-13.ph2
-   >>> openssl-1.0.2r-1.ph2
+   >>> openssh-7.5p1-14.ph2
+   >>> openssl-1.0.2s-1.ph2
    >>> pcre-8.41-1.ph2
    >>> popt-1.16-5.ph2
    >>> python-pip-9.0.1-6.ph2
    >>> python-setuptools-36.0.1-1.ph2
-   >>> python2-2.7.15-5.ph2
-   >>> python3-3.6.5-5.ph2
+   >>> python2-2.7.15-8.ph2
+   >>> python3-3.6.5-7.ph2
    >>> rpcbind-0.2.4-5.ph2
    >>> shadow-4.2.1-16.ph2
-   >>> sqlite-3.27.2-2.ph2
+   >>> sqlite-3.27.2-3.ph2
    >>> sudo-1.8.20p2-5.ph2
-   >>> tzdata-2017b-3.ph2
-   >>> vim-8.0.0533-6.ph2
+   >>> tzdata-2019a-1.ph2
+   >>> vim-8.0.0533-7.ph2
    >>> xz-5.2.3-2.ph2
    >>> zip-3.0-2.ph2
    >>> zlib-1.2.11-1.ph2
@@ -640,6 +640,7 @@ SECTION 5: GNU General Public License, V2.0
 
    >>> apparmor-2.13-4.ph2
    >>> bc-1.06.95-3.ph2
+   >>> ca-certificates-20190521-1.ph2
    >>> cdrkit-1.1.11-4.ph2
    >>> chkconfig-1.9-1.ph2
    >>> dracut-045-5.ph2
@@ -653,13 +654,13 @@ SECTION 5: GNU General Public License, V2.0
    >>> iptables-1.6.1-4.ph2
    >>> keyutils-1.5.10-1.ph2
    >>> libtool-2.4.6-3.ph2
-   >>> linux-esx-4.9.173-2.ph2
+   >>> linux-esx-4.9.182-1.ph2
    >>> logrotate-3.11.0-3.ph2
    >>> lvm2-2.02.171-3.ph2
    >>> motd-0.1.3-5.ph2
    >>> net-tools-1.60-11.ph2
    >>> nfs-utils-2.3.1-2.ph2
-   >>> openjdk8-1.8.0.212-1.ph2
+   >>> openjdk8-1.8.0.212-2.ph2
    >>> perl-yaml-1.23-1.ph2
    >>> pkg-config-0.29.2-2.ph2
    >>> procps-ng-3.3.15-2.ph2
@@ -678,7 +679,7 @@ SECTION 6: GNU General Public License, V3.0
    >>> cifs-utils-6.7-1.ph2
    >>> coreutils-8.27-3.ph2
    >>> cpio-2.12-4.ph2
-   >>> elfutils-0.169-3.ph2
+   >>> elfutils-0.176-1.ph2
    >>> findutils-4.6.0-4.ph2
    >>> gawk-4.1.4-1.ph2
    >>> gdbm-1.13-3.ph2
@@ -691,7 +692,7 @@ SECTION 6: GNU General Public License, V3.0
    >>> readline-7.0-2.ph2
    >>> rsyslog-8.26.0-7.ph2
    >>> sed-4.4-3.ph2
-   >>> tar-1.29-2.ph2
+   >>> tar-1.29-3.ph2
    >>> which-2.21-5.ph2
    >>> xfsprogs-4.10.0-3.ph2
 
@@ -722,15 +723,14 @@ SECTION 8: GNU Lesser General Public License, V3.0
 
 SECTION 9: GNU Library General Public License, V2.0
 
-   >>> glib-2.52.1-3.ph2
+   >>> glib-2.52.1-4.ph2
    >>> newt-0.52.20-1.ph2
 
 
 SECTION 10: Mozilla Public License, V2.0
 
-   >>> ca-certificates-20190509-1.ph2
-   >>> nspr-4.15-1.ph2
-   >>> nss-3.31.1-1.ph2
+   >>> nspr-4.21-1.ph2
+   >>> nss-3.44-1.ph2
 
 
 PART 3. VIRTUAL APPLIANCE: OPERATING SYSTEM LAYER PHOTON#1
@@ -860,6 +860,104 @@ SECTION 9: Mozilla Public License, V2.0
    >>> nspr-4.15-1.ph2
    >>> nss-3.31.1-1.ph2
 
+   
+PART 4. VIRTUAL APPLIANCE: OPERATING SYSTEM LAYER PHOTON#2
+
+
+SECTION 1: Academic Free License, V2.1
+
+   >>> dbus-1.11.12-1.ph2
+
+
+SECTION 2: Apache License, V2.0
+
+   >>> filesystem-1.1-3.ph2
+   >>> photon-release-2.0-2.ph2
+
+
+SECTION 3: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES
+
+   >>> bzip2-1.0.6-8.ph2
+   >>> curl-7.59.0-7.ph2
+   >>> expat-2.2.4-1.ph2
+   >>> iputils-20151218-4.ph2
+   >>> krb5-1.17-1.ph2
+   >>> libarchive-3.3.1-4.ph2
+   >>> libcap-2.25-7.ph2
+   >>> libdb-5.3.28-1.ph2
+   >>> libffi-3.2.1-5.ph2
+   >>> libsolv-0.6.26-4.ph2
+   >>> libssh2-1.8.2-1.ph2
+   >>> libtirpc-1.0.1-8.ph2
+   >>> linux-pam-1.3.0-1.ph2
+   >>> lsof-4.89-2.ph2
+   >>> ncurses-6.0-14.ph2
+   >>> openssh-7.5p1-14.ph2
+   >>> openssl-1.0.2s-1.ph2
+   >>> pcre-8.41-1.ph2
+   >>> popt-1.16-5.ph2
+   >>> shadow-4.2.1-16.ph2
+   >>> sqlite-3.27.2-3.ph2
+   >>> sudo-1.8.20p2-5.ph2
+   >>> vim-8.0.0533-7.ph2
+   >>> xz-5.2.3-2.ph2
+   >>> zlib-1.2.11-1.ph2
+
+
+SECTION 4: GNU General Public License, V2.0
+
+   >>> ca-certificates-20190521-1.ph2
+   >>> e2fsprogs-1.43.4-2.ph2
+   >>> gcc-6.3.0-7.ph2
+   >>> iproute2-4.10.0-4.ph2
+   >>> iptables-1.6.1-4.ph2
+   >>> linux-esx-4.9.182-1.ph2
+   >>> logrotate-3.11.0-3.ph2
+   >>> mingetty-1.08-2.ph2
+   >>> net-tools-1.60-11.ph2
+   >>> procps-ng-3.3.15-2.ph2
+   >>> rpm-4.13.0.2-1.ph2
+   >>> tdnf-1.2.3-8.ph2
+   >>> util-linux-2.32-1.ph2
+
+
+SECTION 5: GNU General Public License, V3.0
+
+   >>> bash-4.4.12-3.ph2
+   >>> coreutils-8.27-3.ph2
+   >>> elfutils-0.176-1.ph2
+   >>> grep-3.0-4.ph2
+   >>> gzip-1.8-1.ph2
+   >>> haveged-1.9.1-4.ph2
+   >>> readline-7.0-2.ph2
+
+
+SECTION 6: GNU Lesser General Public License, V2.1
+
+   >>> cracklib-2.9.6-8.ph2
+   >>> glibc-2.26-16.ph2
+   >>> hawkey-2017.1-6.ph2
+   >>> kmod-24-3.ph2
+   >>> libgcrypt-1.8.1-2.ph2
+   >>> libgpg-error-1.27-1.ph2
+   >>> systemd-233-19.ph2
+
+
+SECTION 7: GNU Lesser General Public License, V3.0
+
+   >>> gmp-6.1.2-2.ph2
+
+
+SECTION 8: GNU Library General Public License, V2.0
+
+   >>> glib-2.52.1-4.ph2
+
+
+SECTION 9: Mozilla Public License, V2.0
+
+   >>> nspr-4.21-1.ph2
+   >>> nss-3.44-1.ph2
+
 
 APPENDIX. Standard License Files
 
@@ -924,7 +1022,8 @@ APPENDIX. Standard License Files
    >>> GNU AFFERO GENERAL PUBLIC LICENSE 3.0
 
 
-==================== PART 1. VIRTUAL APPLIANCE: APPLICATION LAYER ====================
+
+==================== PART 1. VIRTUAL APPLIANCE: APPLICATION LAYER====================
 
 
 --------------- SECTION 1: Apache License, V2.0 ----------
@@ -14473,6 +14572,7 @@ LICENSE: MPL 2.0
 
 License: MPL 2.0
 
+
 ==================== PART 2. VIRTUAL APPLIANCE: OPERATING SYSTEM LAYER PHOTON ====================
 
 
@@ -14947,7 +15047,7 @@ http://www.bzip.org/downloads.html
 For more information about bzip2, please visit:
 http://www.bzip.org/
 
->>> curl-7.59.0-6.ph2
+>>> curl-7.59.0-7.ph2
 
 LICENSE: MIT
 
@@ -15116,34 +15216,34 @@ Sun Microsystems, Inc.
 2550 Garcia Avenue
 Mountain View, California  94043.
 
->>> krb5-1.16-2.ph2
+>>> krb5-1.17-1.ph2
 
-Copyright (c) 2004 Sun Microsystems, Inc.
+Copyright 1993 by OpenVision Technologies, Inc.
 
-Permission is hereby granted, free of charge, to any person obtaining a
-copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
+Permission to use, copy, modify, distribute, and sell this software
+and its documentation for any purpose is hereby granted without fee,
+provided that the above copyright notice appears in all copies and
+that both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of OpenVision not be used
+in advertising or publicity pertaining to distribution of the software
+without specific, written prior permission. OpenVision makes no
+representations about the suitability of this software for any
+purpose.  It is provided "as is" without express or implied warranty.
 
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
-OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
+OPENVISION DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL OPENVISION BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
 
 ADDITIONAL LICENSE INFORMATION:
 
 
-Copyright (C) 1985-2017 by the Massachusetts Institute of Technology.
+krb5-1.17-1.ph2.src.rpm\krb5-1.17-1.ph2.src.cpio\krb5-1.17.tar.gz\krb5-1.17.tar\krb5-1.17\NOTICE
+
+Copyright (C) 1985-2015 by the Massachusetts Institute of Technology.
 
 All rights reserved.
 
@@ -15151,10 +15251,10 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
 
-Redistributions of source code must retain the above copyright
+* Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
 
-Redistributions in binary form must reproduce the above copyright
+* Redistributions in binary form must reproduce the above copyright
 notice, this list of conditions and the following disclaimer in the
 documentation and/or other materials provided with the distribution.
 
@@ -15320,15 +15420,15 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
 
-Redistributions of source code must retain the above copyright
+* Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
 
-Redistributions in binary form must reproduce the above copyright
+* Redistributions in binary form must reproduce the above copyright
 notice, this list of conditions and the following disclaimer in
 the documentation and/or other materials provided with the
 distribution.
 
-Neither the name of Red Hat, Inc., nor the names of its
+* Neither the name of Red Hat, Inc., nor the names of its
 contributors may be used to endorse or promote products derived
 from this software without specific prior written permission.
 
@@ -15370,38 +15470,6 @@ HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
 WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
 OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 DEALINGS IN THE SOFTWARE.
-
-======================================================================
-
-The MS-KKDCP client implementation has the following copyright:
-
-Copyright 2013,2014 Red Hat, Inc.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above
-copyright notice, this list of conditions and the following
-disclaimer.
-
-2. Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following
-disclaimer in the documentation and/or other materials
-provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ======================================================================
 
@@ -15533,15 +15601,15 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
 
-Redistributions of source code must retain the above copyright
+* Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
 
-Redistributions in binary form must reproduce the above copyright
+* Redistributions in binary form must reproduce the above copyright
 notice, this list of conditions and the following disclaimer in
 the documentation and/or other materials provided with the
 distribution.
 
-The copyright holder's name is not used to endorse or promote
+* The copyright holder's name is not used to endorse or promote
 products derived from this software without specific prior
 written permission.
 
@@ -15718,47 +15786,6 @@ ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
 THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
 PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL KTH OR ITS
 CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
-USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
-OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
-======================================================================
-
-The KCM Mach RPC definition file used on macOS has the following
-copyright:
-
-Copyright (C) 2009 Kungliga Tekniska HÃ¶gskola
-(Royal Institute of Technology, Stockholm, Sweden).
-All rights reserved.
-
-Portions Copyright (C) 2009 Apple Inc. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above
-copyright notice, this list of conditions and the following
-disclaimer.
-
-2. Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following
-disclaimer in the documentation and/or other materials provided
-with the distribution.
-
-3. Neither the name of the Institute nor the names of its
-contributors may be used to endorse or promote products derived
-from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
-TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
-PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE
-OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
 SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
 LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
 USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
@@ -16359,10 +16386,10 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
 
-Redistributions of source code must retain the above copyright
+* Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
 
-Redistributions in binary form must reproduce the above copyright
+* Redistributions in binary form must reproduce the above copyright
 notice, this list of conditions and the following disclaimer in
 the documentation and/or other materials provided with the
 distribution.
@@ -16404,15 +16431,15 @@ Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
 
-Redistributions of source code must retain the above copyright
+* Redistributions of source code must retain the above copyright
 notice, this list of conditions and the following disclaimer.
 
-Redistributions in binary form must reproduce the above
+* Redistributions in binary form must reproduce the above
 copyright notice, this list of conditions and the following
 disclaimer in the documentation and/or other materials
 provided with the distribution.
 
-Neither the name of Intel Corporation nor the names of its
+* Neither the name of Intel Corporation nor the names of its
 contributors may be used to endorse or promote products
 derived from this software without specific prior written
 permission.
@@ -16430,95 +16457,39 @@ STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
 
-======================================================================
 
-The following notice applies to
-"src/ccapi/common/win/OldCC/autolock.hxx":
+> GPL 2.0
 
-Copyright (C) 1998 by Danilo Almeida.  All rights reserved.
+krb5-1.17-1.ph2.src.rpm\krb5-1.17-1.ph2.src.cpio\krb5-1.17.tar.gz\krb5-1.17.tar\krb5-1.17\src\util\send-pr\send-pr.1
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
+man page for send-pr (by Heinz G. Seidl, hgs@cygnus.com)
+updated Feb 1993 for GNATS 3.00 by Jeffrey Osier, jeffrey@cygnus.com
 
-Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
+This file is part of the Problem Report Management System (GNATS)
+Copyright 1992 Cygnus Support
 
-Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following
-disclaimer in the documentation and/or other materials provided
-with the distribution.
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
 
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-OF THE POSSIBILITY OF SUCH DAMAGE.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
 
-ADDITIONAL LICENSE INFORMATION:
+You should have received a copy of the GNU Library General Public
+License along with this program; if not, write to the Free
+Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA
 
-> LPPL 1.3c
-
-krb5-1.16-2.ph2.src.rpm\krb5-1.16-2.ph2.src.cpio\krb5-1.16.tar.gz\krb5-1.16.tar\krb5-1.16\doc\pdf\tabulary.sty
-
-
-Copyright (C) 1995 1996 2003 2008 David Carlisle
-This file may be distributed under the terms of the LPPL.
-See 00readme.txt for details.
-
-
-> BSD- 4 Clause
-
-
-krb5-1.16-2.ph2.src.rpm\krb5-1.16-2.ph2.src.cpio\krb5-1.16.tar.gz\krb5-1.16.tar\krb5-1.16\src\lib\apputils\daemon.c
-
-
-Copyright (c) 1990 The Regents of the University of California.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software
-must display the following acknowledgement:
-This product includes software developed by the University of
-California, Berkeley and its contributors.
-4. Neither the name of the University nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
 
 > Public Domain
 
-krb5-1.16-2.ph2.src.rpm\krb5-1.16-2.ph2.src.cpio\krb5-1.16.tar.gz\krb5-1.16.tar\krb5-1.16\src\lib\krb5\rcache\rc_base.c
+krb5-1.17-1.ph2.src.rpm\krb5-1.17-1.ph2.src.cpio\krb5-1.17.tar.gz\krb5-1.17.tar\krb5-1.17\src\util\support\gmt_mktime.c
 
-This file of the Kerberos V5 software is derived from public-domain code
-contributed by Daniel J. Bernstein, <brnstnd@acf10.nyu.edu>.
+This code placed in the public domain by Mark W. Eichin
 
->>> libarchive-3.3.1-3.ph2
+>>> libarchive-3.3.1-4.ph2
 
 Copyright (c) 2003-2009 <author(s)>
 All rights reserved.
@@ -16546,7 +16517,18 @@ THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 ADDITIONAL LICENSE INFORMATION:
 
-> Apache2.0
+>MIT Style
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\build\autoconf\ax_require_defined.m4
+
+Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+
+Copying and distribution of this file, with or without modification, are
+permitted in any medium without royalty provided the copyright notice
+and this notice are preserved. This file is offered as-is, without any
+warranty.
+
+>Apache 2.0
 
 libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\contrib\android\Android.mk
 
@@ -16564,38 +16546,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 
-> BSD-3
-
-libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\libarchive\mtree.5
-
-Copyright (c) 1989, 1990, 1993
-The Regents of the University of California.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-4. Neither the name of the University nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
-> BSD-4
+>BSD – 4Clause
 
 libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\contrib\shar\shar.1
 
@@ -16630,18 +16581,7 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
-> MIT
-
-libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\build\autoconf\ax_require_defined.m4
-
-Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
-
-Copying and distribution of this file, with or without modification, are
-permitted in any medium without royalty provided the copyright notice
-and this notice are preserved. This file is offered as-is, without any
-warranty.
-
-> MIT
+>MIT
 
 libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\doc\mdoc2man.awk
 
@@ -16659,7 +16599,7 @@ WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
 ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-> PublicDomain
+>Public Domain
 
 libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\libarchive\archive_getdate.c
 
@@ -16674,6 +16614,37 @@ work to the public domain, I feel compelled to match their
 generosity.
 
 Tim Kientzle, February 2009.
+
+>BSD – 3Clause
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\libarchive\mtree.5
+
+Copyright (c) 1989, 1990, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
 
 >>> libcap-2.25-7.ph2
 
@@ -17825,7 +17796,7 @@ Public License can be found in '/usr/share/common-licenses/GPL-2'
 
 -- vile: txtmode file-encoding=utf-8
 
->>> openssh-7.5p1-13.ph2
+>>> openssh-7.5p1-14.ph2
 
 This file is part of the OpenSSH software.
 
@@ -18165,10 +18136,10 @@ authorization.
 ------
 $OpenBSD: LICENCE,v 1.19 2004/08/30 09:18:08 markus Exp $
 
->>> openssl-1.0.2r-1.ph2
+>>> openssl-1.0.2s-1.ph2
 
 LICENSE ISSUES
-==============
+
 
 The OpenSSL toolkit stays under a double license, i.e. both the conditions of
 the OpenSSL License and the original SSLeay license apply to the toolkit.
@@ -18177,10 +18148,8 @@ Open Source licenses. In case of any license issues related to OpenSSL
 please contact openssl-core@openssl.org.
 
 OpenSSL License
----------------
 
-====================================================================
-Copyright (c) 1998-2016 The OpenSSL Project.  All rights reserved.
+Copyright (c) 1998-2018 The OpenSSL Project.  All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
@@ -18225,16 +18194,18 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================
+
 
 This product includes cryptographic software written by Eric Young
 (eay@cryptsoft.com).  This product includes software written by Tim
 Hudson (tjh@cryptsoft.com).
 
-Original SSLeay License
------------------------
 
-Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+
+Original SSLeay License
+
+
+ Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
 All rights reserved.
 
 This package is an SSL implementation written
@@ -18294,9 +18265,11 @@ ADDITIONAL LICENSE INFORMATION:
 
 > Apache2.0
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\crypto\ec\ecp_nistputil.c
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\ec\ec_curve.c
 
-Copyright 2011 Google Inc.
+Written by Bodo Moeller for the OpenSSL project.
+/
+/ Copyright 2011 Google Inc.
 
 Licensed under the Apache License, Version 2.0 (the "License");
 
@@ -18313,7 +18286,7 @@ limitations under the License.
 
 > BSD
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\crypto\camellia\asm\cmll-x86_64.pl
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\camellia\asm\ cmll-x86_64.pl
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
@@ -18328,7 +18301,7 @@ http://www.openssl.org/~appro/camellia/.
 
 > BSD-2
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\crypto\seed\seed.c
+openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\seed\seed.c
 
 Copyright (c) 2007 KISA(Korea Information Security Agency). All rights reserved.
 
@@ -18355,9 +18328,9 @@ SUCH DAMAGE.
 
 > BSD-3
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\crypto\x509v3\v3_pci.c
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\x509v3\ v3_pci.c
 
-Copyright (c) 2004 Kungliga Tekniska HÃ¶gskolan
+Copyright (c) 2004 Kungliga Tekniska Högskolan
 (Royal Institute of Technology, Stockholm, Sweden).
 All rights reserved.
 
@@ -18390,11 +18363,11 @@ SUCH DAMAGE.
 
 > BSD-4
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\demos\easy_tls\easy-tls.c
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\demos\demos\easy_tls\easy-tls.c
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-4 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
-Copyright 1999 Bodo Moeller.  All rights reserved.
+(c) Copyright 1999 Bodo Moeller.  All rights reserved.
 
 This is free software; you can redistributed and/or modify it
 unter the terms of either
@@ -18403,6 +18376,8 @@ Free Software Foundation, version 1, or (at your option)
 any later version,
 or
 -  the following license:
+/
+/-
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that each of the following
 conditions is met:
@@ -18449,10 +18424,19 @@ HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
 STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
 OF THE POSSIBILITY OF SUCH DAMAGE.
+/
+/-
+Attribution for OpenSSL library:
+
+This product includes cryptographic software written by Eric Young
+(eay@cryptsoft.com).  This product includes software written by Tim
+Hudson (tjh@cryptsoft.com).
+This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit. (http://www.openssl.org/)
 
 > MIT
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\crypto\md5\asm\md5-ia64.S
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\\crypto\md5\asm\ md5-ia64.S
 
 Copyright (c) 2005 Hewlett-Packard Development Company, L.P.
 
@@ -18473,11 +18457,11 @@ MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
 NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
 LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
 OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
 
 > OpenSSL
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\crypto\aes\asm\bsaes-armv7.pl
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\aes\asm\bsaes-armv7.pl
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE OPENSSL LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
@@ -18492,7 +18476,10 @@ granted.
 
 > PublicDomain
 
-openssl-1.0.2r-1.ph2.src.rpm\openssl-1.0.2r-1.ph2.src.cpio\openssl-1.0.2r.tar.gz\openssl-1.0.2r.tar\openssl-1.0.2r\crypto\aes\asm\vpaes-x86.pl
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\aes\asm\vpaes-x86.pl
+
+Constant-time SSSE3 AES core implementation.
+version 0.1
 
 By Mike Hamburg (Stanford University), 2009
 Public domain.
@@ -18805,7 +18792,7 @@ This file is dual licensed under the terms of the Apache License, Version
 2.0, and the BSD License. See the LICENSE file in the root of this repository
 for complete details.
 
->>> python2-2.7.15-5.ph2
+>>> python2-2.7.15-8.ph2
 
 .. highlightlang:: none
 
@@ -19918,7 +19905,7 @@ Python interpreter. The redistribution of the Python interpreter and
 libraries is governed by the Python Software License included with this
 file, or by other licenses as marked.
 
->>> python3-3.6.5-5.ph2
+>>> python3-3.6.5-7.ph2
 
 .. highlightlang:: none
 
@@ -20869,6 +20856,27 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
+ADDITIONAL LICENSE INFORMATION:
+
+> MIT Style
+
+Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Tools\unicode\python-mappings\TIS-620.TXT
+
+Copyright (c) 2002 Unicode, Inc.  All Rights reserved.
+
+This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
+No claims are made as to fitness for any particular purpose.  No
+warranties of any kind are expressed or implied.  The recipient
+agrees to determine applicability of information provided.  If this
+file has been provided on optical media by Unicode, Inc., the sole
+remedy for any claim will be exchange of defective media within 90
+days of receipt.
+
+Unicode, Inc. hereby grants the right to freely use the information
+supplied in this file in the creation of products supporting the
+Unicode Standard, and to make copies of this file in any form for
+internal or external distribution as long as this notice remains
+attached.
 
 > CRT License
 
@@ -20912,209 +20920,16 @@ Python interpreter. The redistribution of the Python interpreter and
 libraries is governed by the Python Software License included with this
 file, or by other licenses as marked.
 
-ADDITIONAL LICENSE INFORMATION:
+> Microsoft Reciprocal License
 
-> Apache2.0
+Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Tools\msi\bundle\bootstrap\resource.h
 
-Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Lib\pstats.py
+Copyright (c) 2004, Outercurve Foundation.
+This software is released under Microsoft Reciprocal License (MS-RL).
+The license and further copyright text can be found in the file
+LICENSE.TXT at the root directory of the distribution.
 
-Copyright Disney Enterprises, Inc.  All Rights Reserved.
-Licensed to PSF under a Contributor Agreement
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-
-http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-either express or implied.  See the License for the specific language
-governing permissions and limitations under the License.
-
-> BSD-2
-
-python3-3.6.5-5.ph2.src.rpm\python3-3.6.5-5.ph2.src.cpio\Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Doc\license.rst
-
-The :mod:`select` module contains the following notice for the kqueue
-interface::
-
-Copyright (c) 2000 Doug White, 2006 James Knight, 2007 Christian Heimes
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
-
-libmpdec
---------
-
-The :mod:`_decimal` module is built using an included copy of the libmpdec
-library unless the build is configured ``--with-system-libmpdec``::
-
-Copyright (c) 2008-2016 Stefan Krah. All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS" AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
-> BSD-3
-
-python3-3.6.5-5.ph2.src.rpm\python3-3.6.5-5.ph2.src.cpio\Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Doc\license.rst
-
-Copyright (C) 1997 - 2002, Makoto Matsumoto and Takuji Nishimura,
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-
-3. The names of its contributors may not be used to endorse or promote
-products derived from this software without specific prior written
-permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
-CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
-EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
-PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
-PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
-LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
-NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-
-Any feedback is very welcome.
-http://www.math.sci.hiroshima-u.ac.jp/~m-mat/MT/emt.html
-email: m-mat @ math.sci.hiroshima-u.ac.jp (remove space)
-
-
-Sockets
--------
-
-The :mod:`socket` module uses the functions, :func:`getaddrinfo`, and
-:func:`getnameinfo`, which are coded in separate source files from the WIDE
-Project, http://www.wide.ad.jp/. ::
-
-Copyright (C) 1995, 1996, 1997, and 1998 WIDE Project.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-3. Neither the name of the project nor the names of its contributors
-may be used to endorse or promote products derived from this software
-without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
-> BSD-3
-
-python3-3.6.5-5.ph2.src.rpm\python3-3.6.5-5.ph2.src.cpio\Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Doc\license.rst
-
-cfuhash
--------
-
-The implementation of the hash table used by the :mod:`tracemalloc` is based
-on the cfuhash project::
-
-Copyright (c) 2005 Don Owens
-All rights reserved.
-
-This code is released under the BSD license:
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following
-disclaimer in the documentation and/or other materials provided
-with the distribution.
-
-* Neither the name of the author nor the names of its
-contributors may be used to endorse or promote products derived
-from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
-FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
-COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
-INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-OF THE POSSIBILITY OF SUCH DAMAGE.
-
-> GPL2.0
+> GPL 2.0
 
 Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Modules\_ctypes\libffi\doc\libffi.info
 
@@ -21126,11 +20941,12 @@ published by the Free Software Foundation; either version 2, or (at
 your option) any later version.  A copy of the license is included
 in the section entitled "GNU General Public License".
 
-> LGPL2.1
+
+>  LGPL 2.1
 
 Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Modules\_ctypes\libffi\msvcc.sh
 
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE LGPL2.1 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE LGPL 2.1 LICENSE.  PLEASE SEE APPENDIX FOR THE FULL TEXT OF THE LGPL 2.1 LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
 BEGIN LICENSE BLOCK
 Version: MPL 1.1/GPL 2.0/LGPL 2.1
@@ -21171,575 +20987,21 @@ END LICENSE BLOCK
 
 > MIT
 
-Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Tools\unicode\python-mappings\TIS-620.TXT
-
-> MIT Style
-
-Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Tools\unicode\python-mappings\TIS-620.TXT
-
-Copyright (c) 2002 Unicode, Inc.  All Rights reserved.
-
-This file is provided as-is by Unicode, Inc. (The Unicode Consortium).
-No claims are made as to fitness for any particular purpose.  No
-warranties of any kind are expressed or implied.  The recipient
-agrees to determine applicability of information provided.  If this
-file has been provided on optical media by Unicode, Inc., the sole
-remedy for any claim will be exchange of defective media within 90
-days of receipt.
-
-Unicode, Inc. hereby grants the right to freely use the information
-supplied in this file in the creation of products supporting the
-Unicode Standard, and to make copies of this file in any form for
-internal or external distribution as long as this notice remains
-attached.
-
-> MIT
-
 Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Lib\wsgiref\validate.py
 
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE MIT LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE MIT LICENSE .THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE]
 
 (c) 2005 Ian Bicking and contributors; written for Paste (http://pythonpaste.org)
 Licensed under the MIT license: http://www.opensource.org/licenses/mit-license.php
 Also licenced under the Apache License, 2.0: http://opensource.org/licenses/apache2.0.php
 Licensed to PSF under a Contributor Agreement
 
-> MIT
 
-Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Lib\ctypes\macholib\README.ctypes
+> Python 2.2
 
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE MIT LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-License: Any components of the py2app suite may be distributed under
-the MIT or PSF open source licenses.
-
-This is version 1.0, SVN revision 789, from 2006/01/25.
-The main repository is http://svn.red-bean.com/bob/macholib/trunk/macholib/
-
-> MIT
-
-python3-3.6.5-5.ph2.src.rpm\python3-3.6.5-5.ph2.src.cpio\Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Doc\license.rst
-
-Floating point exception control
---------------------------------
-
-The source for the :mod:`fpectl` module includes the following notice::
-
----------------------------------------------------------------------
-Copyright (c) 1996.
-The Regents of the University of California.
-All rights reserved.
-
-Permission to use, copy, modify, and distribute this software for
-any purpose without fee is hereby granted, provided that this en-
-tire notice is included in all copies of any software which is or
-includes  a  copy  or  modification  of  this software and in all
-copies of the supporting documentation for such software.
-
-This  work was produced at the University of California, Lawrence
-Livermore National Laboratory under  contract  no.  W-7405-ENG-48
-between  the  U.S.  Department  of  Energy and The Regents of the
-University of California for the operation of UC LLNL.
-
-DISCLAIMER
-
-This  software was prepared as an account of work sponsored by an
-agency of the United States Government. Neither the United States
-Government  nor the University of California nor any of their em-
-ployees, makes any warranty, express or implied, or  assumes  any
-liability  or  responsibility  for the accuracy, completeness, or
-usefulness of any information,  apparatus,  product,  or  process
-disclosed,   or  represents  that  its  use  would  not  infringe
-privately-owned rights. Reference herein to any specific  commer-
-cial  products,  process,  or  service  by trade name, trademark,
-manufacturer, or otherwise, does not  necessarily  constitute  or
-imply  its endorsement, recommendation, or favoring by the United
-States Government or the University of California. The views  and
-opinions  of authors expressed herein do not necessarily state or
-reflect those of the United States Government or  the  University
-of  California,  and shall not be used for advertising or product
-endorsement purposes.
----------------------------------------------------------------------
-
-
-Asynchronous socket services
-----------------------------
-
-The :mod:`asynchat` and :mod:`asyncore` modules contain the following notice::
-
-Copyright 1996 by Sam Rushing
-
-All Rights Reserved
-
-Permission to use, copy, modify, and distribute this software and
-its documentation for any purpose and without fee is hereby
-granted, provided that the above copyright notice appear in all
-copies and that both that copyright notice and this permission
-notice appear in supporting documentation, and that the name of Sam
-Rushing not be used in advertising or publicity pertaining to
-distribution of the software without specific, written prior
-permission.
-
-SAM RUSHING DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
-INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN
-NO EVENT SHALL SAM RUSHING BE LIABLE FOR ANY SPECIAL, INDIRECT OR
-CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
-OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
-NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
-CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-
-Cookie management
------------------
-
-The :mod:`http.cookies` module contains the following notice::
-
-Copyright 2000 by Timothy O'Malley <timo@alum.mit.edu>
-
-All Rights Reserved
-
-Permission to use, copy, modify, and distribute this software
-and its documentation for any purpose and without fee is hereby
-granted, provided that the above copyright notice appear in all
-copies and that both that copyright notice and this permission
-notice appear in supporting documentation, and that the name of
-Timothy O'Malley  not be used in advertising or publicity
-pertaining to distribution of the software without specific, written
-prior permission.
-
-Timothy O'Malley DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
-SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
-AND FITNESS, IN NO EVENT SHALL Timothy O'Malley BE LIABLE FOR
-ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
-WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
-ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
-PERFORMANCE OF THIS SOFTWARE.
-
-
-Execution tracing
------------------
-
-The :mod:`trace` module contains the following notice::
-
-portions copyright 2001, Autonomous Zones Industries, Inc., all rights...
-err...  reserved and offered to the public under the terms of the
-Python 2.2 license.
-Author: Zooko O'Whielacronx
-http://zooko.com/
-mailto:zooko@zooko.com
-
-Copyright 2000, Mojam Media, Inc., all rights reserved.
-Author: Skip Montanaro
-
-Copyright 1999, Bioreason, Inc., all rights reserved.
-Author: Andrew Dalke
-
-Copyright 1995-1997, Automatrix, Inc., all rights reserved.
-Author: Skip Montanaro
-
-Copyright 1991-1995, Stichting Mathematisch Centrum, all rights reserved.
-
-
-Permission to use, copy, modify, and distribute this Python software and
-its associated documentation for any purpose without fee is hereby
-granted, provided that the above copyright notice appears in all copies,
-and that both that copyright notice and this permission notice appear in
-supporting documentation, and that the name of neither Automatrix,
-Bioreason or Mojam Media be used in advertising or publicity pertaining to
-distribution of the software without specific, written prior permission.
-
-
-UUencode and UUdecode functions
--------------------------------
-
-The :mod:`uu` module contains the following notice::
-
-Copyright 1994 by Lance Ellinghouse
-Cathedral City, California Republic, United States of America.
-All Rights Reserved
-Permission to use, copy, modify, and distribute this software and its
-documentation for any purpose and without fee is hereby granted,
-provided that the above copyright notice appear in all copies and that
-both that copyright notice and this permission notice appear in
-supporting documentation, and that the name of Lance Ellinghouse
-not be used in advertising or publicity pertaining to distribution
-of the software without specific, written prior permission.
-LANCE ELLINGHOUSE DISCLAIMS ALL WARRANTIES WITH REGARD TO
-THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND
-FITNESS, IN NO EVENT SHALL LANCE ELLINGHOUSE CENTRUM BE LIABLE
-FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
-WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
-ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT
-OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
-
-Modified by Jack Jansen, CWI, July 1995:
-- Use binascii module to do the actual line-by-line conversion
-between ascii and binary. This results in a 1000-fold speedup. The C
-version is still 5 times faster, though.
-- Arguments more compliant with Python standard
-
-
-XML Remote Procedure Calls
---------------------------
-
-The :mod:`xmlrpc.client` module contains the following notice::
-
-The XML-RPC client interface is
-
-Copyright (c) 1999-2002 by Secret Labs AB
-Copyright (c) 1999-2002 by Fredrik Lundh
-
-By obtaining, using, and/or copying this software and/or its
-associated documentation, you agree that you have read, understood,
-and will comply with the following terms and conditions:
-
-Permission to use, copy, modify, and distribute this software and
-its associated documentation for any purpose and without fee is
-hereby granted, provided that the above copyright notice appears in
-all copies, and that both that copyright notice and this permission
-notice appear in supporting documentation, and that the name of
-Secret Labs AB or the author not be used in advertising or publicity
-pertaining to distribution of the software without specific, written
-prior permission.
-
-SECRET LABS AB AND THE AUTHOR DISCLAIMS ALL WARRANTIES WITH REGARD
-TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANT-
-ABILITY AND FITNESS.  IN NO EVENT SHALL SECRET LABS AB OR THE AUTHOR
-BE LIABLE FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY
-DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS,
-WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
-ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE
-OF THIS SOFTWARE.
-
-
-test_epoll
-----------
-
-The :mod:`test_epoll` module contains the following notice::
-
-Copyright (c) 2001-2006 Twisted Matrix Laboratories.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
-LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
-OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
-WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-SipHash24
----------
-
-The file :file:`Python/pyhash.c` contains Marek Majkowski' implementation of
-Dan Bernstein's SipHash24 algorithm. The contains the following note::
-
-<MIT License>
-Copyright (c) 2013  Marek Majkowski <marek@popcount.org>
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-</MIT License>
-
-Original location:
-https://github.com/majek/csiphash/
-
-Solution inspired by code from:
-Samuel Neves (supercop/crypto_auth/siphash24/little)
-djb (supercop/crypto_auth/siphash24/little2)
-Jean-Philippe Aumasson (https://131002.net/siphash/siphash24.c)
-
-
-strtod and dtoa
----------------
-
-The file :file:`Python/dtoa.c`, which supplies C functions dtoa and
-strtod for conversion of C doubles to and from strings, is derived
-from the file of the same name by David M. Gay, currently available
-from http://www.netlib.org/fp/.  The original file, as retrieved on
-March 16, 2009, contains the following copyright and licensing
-notice::
-
-The author of this software is David M. Gay.
-
-Copyright (c) 1991, 2000, 2001 by Lucent Technologies.
-
-Permission to use, copy, modify, and distribute this software for any
-purpose without fee is hereby granted, provided that this entire notice
-is included in all copies of any software which is or includes a copy
-or modification of this software and in all copies of the supporting
-documentation for such software.
-
-THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
-WARRANTY.  IN PARTICULAR, NEITHER THE AUTHOR NOR LUCENT MAKES ANY
-REPRESENTATION OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY
-OF THIS SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
-
-expat
------
-
-The :mod:`pyexpat` extension is built using an included copy of the expat
-sources unless the build is configured ``--with-system-expat``::
-
-Copyright (c) 1998, 1999, 2000 Thai Open Source Software Center Ltd
-and Clark Cooper
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-"Software"), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
-IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
-CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
-TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
-SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-
-libffi
-------
-
-The :mod:`_ctypes` extension is built using an included copy of the libffi
-sources unless the build is configured ``--with-system-libffi``::
-
-Copyright (c) 1996-2008  Red Hat, Inc and others.
-
-Permission is hereby granted, free of charge, to any person obtaining
-a copy of this software and associated documentation files (the
-``Software''), to deal in the Software without restriction, including
-without limitation the rights to use, copy, modify, merge, publish,
-distribute, sublicense, and/or sell copies of the Software, and to
-permit persons to whom the Software is furnished to do so, subject to
-the following conditions:
-
-The above copyright notice and this permission notice shall be included
-in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
-MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
-DEALINGS IN THE SOFTWARE.
-
-zlib
-----
-
-The :mod:`zlib` extension is built using an included copy of the zlib
-sources if the zlib version found on the system is too old to be
-used for the build::
-
-Copyright (C) 1995-2011 Jean-loup Gailly and Mark Adler
-
-This software is provided 'as-is', without any express or implied
-warranty.  In no event will the authors be held liable for any damages
-arising from the use of this software.
-
-Permission is granted to anyone to use this software for any purpose,
-including commercial applications, and to alter it and redistribute it
-freely, subject to the following restrictions:
-
-1. The origin of this software must not be misrepresented; you must not
-claim that you wrote the original software. If you use this software
-in a product, an acknowledgment in the product documentation would be
-appreciated but is not required.
-
-2. Altered source versions must be plainly marked as such, and must not be
-misrepresented as being the original software.
-
-3. This notice may not be removed or altered from any source distribution.
-
-Jean-loup Gailly        Mark Adler
-jloup@gzip.org          madler@alumni.caltech.edu
-
-> MS-RL
-
-Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Tools\msi\bundle\bootstrap\resource.h
-
-Copyright (c) 2004, Outercurve Foundation.
-This software is released under Microsoft Reciprocal License (MS-RL).
-The license and further copyright text can be found in the file
-LICENSE.TXT at the root directory of the distribution.
-
-> OpenSSL
-
-python3-3.6.5-5.ph2.src.rpm\python3-3.6.5-5.ph2.src.cpio\Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Doc\license.rst
-
-OpenSSL
--------
-
-The modules :mod:`hashlib`, :mod:`posix`, :mod:`ssl`, :mod:`crypt` use
-the OpenSSL library for added performance if made available by the
-operating system. Additionally, the Windows and Mac OS X installers for
-Python may include a copy of the OpenSSL libraries, so we include a copy
-of the OpenSSL license here::
-
-
-LICENSE ISSUES
-==============
-
-The OpenSSL toolkit stays under a dual license, i.e. both the conditions of
-the OpenSSL License and the original SSLeay license apply to the toolkit.
-See below for the actual license texts. Actually both licenses are BSD-style
-Open Source licenses. In case of any license issues related to OpenSSL
-please contact openssl-core@openssl.org.
-
-OpenSSL License
----------------
-
-====================================================================
-Copyright (c) 1998-2008 The OpenSSL Project.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in
-the documentation and/or other materials provided with the
-distribution.
-
-3. All advertising materials mentioning features or use of this
-software must display the following acknowledgment:
-"This product includes software developed by the OpenSSL Project
-for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
-
-4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
-endorse or promote products derived from this software without
-prior written permission. For written permission, please contact
-openssl-core@openssl.org.
-
-5. Products derived from this software may not be called "OpenSSL"
-nor may "OpenSSL" appear in their names without prior written
-permission of the OpenSSL Project.
-
-6. Redistributions of any form whatsoever must retain the following
-acknowledgment:
-"This product includes software developed by the OpenSSL Project
-for use in the OpenSSL Toolkit (http://www.openssl.org/)"
-
-THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
-EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
-ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
-NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
-OF THE POSSIBILITY OF SUCH DAMAGE.
-====================================================================
-
-This product includes cryptographic software written by Eric Young
-(eay@cryptsoft.com).  This product includes software written by Tim
-Hudson (tjh@cryptsoft.com).
-
-Original SSLeay License
------------------------
-
-/ Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
-All rights reserved.
-
-This package is an SSL implementation written
-by Eric Young (eay@cryptsoft.com).
-The implementation was written so as to conform with Netscapes SSL.
-
-This library is free for commercial and non-commercial use as long as
-the following conditions are aheared to.  The following conditions
-apply to all code found in this distribution, be it the RC4, RSA,
-lhash, DES, etc., code; not just the SSL code.  The SSL documentation
-included with this distribution is covered by the same copyright terms
-except that the holder is Tim Hudson (tjh@cryptsoft.com).
-
-Copyright remains Eric Young's, and as such any Copyright notices in
-the code are not to be removed.
-If this package is used in a product, Eric Young should be given attribution
-as the author of the parts of the library used.
-This can be in the form of a textual message at program startup or
-in documentation (online or textual) provided with the package.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the copyright
-notice, this list of conditions and the following disclaimer.
-2. Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-3. All advertising materials mentioning features or use of this software
-must display the following acknowledgement:
-"This product includes cryptographic software written by
-Eric Young (eay@cryptsoft.com)"
-The word 'cryptographic' can be left out if the rouines from the library
-being used are not cryptographic related :-).
-4. If you include any Windows specific code (or a derivative thereof) from
-the apps directory (application code) you must include an acknowledgement:
-"This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
-
-THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGE.
-
-The licence and distribution terms for any publically available version or
-derivative of this code cannot be changed.  i.e. this code cannot simply be
-copied and put under another distribution licence
-[including the GNU Public Licence.]
-
-> PublicDomain
-
-Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Modules\_ctypes\libffi\src\dlmalloc.c
-
-This is a version (aka dlmalloc) of malloc/free/realloc written by
-Doug Lea and released to the public domain, as explained at
-http://creativecommons.org/licenses/publicdomain.  Send questions,
-comments, complaints, performance data, etc to dl@cs.oswego.edu
-
-> Python
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE PYTHON LICENSE. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
 Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Lib\urllib\robotparser.py
-
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE PYTHON LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
 Copyright (C) 2000  Bastian Kleineidam
 
@@ -21749,6 +21011,64 @@ You can choose between two licenses when using this package:
 
 The robots.txt Exclusion Protocol is implemented as specified in
 http://www.robotstxt.org/norobots-rfc.txt
+
+
+> MIT
+
+Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Lib\ctypes\macholib\README.ctypes
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE MIT LICENSE.   THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+License: Any components of the py2app suite may be distributed under
+the MIT or PSF open source licenses.
+
+This is version 1.0, SVN revision 789, from 2006/01/25.
+The main repository is http://svn.red-bean.com/bob/macholib/trunk/macholib/
+
+
+> CNRI Python 1.6
+
+Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Lib\re.py
+
+Copyright (c) 1998-2001 by Secret Labs AB.  All rights reserved.
+
+This version of the SRE library can be redistributed under CNRI's
+Python 1.6 license.  For any other use, please contact Secret Labs
+AB (info@pythonware.com).
+
+Portions of this engine have been developed in cooperation with
+CNRI.  Hewlett-Packard provided funding for 1.6 integration and
+other compatibility work.
+
+
+> Apache 2.0
+
+Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Lib\pstats.py
+
+Copyright Disney Enterprises, Inc.  All Rights Reserved.
+Licensed to PSF under a Contributor Agreement
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+either express or implied.  See the License for the specific language
+governing permissions and limitations under the License.
+
+
+> Public Domain
+
+Python-3.6.5.tar.xz\Python-3.6.5.tar\Python-3.6.5\Modules\_ctypes\libffi\src\dlmalloc.c
+
+This is a version (aka dlmalloc) of malloc/free/realloc written by
+Doug Lea and released to the public domain, as explained at
+http://creativecommons.org/licenses/publicdomain.  Send questions,
+comments, complaints, performance data, etc to dl@cs.oswego.edu
 
 >>> rpcbind-0.2.4-5.ph2
 
@@ -22010,7 +21330,7 @@ man pages are NOT obsolete!
 <ragnar@maculanet>
 TH su 1 "18 August 1999" "GNU Shell Utilities 20"
 
->>> sqlite-3.27.2-2.ph2
+>>> sqlite-3.27.2-3.ph2
 
 The author disclaims copyright to this source code.  In place of
 a legal notice, here is a blessing:
@@ -22018,23 +21338,6 @@ a legal notice, here is a blessing:
 May you do good and not evil.
 May you find forgiveness for yourself and forgive others.
 May you share freely, never taking more than you give.
-
-ADDITIONAL LICENSE INFORMATION:
-
-> MIT
-
-sqlite-3.27.2-2.ph2.src.rpm\sqlite-3.27.2-2.ph2.src.cpio\sqlite-autoconf-3270200.tar.gz\sqlite-autoconf-3270200.tar\sqlite-autoconf-3270200\aclocal.m4
-
-Copyright (C) 1996-2017 Free Software Foundation, Inc.
-
-This file is free software; the Free Software Foundation
-gives unlimited permission to copy and/or distribute it,
-with or without modifications, as long as this notice is preserved.
-
-This program is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY, to the extent permitted by law; without
-even the implied warranty of MERCHANTABILITY or FITNESS FOR A
-PARTICULAR PURPOSE.
 
 >>> sudo-1.8.20p2-5.ph2
 
@@ -22232,18 +21535,19 @@ sudo-1.8.20p2.tar.gz\sudo-1.8.20p2.tar\sudo-1.8.20p2\lib\util\regress\glob\globt
 
 Public domain, 2008, Todd C. Miller Todd.Miller@courtesan.com
 
->>> tzdata-2017b-3.ph2
+>>> tzdata-2019a-1.ph2
 
-With a few exceptions, all files in the tz code and data (including
-this one) are in the public domain.  The exceptions are date.c,
-newstrftime.3, and strftime.c, which contain material derived from BSD
-and which use the BSD 3-clause license.
+Unless specified below, all files in the tz code and data (including
+this LICENSE file) are in the public domain.
 
->>> vim-8.0.0533-6.ph2
+If the files date.c, newstrftime.3, and strftime.c are present, they
+contain material derived from BSD and use the BSD 3-clause license.
+
+>>> vim-8.0.0533-7.ph2
 
 Vim is Charityware.  You can use and copy it as much as you like, but you are
 encouraged to make a donation to help orphans in Uganda.  Please read the file
-"runtime/doc/uganda.txt" for details (do ":help uganda" inside Vim).
+`runtime/doc/uganda.txt` for details (do `:help uganda` inside Vim).
 
 Summary of the license: There are no restrictions on using or distributing an
 unmodified copy of Vim.  Parts of Vim may also be distributed, but the license
@@ -22253,9 +21557,27 @@ distribute it.
 
 ADDITIONAL LICENSE INFORMATION:
 
->MIT
+> GPL2.0
 
-vim-8.0.0533\runtime\autoload\netrwFileHandlers.vim
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\runtime\tools\efm_perl.pl
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GPL2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (c) 2001 by Joerg Ziefle <joerg.ziefle@gmx.de>
+You may use and distribute this software under the same terms as Perl itself.
+
+> GPL3.0
+
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\runtime\plugin\tarPlugin.vim
+
+tarPlugin.vim -- a Vim plugin for browsing tarfiles
+Original was copyright (c) 2002, Michael C. Toren <mct@toren.net>
+Modified by Charles E. Campbell
+Distributed under the GNU General Public License.
+
+> MIT
+
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\runtime\autoload\netrwFileHandlers.vim
 
 Copyright (C) 1999-2012 Charles E. Campbell {{{1
 Permission is hereby granted to use and distribute this code,
@@ -22266,27 +21588,9 @@ warranty of any kind, either expressed or implied. In no
 event will the copyright holder be liable for any damages
 resulting from the use of this software.
 
->GPL 3.0
+> PublicDomain
 
-vim-8.0.0533\runtime\plugin\tarPlugin.vim
-
-tarPlugin.vim -- a Vim plugin for browsing tarfiles
-Original was copyright (c) 2002, Michael C. Toren <mct@toren.net>
-Modified by Charles E. Campbell
-Distributed under the GNU General Public License.
-
->GPL 2.0
-
-vim-8.0.0533\runtime\tools\efm_perl.pl
-
-[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE GPL 2.PLEASE SEE THE APPENDIX TO REVIEW THE FULL TEXT OF THE GPL 2.0.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-Copyright (c) 2001 by Joerg Ziefle <joerg.ziefle@gmx.de>
-You may use and distribute this software under the same terms as Perl itself.
-
->Public Domain
-
-vim-8.0.0533\src\tee\tee.c
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\src\tee\tee.c
 
 Copyright (c) 1996, Paul Slootman
 
@@ -22854,6 +22158,25 @@ This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY, to the extent permitted by law; without
 even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.
+
+>>> ca-certificates-20190521-1.ph2
+
+Copyright (C) 2009 Philipp Kern <pkern@debian.org>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301,
+ USA.
 
 >>> cdrkit-1.1.11-4.ph2
 
@@ -24305,22 +23628,21 @@ copy can be downloaded from  http://www.gnu.org/licenses/lgpl.html,
 or obtained by writing to the Free Software Foundation, Inc.,
 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
 
->>> linux-esx-4.9.173-2.ph2
+>>> linux-esx-4.9.182-1.ph2
 
-Copyright (C) 2012 Red Hat, Inc. All Rights Reserved.
-Written by David Howells (dhowells@redhat.com)
+Copyright (C) Paul Mackerras 1997.
 
 This program is free software; you can redistribute it and/or
-modify it under the terms of the GNU General Public Licence
+modify it under the terms of the GNU General Public License
 as published by the Free Software Foundation; either version
-2 of the Licence, or (at your option) any later version.
-
+2 of the License, or (at your option) any later version.
 
 ADDITIONAL LICENSE INFORMATION:
 
+
 > Third Party
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\microblaze\lib\memcpy.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\microblaze\lib\memcpy.c
 
 Copyright (C) 2008-2009 Michal Simek <monstr@monstr.eu>
 Copyright (C) 2008-2009 PetaLogix
@@ -24346,19 +23668,11 @@ for a particular purpose. Intel does not assume any
 responsibility for and errors which may appear in this program
 not any responsibility to update it.
 
-> Third Party Agreement (Microsoft Developer Service Agreement)
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\usb\ linux-cdc-acm.inf
-
-Based on INF template which was:
-Copyright (c) 2000 Microsoft Corporation
-Copyright (c) 2007 Microchip Technology Inc.
-likely to be covered by the MLPL as found at:
-<http://msdn.microsoft.com/en-us/cc300389.aspx#MLPL>
-
 > Apache2.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\drivers\staging\android\ashmem.h
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\staging\android\ashmem.h
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE APACHE2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
 Copyright 2008 Google Inc.
 Author: Robert Love
@@ -24369,7 +23683,7 @@ General Public License.
 
 > BSD
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\arm\nwfpe\milieu.h
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\nwfpe\milieu.h
 
 This C header file is part of the SoftFloat IEC/IEEE Floating-point
 Arithmetic Package, Release 2.
@@ -24397,24 +23711,7 @@ this code that are retained.
 
 > BSD
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\mips\sgi-ip22\ip22-eisa.c
-
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-(C) 2002 Pascal Dameme <netinet@freesurf.fr>
-and Marc Zyngier <mzyngier@freesurf.fr>
-
-This code is released under both the GPL version 2 and BSD
-licenses.  Either license may be used.
-
-This code offers a very basic support for this EISA bus present in
-the SGI Indigo-2. It currently only supports PIO (forget about DMA
-for the time being). This is enough for a low-end ethernet card,
-but forget about your favorite SCSI card...
-
-> BSD
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\scsi\dpti.txt
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\scsi\dpti.txt
 
 Redistribution and use in source form, with or without modification, are
 permitted provided that redistributions of source code must retain the
@@ -24432,42 +23729,57 @@ contract, strict liability, or tort (including negligence or otherwise)
 arising in any way out of the use of this driver software, even if advised
 of the possibility of such damage.
 
+> BSD
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\mips\sgi-ip22\ip22-eisa.c
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+(C) 2002 Pascal Dameme <netinet@freesurf.fr>
+and Marc Zyngier <mzyngier@freesurf.fr>
+
+This code is released under both the GPL version 2 and BSD
+licenses.  Either license may be used.
+
+This code offers a very basic support for this EISA bus present in
+the SGI Indigo-2. It currently only supports PIO (forget about DMA
+for the time being). This is enough for a low-end ethernet card,
+but forget about your favorite SCSI card...
+
 > BSD-2
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\cris\arch-v10\lib\memset.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\input\keyboard\hil_kbd.c
 
-Copyright (C) 1999-2005 Axis Communications.
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-2 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (c) 2001 Brian S. Julin
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions
 are met:
-
 1. Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
+notice, this list of conditions, and the following disclaimer,
+without modification.
+2. The name of the author may not be used to endorse or promote products
+derived from this software without specific prior written permission.
 
-2. Neither the name of Axis Communications nor the names of its
-contributors may be used to endorse or promote products derived
-from this software without specific prior written permission.
+Alternatively, this software may be distributed under the terms of the
+GNU General Public License ("GPL").
 
-THIS SOFTWARE IS PROVIDED BY AXIS COMMUNICATIONS AND ITS CONTRIBUTORS
-``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL AXIS
-COMMUNICATIONS OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
-INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
-STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
-IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 
 > BSD-2
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\mips\include\asm\netlogic\xlp-hal\bridge.h
-
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-2 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\mips\include\asm\netlogic\xlp-hal\bridge.h
 
 Copyright 2003-2011 NetLogic Microsystems, Inc. (NetLogic). All rights
 reserved.
@@ -24503,38 +23815,7 @@ IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 > BSD-2
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\drivers\input\keyboard\hil_kbd.c
-
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-2 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-Copyright (c) 2001 Brian S. Julin
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions
-are met:
-1. Redistributions of source code must retain the above copyright
-notice, this list of conditions, and the following disclaimer,
-without modification.
-2. The name of the author may not be used to endorse or promote products
-derived from this software without specific prior written permission.
-
-Alternatively, this software may be distributed under the terms of the
-GNU General Public License ("GPL").
-
-THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
-ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR
-ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
-OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
-HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
-LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
-
-> BSD-2
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\cris\arch-v10\lib\memset.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\cris\arch-v10\lib\memset.c
 
 Copyright (C) 1999-2005 Axis Communications.
 All rights reserved.
@@ -24565,93 +23846,7 @@ POSSIBILITY OF SUCH DAMAGE.
 
 > BSD-3
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\blackfin\Clear_BSD.txt
-
-Copyright (c) 2012, Analog Devices, Inc.  All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted (subject to the limitations in the
-disclaimer below) provided that the following conditions are met:
-
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-
-* Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the
-distribution.
-
-* Neither the name of Analog Devices, Inc.  nor the names of its
-contributors may be used to endorse or promote products derived
-from this software without specific prior written permission.
-
-NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
-GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
-HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
-WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
-MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
-WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
-OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
-IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
-> BSD-3
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\blackfin\include\asm\bfin_pfmon.h
-
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-3 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-Copyright 2005-2011 Analog Devices Inc.
-
-Licensed under the Clear BSD license or GPL-2 (or later).
-
-> BSD-3
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\powerpc\include\asm\ibmebus.h
-
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-3 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-Copyright (c) 2005 IBM Corporation
-Joachim Fenkes <fenkes@de.ibm.com>
-Heiko J Schick <schickhj@de.ibm.com>
-
-All rights reserved.
-
-This source code is distributed under a dual license of GPL v2.0 and OpenIB
-BSD.
-
-OpenIB BSD License
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-Redistributions of source code must retain the above copyright notice, this
-list of conditions and the following disclaimer.
-
-Redistributions in binary form must reproduce the above copyright notice,
-this list of conditions and the following disclaimer in the documentation
-and/or other materials
-provided with the distribution.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
-ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
-LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
-CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
-SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
-BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
-IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
-ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
-POSSIBILITY OF SUCH DAMAGE.
-
-> BSD-3
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\crypto\drbg.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\crypto\drbg.c
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-3 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
@@ -24689,9 +23884,55 @@ LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
 DAMAGE.
 
+> BSD-3
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\blackfin\ Clear_BSD.txt
+
+Copyright (c) 2012, Analog Devices, Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of Analog Devices, Inc.  nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+> BSD-3
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\blackfin\include\asm\bfin_pfmon.h
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-3 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright 2005-2011 Analog Devices Inc.
+
+Licensed under the Clear BSD license or GPL-2 (or later).
+
 > BSD-4
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\drivers\net\ppp\bsd_comp.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\net\ppp\drivers\net\ppp\bsd_comp.c
 
 Copyright (c) 1985, 1986 The Regents of the University of California.
 All rights reserved.
@@ -24730,7 +23971,7 @@ SUCH DAMAGE.
 
 > CC-Attribution-ShareAlike2.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\PCI\pci.txt
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\PCI\pci.txt
 
 A more complete resource is the third edition of "Linux Device Drivers"
 by Jonathan Corbet, Alessandro Rubini, and Greg Kroah-Hartman.
@@ -24746,20 +23987,23 @@ Please send questions/comments/patches about Linux PCI API to the
 
 > GFDL1.1
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\DocBook\media_api.tmpl
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\parport\ieee1284.c
 
-Copyright 2009-2012
-LinuxTV Developers
+Authors: Phil Blundell <philb@gnu.org>
+Carsten Gross <carsten@sol.wohnheim.uni-ulm.de>
+Jose Renau <renau@acm.org>
+Tim Waugh <tim@cyberelk.demon.co.uk> (largely rewritten)
 
-Permission is granted to copy, distribute and/or modify
-this document under the terms of the GNU Free Documentation License,
-Version 1.1 or any later version published by the Free Software
-Foundation. A copy of the license is included in the chapter entitled
-"GNU Free Documentation License".
+This file is responsible for IEEE 1284 negotiation, and for handing
+read/write requests to low-level drivers.
+
+Any part of this program may be used in documents licensed under
+the GNU Free Documentation License, Version 1.1 or any later version
+published by the Free Software Foundation.
 
 > GFDL1.2
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\trace\ftrace.txt
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\trace\ftrace.txt
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GFDL1.2 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
@@ -24770,7 +24014,7 @@ License:   The GNU Free Documentation License, Version 1.2
 
 > GPL1.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\powerpc\xmon\ppc.h
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\powerpc\xmon\ppc.h
 
 Copyright 1994, 1995, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006
 Free Software Foundation, Inc.
@@ -24794,7 +24038,7 @@ Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, US
 
 > GPL2.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\m68k\lib\divsi3.S
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\m68k\lib\divsi3.S
 
 Copyright (C) 1994, 1996, 1997, 1998 Free Software Foundation, Inc.
 
@@ -24831,38 +24075,7 @@ the executable file might be covered by the GNU General Public License.
 
 > GPL2.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\drivers\ide\ide-cs.c
-
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GPL2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-The contents of this file are subject to the Mozilla Public
-License Version 1.1 (the "License"); you may not use this file
-except in compliance with the License. You may obtain a copy of
-the License at http://www.mozilla.org/MPL/
-
-Software distributed under the License is distributed on an "AS
-IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
-implied. See the License for the specific language governing
-rights and limitations under the License.
-
-The initial developer of the original code is David A. Hinds
-<dahinds@users.sourceforge.net>.  Portions created by David A. Hinds
-are Copyright (C) 1999 David A. Hinds.  All Rights Reserved.
-
-Alternatively, the contents of this file may be used under the
-terms of the GNU General Public License version 2 (the "GPL"), in
-which case the provisions of the GPL are applicable instead of the
-above.  If you wish to allow the use of your version of this file
-only under the terms of the GPL and not to allow others to use
-your version of this file under the MPL, indicate your decision
-by deleting the provisions above and replace them with the notice
-and other provisions required by the GPL.  If you do not delete
-the provisions above, a recipient may use your version of this
-file under either the MPL or the GPL.
-
-> GPL2.0
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\fs\jffs2\LICENCE
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\fs\jffs2\LICENCE
 
 Copyright Â© 2001-2007 Red Hat, Inc. and others
 
@@ -24891,16 +24104,47 @@ of the GNU General Public License.
 This exception does not invalidate any other reasons why a work based on
 this file might be covered by the GNU General Public License.
 
+> GPL2.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\ide\ide-cs.c
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GPL2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+The contents of this file are subject to the Mozilla Public
+License Version 1.1 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of
+the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS
+IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+implied. See the License for the specific language governing
+rights and limitations under the License.
+
+The initial developer of the original code is David A. Hinds
+<dahinds@users.sourceforge.net>.  Portions created by David A. Hinds
+are Copyright (C) 1999 David A. Hinds.  All Rights Reserved.
+
+Alternatively, the contents of this file may be used under the
+terms of the GNU General Public License version 2 (the "GPL"), in
+which case the provisions of the GPL are applicable instead of the
+above.  If you wish to allow the use of your version of this file
+only under the terms of the GPL and not to allow others to use
+your version of this file under the MPL, indicate your decision
+by deleting the provisions above and replace them with the notice
+and other provisions required by the GPL.  If you do not delete
+the provisions above, a recipient may use your version of this
+file under either the MPL or the GPL.
+
 > GPL3.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\arm\mach-imx\pm-imx27.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\mach-imx\pm-imx27.c
 
 This program is free software; you can redistribute it and/or
 modify it under the terms of the GNU General Public License.
 
 > LGPL2.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\arm\mach-orion5x\dns323-setup.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\mach-orion5x\dns323-setup.c
 
 Copyright (C) 2010 Benjamin Herrenschmidt <benh@kernel.crashing.org>
 
@@ -24911,7 +24155,7 @@ License, or (at your option) any later version.
 
 > LGPL2.1
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\parisc\lib\memset.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\parisc\lib\memset.c
 
 Copyright (C) 1991, 1997 Free Software Foundation, Inc.
 This file is part of the GNU C Library.
@@ -24933,7 +24177,7 @@ Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
 
 > LGPL3.0
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\include\uapi\linux\dm-ioctl.h
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\include\uapi\linux\dm-ioctl.h
 
 Copyright (C) 2001 - 2003 Sistina Software (UK) Limited.
 Copyright (C) 2004 - 2009 Red Hat, Inc. All rights reserved.
@@ -24942,75 +24186,7 @@ This file is released under the LGPL.
 
 > MIT
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\arm\boot\dts\arm-realview-pb1176.dts
-
-Copyright 2014 Linaro Ltd
-
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
-THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
-THE SOFTWARE.
-
-> MIT
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\m68k\fpsp040\README
-
-M68040 Software Package Copyright (c) 1993, 1994 Motorola Inc.
-All rights reserved.
-
-THE SOFTWARE is provided on an "AS IS" basis and without warranty.
-To the maximum extent permitted by applicable law,
-MOTOROLA DISCLAIMS ALL WARRANTIES WHETHER EXPRESS OR IMPLIED,
-INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
-PARTICULAR PURPOSE and any warranty against infringement with
-regard to the SOFTWARE (INCLUDING ANY MODIFIED VERSIONS THEREOF)
-and any accompanying written materials.
-
-To the maximum extent permitted by applicable law,
-IN NO EVENT SHALL MOTOROLA BE LIABLE FOR ANY DAMAGES WHATSOEVER
-(INCLUDING WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS
-PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR
-OTHER PECUNIARY LOSS) ARISING OF THE USE OR INABILITY TO USE THE
-SOFTWARE.  Motorola assumes no responsibility for the maintenance
-and support of the SOFTWARE.
-
-You are hereby granted a copyright license to use, modify, and
-distribute the SOFTWARE so long as this entire notice is retained
-without alteration in any modified and/or redistributed versions,
-and that such modified versions are clearly identified as such.
-No licenses are granted by implication, estoppel or otherwise
-under any patents or trademarks of Motorola, Inc.
-
-> MIT
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\m68k\math-emu\fp_log.c
-
-Copyright (c) 1998-1999 David Huggins-Daines / Roman Zippel.
-
-I hereby give permission, free of charge, to copy, modify, and
-redistribute this software, in source or binary form, provided that
-the above copyright notice and the following disclaimer are included
-in all such copies.
-
-THIS SOFTWARE IS PROVIDED "AS IS", WITH ABSOLUTELY NO WARRANTY, REAL
-OR IMPLIED.
-
-> MIT
-
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\include\dt-bindings\clock\sun4i-a10-pll2.h
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\include\dt-bindings\clock\sun4i-a10-pll2.h
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE MIT LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
@@ -25056,18 +24232,87 @@ WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
 FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
 OTHER DEALINGS IN THE SOFTWARE.
 
+> MIT
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\m68k\fpsp040\README
+
+M68040 Software Package Copyright (c) 1993, 1994 Motorola Inc.
+All rights reserved.
+
+THE SOFTWARE is provided on an "AS IS" basis and without warranty.
+To the maximum extent permitted by applicable law,
+MOTOROLA DISCLAIMS ALL WARRANTIES WHETHER EXPRESS OR IMPLIED,
+INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE and any warranty against infringement with
+regard to the SOFTWARE (INCLUDING ANY MODIFIED VERSIONS THEREOF)
+and any accompanying written materials.
+
+To the maximum extent permitted by applicable law,
+IN NO EVENT SHALL MOTOROLA BE LIABLE FOR ANY DAMAGES WHATSOEVER
+(INCLUDING WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS
+PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR
+OTHER PECUNIARY LOSS) ARISING OF THE USE OR INABILITY TO USE THE
+SOFTWARE.  Motorola assumes no responsibility for the maintenance
+and support of the SOFTWARE.
+
+You are hereby granted a copyright license to use, modify, and
+distribute the SOFTWARE so long as this entire notice is retained
+without alteration in any modified and/or redistributed versions,
+and that such modified versions are clearly identified as such.
+No licenses are granted by implication, estoppel or otherwise
+under any patents or trademarks of Motorola, Inc.
+
+> MIT
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\boot\dts\arm-realview-pb1176.dts
+
+Copyright 2014 Linaro Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+> MIT
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\m68k\math-emu\fp_log.c
+
+Copyright (c) 1998-1999 David Huggins-Daines / Roman Zippel.
+
+I hereby give permission, free of charge, to copy, modify, and
+redistribute this software, in source or binary form, provided that
+the above copyright notice and the following disclaimer are included
+in all such copies.
+
+THIS SOFTWARE IS PROVIDED "AS IS", WITH ABSOLUTELY NO WARRANTY, REAL
+OR IMPLIED.
+
 > MS-LPL
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\usb\linux-cdc-acm.inf
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\usb\linux-cdc-acm.inf
 
+Based on INF template which was:
 Copyright (c) 2000 Microsoft Corporation
 Copyright (c) 2007 Microchip Technology Inc.
-likely to be covered by the MLPL as found at
-<http//msdn.microsoft.com/en-us/cc300389.aspx#MLPL>.
+likely to be covered by the MLPL as found at:
+<http://msdn.microsoft.com/en-us/cc300390.aspx#MLPL>
 
 > OpenSSL
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\arch\arm\crypto\aes-armv4.S
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\crypto\aes-armv4.S
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE OPENSSL LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
@@ -25078,7 +24323,7 @@ details see http://www.openssl.org/~appro/cryptogams/.
 
 > OSL1.1
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\DocBook\libata.tmpl
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\DocBook\libata.tmpl
 
 [NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE OSL1.1 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
 
@@ -25100,14 +24345,14 @@ version of this file under either the OSL or the GPL.
 
 > PublicDomain
 
-linux-4.4.67.tar.xz\linux-4.4.67.tar\linux-4.4.67\Documentation\vDSO\parse_vdso.c
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\crypto\md4.c
 
-Written by Andrew Lutomirski, 2011-2014.
+MD4 Message Digest Algorithm (RFC1320).
 
-This code is meant to be linked in to various programs that run on Linux.
-As such, it is available with as few restrictions as possible.  This file
-is licensed under the Creative Commons Zero License, version 1.0,
-available at http://creativecommons.org/publicdomain/zero/1.0/legalcode
+Implementation derived from Andrew Tridgell and Steve French's
+CIFS MD4 implementation, and the cryptoapi implementation
+originally based on the public domain implementation written
+by Colin Plumb in 1993.
 
 >>> logrotate-3.11.0-3.ph2
 
@@ -25409,7 +24654,7 @@ nfs-utils-2.3.1.tar.xz\nfs-utils-2.3.1.tar\nfs-utils-2.3.1\utils\showmount\showm
 Copyright 1993 Rick Sladkey <jrs@world.std.com>
 May be distributed under the GNU General Public License
 
->>> openjdk8-1.8.0.212-1.ph2
+>>> openjdk8-1.8.0.212-2.ph2
 
 Copyright (c) 2010, 2014, Oracle and/or its affiliates. All rights reserved.
 DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
@@ -29176,11 +28421,11 @@ There are some unavoidable exceptions within include files to
 define necessary library symbols; they are noted "INFRINGES ON
 USER NAME SPACE" below.
 
->>> elfutils-0.169-3.ph2
+>>> elfutils-0.176-1.ph2
 
-Copyright (C) 2000, 2002, 2005 Red Hat, Inc.
+Copyright (C) 2012 Red Hat, Inc.
+
 This file is part of elfutils.
-Written by Ulrich Drepper <drepper@redhat.com>, 2000.
 
 This file is free software; you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -29195,16 +28440,36 @@ GNU General Public License for more details.
 You should have received a copy of the GNU General Public License
 along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-ADDITIONAL LICENSE INFORMATION
+ADDITIONAL LICENSE INFORMATION:
 
-> LGPL 3.0
+> LGPL2.1
 
-elfutils-0.169.tar.bz2\elfutils-0.169.tar\elfutils-0.169\lib\color.c
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\libelf\elf.h
 
-[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE LGPL 3.0 LICENSE.  PLEASE SEE THE APPENDIX FOR THE FULL TEXT OF THE LGPL 3.0 LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+Copyright (C) 1995-2013 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
 
-Copyright (C) 2008 Red Hat, Inc.
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
 
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with the GNU C Library; if not, see
+<http://www.gnu.org/licenses/>.
+
+> LGPL3.0
+
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\libelf\version.h
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE LGPL3.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (C) 2013 Red Hat, Inc.
 This file is part of elfutils.
 
 This file is free software; you can redistribute it and/or modify
@@ -29231,9 +28496,9 @@ You should have received copies of the GNU General Public License and
 the GNU Lesser General Public License along with this program.  If
 not, see <http://www.gnu.org/licenses/>.
 
-> MIT-Style
+> MIT
 
-elfutils-0.169.tar.bz2\elfutils-0.169.tar\elfutils-0.169\aclocal.m4
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\aclocal.m4
 
 Copyright (C) 1996-2013 Free Software Foundation, Inc.
 
@@ -29246,27 +28511,13 @@ but WITHOUT ANY WARRANTY, to the extent permitted by law; without
 even the implied warranty of MERCHANTABILITY or FITNESS FOR A
 PARTICULAR PURPOSE.
 
+> PublicDomain
 
-> LGPL 2.1
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\lib\md5.c
 
-elfutils-0.169.tar.bz2\elfutils-0.169.tar\elfutils-0.169\libelf\elf.h
-
-Copyright (C) 1995-2014 Free Software Foundation, Inc.
-This file is part of the GNU C Library.
-
-The GNU C Library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation; either
-version 2.1 of the License, or (at your option) any later version.
-
-The GNU C Library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with the GNU C Library; if not, see
-<http://www.gnu.org/licenses/>.
+These are the four functions used in the four steps of the MD5 algorithm
+and defined in the RFC 1321.  The first function is a little bit optimized
+(as found in Colin Plumbs public domain implementation).
 
 >>> findutils-4.6.0-4.ph2
 
@@ -30340,7 +29591,7 @@ sed-4.4.tar.xz\sed-4.4.tar\sed-4.4\lib\alloca.c
 alloca.c -- allocate automatically reclaimed memory
 (Mostly) portable public-domain implementation -- D A Gwyn
 
->>> tar-1.29-2.ph2
+>>> tar-1.29-3.ph2
 
 Copyright (C) 2010-2015 Free Software Foundation, Inc.
 
@@ -33192,7 +32443,7 @@ LICENSE: GPL 3.0
 GNU Library General Public License, V2.0 is applicable to the following component(s).
 
 
->>> glib-2.52.1-3.ph2
+>>> glib-2.52.1-4.ph2
 
 Copyright © 2015 Canonical Limited
 
@@ -33346,7 +32597,7 @@ CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
 ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 POSSIBILITY OF SUCH DAMAGE.
 
-> BSD-4
+> BSD
 
 glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\glib\valgrind.h
 
@@ -33430,13 +32681,10 @@ Copyright (C) 1996, 1997 Elliot Lee
 Mozilla Public License, V2.0 is applicable to the following component(s).
 
 
->>> ca-certificates-20190509-1.ph2
+>>> nspr-4.21-1.ph2
 
-This Source Code Form is subject to the terms of the Mozilla Public
-License, v. 2.0. If a copy of the MPL was not distributed with this
-file, You can obtain one at http://mozilla.org/MPL/2.0/.
-
->>> nspr-4.15-1.ph2
+Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+Use is subject to license terms.
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
@@ -33444,27 +32692,9 @@ file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
 ADDITIONAL LICENSE INFORMATION:
 
-> MPL 2.0
+> BSD-3
 
-[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE MPL 2.0.  PLEASE SEE THE APPENDIX TO REVIEW THE FULL TEXT OF THE MPL 2.0.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
-
-
-nspr-4.15.tar.gz\..\stage\v4.15\src\nspr-4.15.tar\nspr-4.15\nspr\pkg\linux\sun-nspr.spec
-
-Under "MPL/GPL" license.
-
->BEER-WARE LICENSE
-
-nspr-4.15.tar.gz\..\stage\v4.15\src\nspr-4.15.tar\nspr-4.15\nspr\pr\src\malloc\prmalloc.c
-
-"THE BEER-WARE LICENSE" (Revision 42):
-<phk@FreeBSD.ORG> wrote this file.  As long as you retain this notice you
-can do whatever you want with this stuff. If we meet some day, and you think
-this stuff is worth it, you can buy me a beer in return.   Poul-Henning
-
->BSD-3
-
-nspr-4.15.tar.gz\..\stage\v4.15\src\nspr-4.15.tar\nspr-4.15\nspr\pr\src\misc\prcountr.c
+nspr-4.21-1.ph2.src.rpm\nspr-4.21-1.ph2.src.cpio\nspr-4.21.tar.gz\..\stage\v4.21\src\nspr-4.21.tar\nspr-4.21\nspr\pr\src\misc\praton.c
 
 Copyright (c) 1983, 1990, 1993
 The Regents of the University of California.  All rights reserved.
@@ -33493,11 +32723,9 @@ LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
 OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 SUCH DAMAGE.
 
+> MIT
 
->MIT
-
-
-nspr-4.15.tar.gz\..\stage\v4.15\src\nspr-4.15.tar\nspr-4.15\nspr\pr\src\misc\prcountr.c
+nspr-4.21-1.ph2.src.rpm\nspr-4.21-1.ph2.src.cpio\nspr-4.21.tar.gz\..\stage\v4.21\src\nspr-4.21.tar\nspr-4.21\nspr\pr\src\misc\praton.c
 
 Portions Copyright (c) 1993 by Digital Equipment Corporation.
 
@@ -33517,27 +32745,48 @@ PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
 ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
 SOFTWARE.
 
-> MPL-2.0
+> PublicDomain
 
-nspr-4.15.tar.gz\..\stage\v4.15\src\nspr-4.15.tar\nspr-4.15\nspr\pkg\linux\sun-nspr.spec
+nspr-4.21-1.ph2.src.rpm\nspr-4.21-1.ph2.src.cpio\nspr-4.21.tar.gz\..\stage\v4.21\src\nspr-4.21.tar\nspr-4.21\nspr\config\nspr.m4
 
-[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE MPL-2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+Public domain - Chris Seawood <cls@seawood.org> 2001-04-05
+Based upon gtk.m4 (also PD) by Owen Taylor
 
-Under "MPL/GPL" license.
-
->>> nss-3.31.1-1.ph2
+>>> nss-3.44-1.ph2
 
 This Source Code Form is subject to the terms of the Mozilla Public
 License, v. 2.0. If a copy of the MPL was not distributed with this
 file, You can obtain one at http://mozilla.org/MPL/2.0/.
 
+
+This script builds NSS with gyp and ninja.
+
+This build system is still under development.  It does not yet support all
+the features or platforms that NSS supports.
+
 ADDITIONAL LICENSE INFORMATION:
 
-> BSD-2
+> Apache2.0
 
-nss-3.31.1.tar.gz\..\stage\NSS_3_31_1_RTM\src\nss-3.31.1.tar\nss-3.31.1\nss\cmd\libpkix\pkix_pl\module\test_socket.c
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\automation\taskcluster\docker-hacl\license.txt
 
-Test Socket Type
+Copyright 2016-2017 INRIA and Microsoft Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+> BSD-3
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\nss\cmd\libpkix\pkix_pl\module\test_socket.c
 
 Copyright 2004-2005 Sun Microsystems, Inc.  All rights reserved.
 
@@ -33567,76 +32816,51 @@ INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY
 OF LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE THIS SOFTWARE,
 EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
 
-You acknowledge that this software is not designed or intended for use in
-the design, construction, operation or maintenance of any nuclear facility.
+> GPL2.0
 
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\freebl\mpi\montmulfv9.s
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GPL2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+The contents of this file are subject to the Mozilla Public
+License Version 1.1 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of
+the License at http://www.mozilla.org/MPL/
+Software distributed under the License is distributed on an "AS
+IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+implied. See the License for the specific language governing
+rights and limitations under the License.
+The Original Code is SPARC optimized Montgomery multiply functions.
+The Initial Developer of the Original Code is Sun Microsystems Inc.
+Portions created by Sun Microsystems Inc. are
+Copyright (C) 1999-2000 Sun Microsystems Inc.  All Rights Reserved.
+Contributor(s):
+Netscape Communications Corporation
+Alternatively, the contents of this file may be used under the
+terms of the GNU General Public License Version 2 or later (the
+"GPL"), in which case the provisions of the GPL are applicable
+instead of those above.	If you wish to allow use of your
+version of this file only under the terms of the GPL and not to
+allow others to use your version of this file under the MPL,
+indicate your decision by deleting the provisions above and
+replace them with the notice and other provisions required by
+the GPL.  If you do not delete the provisions above, a recipient
+may use your version of this file under either the MPL or the
+GPL.
+
+> LGPL2.1
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\doc\html\derdump.html
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE LGPL2.1 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Licensed under the Mozilla Public License, version 1.1,
+and/or the GNU General Public License, version 2 or later,
+and/or the GNU Lesser General Public License, version 2.1 or later.
 
 > MIT
 
-nss-3.31.1.tar.gz\..\stage\NSS_3_31_1_RTM\src\nss-3.31.1.tar\nss-3.31.1\nss\coreconf\mkdepend\def.h
-
-Copyright (c) 1993, 1994, 1998 The Open Group.
-
-Permission to use, copy, modify, distribute, and sell this software and its
-documentation for any purpose is hereby granted without fee, provided that
-the above copyright notice appear in all copies and that both that
-copyright notice and this permission notice appear in supporting
-documentation.
-
-The above copyright notice and this permission notice shall be included in
-all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
-OPEN GROUP BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
-AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
-CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
-
-> BSD-3
-
-nss-3.31.1.tar.gz\..\stage\NSS_3_31_1_RTM\src\nss-3.31.1.tar\nss-3.31.1\nss\gtests\google_test\gtest\include\gtest\internal\gtest-death-test-internal.h
-
-Copyright 2005, Google Inc.
-All rights reserved.
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are
-met:
-Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-Redistributions in binary form must reproduce the above
-copyright notice, this list of conditions and the following disclaimer
-in the documentation and/or other materials provided with the
-distribution.
-Neither the name of Google Inc. nor the names of its
-contributors may be used to endorse or promote products derived from
-this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
-"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
-LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
-A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
-OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
-SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
-LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
-DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
-THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
->Public Domain
-
-nss-3.31.1.tar.gz\..\stage\NSS_3_31_1_RTM\src\nss-3.31.1.tar\nss-3.31.1\nss\lib\dbm\src\dirent.h
-
-A public domain implementation of BSD directory routines for
-MS-DOS.  Written by Michael Rendell ({uunet,utai}michael@garfield),
-August 1897
-
-
-> MIT- Style
-
-nss-3.31.1.tar.gz\..\stage\NSS_3_31_1_RTM\src\nss-3.31.1.tar\nss-3.31.1\nss\lib\jar\jzlib.h
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\jar\jzlib.h
 
 Copyright (C) 1995-1996 Jean-loup Gailly and Mark Adler
 
@@ -33660,15 +32884,60 @@ Jean-loup Gailly        Mark Adler
 gzip@prep.ai.mit.edu    madler@alumni.caltech.edu
 
 
->MPL 2.0
+The data format used by the zlib library is described by RFCs (Request for
+Comments) 1950 to 1952 in the files ftp://ds.internic.net/rfc/rfc1950.txt
+(zlib format), rfc1951.txt (deflate format) and rfc1952.txt (gzip format).
 
-[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE MPL 2.0.  PLEASE SEE THE APPENDIX TO REVIEW THE FULL TEXT OF THE MPL 2.0.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+This file was modified since it was taken from the zlib distribution */
 
+> MIT
 
-nss-3.31.1.tar.gz\..\stage\NSS_3_31_1_RTM\src\nss-3.31.1.tar\nss-3.31.1\nss\pkg\linux\sun-nss.spec
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\coreconf\mkdepend\ifparser.c
 
-Under "MPL/GPL" license.
+Copyright 1992 Network Computing Devices, Inc.
 
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted, provided
+that the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of Network Computing Devices may not be
+used in advertising or publicity pertaining to distribution of the software
+without specific, written prior permission.  Network Computing Devices makes
+no representations about the suitability of this software for any purpose.
+It is provided ``as is'' without express or implied warranty.
+
+NETWORK COMPUTING DEVICES DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS,
+IN NO EVENT SHALL NETWORK COMPUTING DEVICES BE LIABLE FOR ANY SPECIAL,
+INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+> PublicDomain
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\dbm\src\dirent.h
+
+msd_dir.h 1.4 87/11/06   Public Domain.
+
+A public domain implementation of BSD directory routines for
+MS-DOS.  Written by Michael Rendell ({uunet,utai}michael@garfield),
+August 1897
+
+Extended by Peter Lim (lim@mullian.oz) to overcome some MS DOS quirks
+and returns 2 more pieces of information - file size & attribute.
+Plus a little reshuffling of some #define's positions    December 1987
+
+Some modifications by Martin Junius
+
+> RSA Data Security
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\util\pkcs11p.h
+
+Copyright (C) 1994-1999 RSA Security Inc. Licence to copy this document
+is granted provided that it is identified as "RSA Security Inc. Public-Key
+Cryptography Standards (PKCS)" in all material mentioning or referencing
+this document.
 
 ==================== PART 3. VIRTUAL APPLIANCE: OPERATING SYSTEM LAYER PHOTON#1 ====================
 
@@ -49275,7 +48544,9306 @@ nss-3.31.1.tar.gz\..\stage\NSS_3_31_1_RTM\src\nss-3.31.1.tar\nss-3.31.1\nss\pkg\
 Under "MPL/GPL" license.
 
 
+==================== PART 4. VIRTUAL APPLIANCE: OPERATING SYSTEM LAYER PHOTON#2 ====================
+
+
+--------------- SECTION 1: Academic Free License, V2.1 ----------
+
+Academic Free License, V2.1 is applicable to the following component(s).
+
+
+>>> dbus-1.11.12-1.ph2
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE AFL 2.1 LICENSE.  PLEASE SEE APPENDIX FOR THE FULL TEXT OF THE AFL 2.1 LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+D-Bus is licensed to you under your choice of the Academic Free
+License version 2.1, or the GNU General Public License version 2
+(or, at your option any later version).
+
+Both licenses are included here. Some of the standalone binaries are
+under the GPL only; in particular, but not limited to,
+tools/dbus-cleanup-sockets.c and test/decode-gcov.c. Each source code
+file is marked with the proper copyright information - if you find a
+file that isn't marked please bring it to our attention.
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+dbus-1.11.12.tar.gz\dbus-1.11.12.tar\dbus-1.11.12\cmake\modules\COPYING-CMAKE-SCRIPTS
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the copyright
+   notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+   derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+> Sun Microsystems License (MIT-Style)
+
+dbus-1.11.12.tar.gz\dbus-1.11.12.tar\dbus-1.11.12\dbus\dbus-hash.c
+
+Copyright (c) 1991-1993 The Regents of the University of California.
+Copyright (c) 1994 Sun Microsystems, Inc.
+
+This software is copyrighted by the Regents of the University of
+California, Sun Microsystems, Inc., Scriptics Corporation, and
+other parties.  The following terms apply to all files associated
+with the software unless explicitly disclaimed in individual files.
+
+The authors hereby grant permission to use, copy, modify,
+distribute, and license this software and its documentation for any
+purpose, provided that existing copyright notices are retained in
+all copies and that this notice is included verbatim in any
+distributions. No written agreement, license, or royalty fee is
+required for any of the authorized uses.  Modifications to this
+software may be copyrighted by their authors and need not follow
+the licensing terms described here, provided that the new terms are
+clearly indicated on the first page of each file where they apply.
+
+IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY
+PARTY FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL
+DAMAGES ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION,
+OR ANY DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND
+NON-INFRINGEMENT.  THIS SOFTWARE IS PROVIDED ON AN "AS IS" BASIS,
+AND THE AUTHORS AND DISTRIBUTORS HAVE NO OBLIGATION TO PROVIDE
+MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.
+
+GOVERNMENT USE: If you are acquiring this software on behalf of the
+U.S. government, the Government shall have only "Restricted Rights"
+in the software and related documentation as defined in the Federal
+Acquisition Regulations (FARs) in Clause 52.227.19 (c) (2).  If you
+are acquiring the software on behalf of the Department of Defense,
+the software shall be classified as "Commercial Computer Software"
+and the Government shall have only "Restricted Rights" as defined
+in Clause 252.227-7013 (c) (1) of DFARs.  Notwithstanding the
+foregoing, the authors grant the U.S. Government and others acting
+in its behalf permission to use and distribute the software in
+accordance with the terms specified in this license.
+
+
+> MIT
+
+dbus-1.11.12.tar.gz\dbus-1.11.12.tar\dbus-1.11.12\dbus\dbus-server-launchd.c
+
+Copyright (C) 2007, Tanner Lovelace <lovelace@wayfarer.org>
+Copyright (C) 2008, Colin Walters <walters@verbum.org>
+Copyright (C) 2008-2009, Benjamin Reed <rangerrick@befunk.com>
+Copyright (C) 2009, Jonas Bähr <jonas.baehr@web.de>
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+
+> GPL 2.0
+
+dbus-1.11.12.tar.gz\dbus-1.11.12.tar\dbus-1.11.12\doc\introspect.dtd
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE GPL 2.0 LICENSE.  PLEASE SEE APPENDIX FOR THE FULL TEXT OF THE GPL 2.0 LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+(C) 2005-02-02 David A. Wheeler; released under the D-Bus licenses,
+GNU GPL version 2 (or greater) and AFL 1.1 (or greater)
+
+
+> LGPL 3.0
+
+dbus-1.11.12.tar.gz\dbus-1.11.12.tar\dbus-1.11.12\tools\dbus-cleanup-sockets.c
+
+Copyright (C) 2003 Red Hat, Inc.
+Copyright (C) 2002 Michael Meeks
+ 
+Note that this file is NOT licensed under the Academic Free License,
+as it is based on linc-cleanup-sockets which is LGPL.
+
+
+> GPL 2.0
+
+dbus-1.11.12.tar.gz\dbus-1.11.12.tar\dbus-1.11.12\tools\dbus-echo.c
+
+Copyright © 2003 Philip Blundell <philb@gnu.org>
+Copyright © 2011 Nokia Corporation
+Copyright © 2014 Collabora Ltd.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--------------- SECTION 2: Apache License, V2.0 ----------
+
+Apache License, V2.0 is applicable to the following component(s).
+
+
+>>> filesystem-1.1-3.ph2
+
+Copyright (c) .NET Foundation and Contributors
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+>>> photon-release-2.0-2.ph2
+
+License:    Apache License
+
+--------------- SECTION 3: BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES ----------
+
+BSD-STYLE, MIT-STYLE, OR SIMILAR STYLE LICENSES are applicable to the following component(s).
+
+
+>>> bzip2-1.0.6-8.ph2
+
+This program, "bzip2", the associated library "libbzip2", and all
+documentation, are copyright (C) 1996-2010 Julian R Seward.  All
+rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. The origin of this software must not be misrepresented; you must
+not claim that you wrote the original software.  If you use this
+software in a product, an acknowledgment in the product
+documentation would be appreciated but is not required.
+
+3. Altered source versions must be plainly marked as such, and must
+not be misrepresented as being the original software.
+
+4. The name of the author may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Julian Seward, jseward@bzip.org
+bzip2/libbzip2 version 1.0.6 of 6 September 2010
+
+ADDITIONAL LICENSE INFORMATION :
+
+> GPL 3.0
+
+bzip2_1.0.6-1.debian.tar.bz2\bzip2_1.0.6-1.debian.tar\debian\copyright.in
+
+This package (bzip2) was created by Philippe Troin <phil@fifi.org>.
+It is currently mantained by Anibal Monsalve Salazar <anibal@debian.org>.
+This package is Copyright (C) 1999, 2000, 2001, 2002 Philippe Troin
+<phil@fifi.org> and Copyright (C) 2004-2007 Anibal Monsalve Salazar.
+It is licensed under the GNU General Public License which can be
+found in /usr/share/common-licenses/GPL.
+
+It was downloaded from
+http://www.bzip.org/downloads.html
+
+For more information about bzip2, please visit:
+http://www.bzip.org/
+
+>>> curl-7.59.0-7.ph2
+
+LICENSE: MIT
+
+>>> expat-2.2.4-1.ph2
+
+Copyright (c) 1997-2000 Thai Open Source Software Center Ltd
+   Copyright (c) 2000-2017 Expat development team
+   Licensed under the MIT license:
+
+   Permission is  hereby granted,  free of charge,  to any  person obtaining
+   a  copy  of  this  software   and  associated  documentation  files  (the
+   "Software"),  to  deal in  the  Software  without restriction,  including
+   without  limitation the  rights  to use,  copy,  modify, merge,  publish,
+   distribute, sublicense, and/or sell copies of the Software, and to permit
+   persons  to whom  the Software  is  furnished to  do so,  subject to  the
+   following conditions:
+
+   The above copyright  notice and this permission notice  shall be included
+   in all copies or substantial portions of the Software.
+
+   THE  SOFTWARE  IS  PROVIDED  "AS  IS",  WITHOUT  WARRANTY  OF  ANY  KIND,
+   EXPRESS  OR IMPLIED,  INCLUDING  BUT  NOT LIMITED  TO  THE WARRANTIES  OF
+   MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN
+   NO EVENT SHALL THE AUTHORS OR  COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+   DAMAGES OR  OTHER LIABILITY, WHETHER  IN AN  ACTION OF CONTRACT,  TORT OR
+   OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE
+   USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>>> iputils-20151218-4.ph2
+
+Copyright (c) 1989 The Regents of the University of California.
+All rights reserved.
+
+This code is derived from software contributed to Berkeley by
+Mike Muuss.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+This product includes software developed by the University of
+California, Berkeley and its contributors.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+
+> GPL 2.0
+
+iputils-s20151218.tar.bz2\iputils-s20151218.tar\iputils-s20151218\arping.c
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version
+2 of the License, or (at your option) any later version.
+
+Authors:	Alexey Kuznetsov, <kuznet@ms2.inr.ac.ru>
+YOSHIFUJI Hideaki yoshfuji@linux-ipv6.org
+
+
+> MIT-Style
+
+iputils-s20151218.tar.bz2\iputils-s20151218.tar\iputils-s20151218\rdisc.c
+
+
+Rdisc (this program) was developed by Sun Microsystems, Inc. and is
+provided for unrestricted use provided that this legend is included on
+all tape media and as a part of the software program in whole or part.
+Users may copy or modify Rdisc without charge, and they may freely
+distribute it.
+
+RDISC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
+WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+
+Rdisc is provided with no support and without any obligation on the
+part of Sun Microsystems, Inc. to assist in its use, correction,
+modification or enhancement.
+
+SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY RDISC
+OR ANY PART THEREOF.
+
+In no event will Sun Microsystems, Inc. be liable for any lost revenue
+or profits or other special, indirect and consequential damages, even if
+Sun has been advised of the possibility of such damages.
+
+Sun Microsystems, Inc.
+2550 Garcia Avenue
+Mountain View, California  94043.
+
+>>> krb5-1.17-1.ph2
+
+Copyright 1993 by OpenVision Technologies, Inc.
+
+Permission to use, copy, modify, distribute, and sell this software
+and its documentation for any purpose is hereby granted without fee,
+provided that the above copyright notice appears in all copies and
+that both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of OpenVision not be used
+in advertising or publicity pertaining to distribution of the software
+without specific, written prior permission. OpenVision makes no
+representations about the suitability of this software for any
+purpose.  It is provided "as is" without express or implied warranty.
+
+OPENVISION DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL OPENVISION BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+
+krb5-1.17-1.ph2.src.rpm\krb5-1.17-1.ph2.src.cpio\krb5-1.17.tar.gz\krb5-1.17.tar\krb5-1.17\NOTICE
+
+Copyright (C) 1985-2015 by the Massachusetts Institute of Technology.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Downloading of this software may constitute an export of cryptographic
+software from the United States of America that is subject to the
+United States Export Administration Regulations (EAR), 15 CFR 730-774.
+Additional laws or regulations may apply.  It is the responsibility of
+the person or entity contemplating export to comply with all
+applicable export laws and regulations, including obtaining any
+required license from the U.S. government.
+
+The U.S. government prohibits export of encryption source code to
+certain countries and individuals, including, but not limited to, the
+countries of Cuba, Iran, North Korea, Sudan, Syria, and residents and
+nationals of those countries.
+
+Documentation components of this software distribution are licensed
+under a Creative Commons Attribution-ShareAlike 3.0 Unported License.
+(http://creativecommons.org/licenses/by-sa/3.0/)
+
+Individual source code files are copyright MIT, Cygnus Support,
+Novell, OpenVision Technologies, Oracle, Red Hat, Sun Microsystems,
+FundsXpress, and others.
+
+Project Athena, Athena, Athena MUSE, Discuss, Hesiod, Kerberos, Moira,
+and Zephyr are trademarks of the Massachusetts Institute of Technology
+(MIT).  No commercial use of these trademarks may be made without
+prior written permission of MIT.
+
+"Commercial use" means use of a name in a product or other for-profit
+manner.  It does NOT prevent a commercial firm from referring to the
+MIT trademarks in order to convey information (although in doing so,
+recognition of their trademark status should be given).
+
+======================================================================
+
+The following copyright and permission notice applies to the
+OpenVision Kerberos Administration system located in "kadmin/create",
+"kadmin/dbutil", "kadmin/passwd", "kadmin/server", "lib/kadm5", and
+portions of "lib/rpc":
+
+Copyright, OpenVision Technologies, Inc., 1993-1996, All Rights
+Reserved
+
+WARNING:  Retrieving the OpenVision Kerberos Administration system
+source code, as described below, indicates your acceptance of the
+following terms.  If you do not agree to the following terms, do
+not retrieve the OpenVision Kerberos administration system.
+
+You may freely use and distribute the Source Code and Object Code
+compiled from it, with or without modification, but this Source
+Code is provided to you "AS IS" EXCLUSIVE OF ANY WARRANTY,
+INCLUDING, WITHOUT LIMITATION, ANY WARRANTIES OF MERCHANTABILITY OR
+FITNESS FOR A PARTICULAR PURPOSE, OR ANY OTHER WARRANTY, WHETHER
+EXPRESS OR IMPLIED. IN NO EVENT WILL OPENVISION HAVE ANY LIABILITY
+FOR ANY LOST PROFITS, LOSS OF DATA OR COSTS OF PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES, OR FOR ANY SPECIAL, INDIRECT, OR
+CONSEQUENTIAL DAMAGES ARISING OUT OF THIS AGREEMENT, INCLUDING,
+WITHOUT LIMITATION, THOSE RESULTING FROM THE USE OF THE SOURCE
+CODE, OR THE FAILURE OF THE SOURCE CODE TO PERFORM, OR FOR ANY
+OTHER REASON.
+
+OpenVision retains all copyrights in the donated Source Code.
+OpenVision also retains copyright to derivative works of the Source
+Code, whether created by OpenVision or by a third party. The
+OpenVision copyright notice must be preserved if derivative works
+are made based on the donated Source Code.
+
+OpenVision Technologies, Inc. has donated this Kerberos
+Administration system to MIT for inclusion in the standard Kerberos
+5 distribution. This donation underscores our commitment to
+continuing Kerberos technology development and our gratitude for
+the valuable work which has been performed by MIT and the Kerberos
+community.
+
+======================================================================
+
+Portions contributed by Matt Crawford "crawdad@fnal.gov" were work
+performed at Fermi National Accelerator Laboratory, which is
+operated by Universities Research Association, Inc., under contract
+DE-AC02-76CHO3000 with the U.S. Department of Energy.
+
+======================================================================
+
+Portions of "src/lib/crypto" have the following copyright:
+
+Copyright (C) 1998 by the FundsXpress, INC.
+
+All rights reserved.
+
+Export of this software from the United States of America may
+require a specific license from the United States Government.
+It is the responsibility of any person or organization
+contemplating export to obtain such a license before exporting.
+
+WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+distribute this software and its documentation for any purpose and
+without fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright notice and
+this permission notice appear in supporting documentation, and that
+the name of FundsXpress. not be used in advertising or publicity
+pertaining to distribution of the software without specific,
+written prior permission.  FundsXpress makes no representations
+about the suitability of this software for any purpose.  It is
+provided "as is" without express or implied warranty.
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+======================================================================
+
+The implementation of the AES encryption algorithm in
+"src/lib/crypto/builtin/aes" has the following copyright:
+
+Copyright (C) 2001, Dr Brian Gladman "brg@gladman.uk.net", Worcester, UK.
+All rights reserved.
+
+LICENSE TERMS
+
+The free distribution and use of this software in both source and
+binary form is allowed (with or without changes) provided that:
+
+1. distributions of this source code include the above copyright
+notice, this list of conditions and the following disclaimer;
+
+2. distributions in binary form include the above copyright notice,
+this list of conditions and the following disclaimer in the
+documentation and/or other associated materials;
+
+3. the copyright holder's name is not used to endorse products
+built using this software without specific written permission.
+
+DISCLAIMER
+
+This software is provided 'as is' with no explcit or implied
+warranties in respect of any properties, including, but not limited
+to, correctness and fitness for purpose.
+
+======================================================================
+
+Portions contributed by Red Hat, including the pre-authentication
+plug-in framework and the NSS crypto implementation, contain the
+following copyright:
+
+Copyright (C) 2006 Red Hat, Inc.
+Portions copyright (C) 2006 Massachusetts Institute of Technology
+All Rights Reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of Red Hat, Inc., nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+The bundled verto source code is subject to the following license:
+
+Copyright 2011 Red Hat, Inc.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+======================================================================
+
+The implementations of GSSAPI mechglue in GSSAPI-SPNEGO in
+"src/lib/gssapi", including the following files:
+
+lib/gssapi/generic/gssapi_err_generic.et
+lib/gssapi/mechglue/g_accept_sec_context.c
+lib/gssapi/mechglue/g_acquire_cred.c
+lib/gssapi/mechglue/g_canon_name.c
+lib/gssapi/mechglue/g_compare_name.c
+lib/gssapi/mechglue/g_context_time.c
+lib/gssapi/mechglue/g_delete_sec_context.c
+lib/gssapi/mechglue/g_dsp_name.c
+lib/gssapi/mechglue/g_dsp_status.c
+lib/gssapi/mechglue/g_dup_name.c
+lib/gssapi/mechglue/g_exp_sec_context.c
+lib/gssapi/mechglue/g_export_name.c
+lib/gssapi/mechglue/g_glue.c
+lib/gssapi/mechglue/g_imp_name.c
+lib/gssapi/mechglue/g_imp_sec_context.c
+lib/gssapi/mechglue/g_init_sec_context.c
+lib/gssapi/mechglue/g_initialize.c
+lib/gssapi/mechglue/g_inquire_context.c
+lib/gssapi/mechglue/g_inquire_cred.c
+lib/gssapi/mechglue/g_inquire_names.c
+lib/gssapi/mechglue/g_process_context.c
+lib/gssapi/mechglue/g_rel_buffer.c
+lib/gssapi/mechglue/g_rel_cred.c
+lib/gssapi/mechglue/g_rel_name.c
+lib/gssapi/mechglue/g_rel_oid_set.c
+lib/gssapi/mechglue/g_seal.c
+lib/gssapi/mechglue/g_sign.c
+lib/gssapi/mechglue/g_store_cred.c
+lib/gssapi/mechglue/g_unseal.c
+lib/gssapi/mechglue/g_userok.c
+lib/gssapi/mechglue/g_utils.c
+lib/gssapi/mechglue/g_verify.c
+lib/gssapi/mechglue/gssd_pname_to_uid.c
+lib/gssapi/mechglue/mglueP.h
+lib/gssapi/mechglue/oid_ops.c
+lib/gssapi/spnego/gssapiP_spnego.h
+lib/gssapi/spnego/spnego_mech.c
+
+and the initial implementation of incremental propagation, including
+the following new or changed files:
+
+include/iprop_hdr.h
+kadmin/server/ipropd_svc.c
+lib/kdb/iprop.x
+lib/kdb/kdb_convert.c
+lib/kdb/kdb_log.c
+lib/kdb/kdb_log.h
+lib/krb5/error_tables/kdb5_err.et
+slave/kpropd_rpc.c
+slave/kproplog.c
+
+are subject to the following license:
+
+Copyright (C) 2004 Sun Microsystems, Inc.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+======================================================================
+
+Kerberos V5 includes documentation and software developed at the
+University of California at Berkeley, which includes this copyright
+notice:
+
+Copyright (C) 1983 Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the University nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+======================================================================
+
+Portions contributed by Novell, Inc., including the LDAP database
+backend, are subject to the following license:
+
+Copyright (C) 2004-2005, Novell, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+* The copyright holder's name is not used to endorse or promote
+products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+Portions funded by Sandia National Laboratory and developed by the
+University of Michigan's Center for Information Technology
+Integration, including the PKINIT implementation, are subject to the
+following license:
+
+COPYRIGHT (C) 2006-2007
+THE REGENTS OF THE UNIVERSITY OF MICHIGAN
+ALL RIGHTS RESERVED
+
+Permission is granted to use, copy, create derivative works and
+redistribute this software and such derivative works for any
+purpose, so long as the name of The University of Michigan is not
+used in any advertising or publicity pertaining to the use of
+distribution of this software without specific, written prior
+authorization.  If the above copyright notice or any other
+identification of the University of Michigan is included in any
+copy of any portion of this software, then the disclaimer below
+must also be included.
+
+THIS SOFTWARE IS PROVIDED AS IS, WITHOUT REPRESENTATION FROM THE
+UNIVERSITY OF MICHIGAN AS TO ITS FITNESS FOR ANY PURPOSE, AND
+WITHOUT WARRANTY BY THE UNIVERSITY OF MICHIGAN OF ANY KIND, EITHER
+EXPRESS OR IMPLIED, INCLUDING WITHOUT LIMITATION THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+THE REGENTS OF THE UNIVERSITY OF MICHIGAN SHALL NOT BE LIABLE FOR
+ANY DAMAGES, INCLUDING SPECIAL, INDIRECT, INCIDENTAL, OR
+CONSEQUENTIAL DAMAGES, WITH RESPECT TO ANY CLAIM ARISING OUT OF OR
+IN CONNECTION WITH THE USE OF THE SOFTWARE, EVEN IF IT HAS BEEN OR
+IS HEREAFTER ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+======================================================================
+
+The pkcs11.h file included in the PKINIT code has the following
+license:
+
+Copyright 2006 g10 Code GmbH
+Copyright 2006 Andreas Jellinghaus
+
+This file is free software; as a special exception the author gives
+unlimited permission to copy and/or distribute it, with or without
+modifications, as long as this notice is preserved.
+
+This file is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY, to the extent permitted by law; without even
+the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
+PURPOSE.
+
+======================================================================
+
+Portions contributed by Apple Inc. are subject to the following
+license:
+
+Copyright 2004-2008 Apple Inc.  All Rights Reserved.
+
+Export of this software from the United States of America may
+require a specific license from the United States Government.
+It is the responsibility of any person or organization
+contemplating export to obtain such a license before exporting.
+
+WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+distribute this software and its documentation for any purpose and
+without fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright notice and
+this permission notice appear in supporting documentation, and that
+the name of Apple Inc. not be used in advertising or publicity
+pertaining to distribution of the software without specific,
+written prior permission.  Apple Inc. makes no representations
+about the suitability of this software for any purpose.  It is
+provided "as is" without express or implied warranty.
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+======================================================================
+
+The implementations of UTF-8 string handling in src/util/support and
+src/lib/krb5/unicode are subject to the following copyright and
+permission notice:
+
+The OpenLDAP Public License
+Version 2.8, 17 August 2003
+
+Redistribution and use of this software and associated
+documentation ("Software"), with or without modification, are
+permitted provided that the following conditions are met:
+
+1. Redistributions in source form must retain copyright statements
+and notices,
+
+2. Redistributions in binary form must reproduce applicable
+copyright statements and notices, this list of conditions, and
+the following disclaimer in the documentation and/or other
+materials provided with the distribution, and
+
+3. Redistributions must contain a verbatim copy of this document.
+
+The OpenLDAP Foundation may revise this license from time to time.
+Each revision is distinguished by a version number.  You may use
+this Software under terms of this license revision or under the
+terms of any subsequent revision of the license.
+
+THIS SOFTWARE IS PROVIDED BY THE OPENLDAP FOUNDATION AND ITS
+CONTRIBUTORS "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE OPENLDAP FOUNDATION, ITS
+CONTRIBUTORS, OR THE AUTHOR(S) OR OWNER(S) OF THE SOFTWARE BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+The names of the authors and copyright holders must not be used in
+advertising or otherwise to promote the sale, use or other dealing
+in this Software without specific, written prior permission.  Title
+to copyright in this Software shall at all times remain with
+copyright holders.
+
+OpenLDAP is a registered trademark of the OpenLDAP Foundation.
+
+Copyright 1999-2003 The OpenLDAP Foundation, Redwood City,
+California, USA.  All Rights Reserved.  Permission to copy and
+distribute verbatim copies of this document is granted.
+
+======================================================================
+
+Marked test programs in src/lib/krb5/krb have the following copyright:
+
+Copyright (C) 2006 Kungliga Tekniska HÃ¶gskola
+(Royal Institute of Technology, Stockholm, Sweden).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of KTH nor the names of its contributors may be
+used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY KTH AND ITS CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO,
+THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL KTH OR ITS
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+======================================================================
+
+Portions of the RPC implementation in src/lib/rpc and
+src/include/gssrpc have the following copyright and permission notice:
+
+Copyright (C) 2010, Oracle America, Inc.
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the "Oracle America, Inc." nor the names of
+its contributors may be used to endorse or promote products
+derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+Copyright (C) 2006,2007,2009 NTT (Nippon Telegraph and Telephone
+Corporation).  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer as
+the first lines of this file unmodified.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY NTT "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL NTT BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+======================================================================
+
+Copyright 2000 by Carnegie Mellon University
+
+All Rights Reserved
+
+Permission to use, copy, modify, and distribute this software and
+its documentation for any purpose and without fee is hereby
+granted, provided that the above copyright notice appear in all
+copies and that both that copyright notice and this permission
+notice appear in supporting documentation, and that the name of
+Carnegie Mellon University not be used in advertising or publicity
+pertaining to distribution of the software without specific,
+written prior permission.
+
+CARNEGIE MELLON UNIVERSITY DISCLAIMS ALL WARRANTIES WITH REGARD TO
+THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY
+AND FITNESS, IN NO EVENT SHALL CARNEGIE MELLON UNIVERSITY BE LIABLE
+FOR ANY SPECIAL, INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN
+AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING
+OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+======================================================================
+
+Copyright (C) 2002 Naval Research Laboratory (NRL/CCS)
+
+Permission to use, copy, modify and distribute this software and
+its documentation is hereby granted, provided that both the
+copyright notice and this permission notice appear in all copies of
+the software, derivative works or modified versions, and any
+portions thereof.
+
+NRL ALLOWS FREE USE OF THIS SOFTWARE IN ITS "AS IS" CONDITION AND
+DISCLAIMS ANY LIABILITY OF ANY KIND FOR ANY DAMAGES WHATSOEVER
+RESULTING FROM THE USE OF THIS SOFTWARE.
+
+======================================================================
+
+Portions extracted from Internet RFCs have the following copyright
+notice:
+
+Copyright (C) The Internet Society (2006).
+
+This document is subject to the rights, licenses and restrictions
+contained in BCP 78, and except as set forth therein, the authors
+retain all their rights.
+
+This document and the information contained herein are provided on
+an "AS IS" basis and THE CONTRIBUTOR, THE ORGANIZATION HE/SHE
+REPRESENTS OR IS SPONSORED BY (IF ANY), THE INTERNET SOCIETY AND
+THE INTERNET ENGINEERING TASK FORCE DISCLAIM ALL WARRANTIES,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY WARRANTY THAT
+THE USE OF THE INFORMATION HEREIN WILL NOT INFRINGE ANY RIGHTS OR
+ANY IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE.
+
+======================================================================
+
+Copyright (C) 1991, 1992, 1994 by Cygnus Support.
+
+Permission to use, copy, modify, and distribute this software and
+its documentation for any purpose and without fee is hereby
+granted, provided that the above copyright notice appear in all
+copies and that both that copyright notice and this permission
+notice appear in supporting documentation. Cygnus Support makes no
+representations about the suitability of this software for any
+purpose.  It is provided "as is" without express or implied
+warranty.
+
+======================================================================
+
+Copyright (C) 2006 Secure Endpoints Inc.
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+======================================================================
+
+Portions of the implementation of the Fortuna-like PRNG are subject to
+the following notice:
+
+Copyright (C) 2005 Marko Kreen
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+Copyright (C) 1994 by the University of Southern California
+
+EXPORT OF THIS SOFTWARE from the United States of America may
+require a specific license from the United States Government. It
+is the responsibility of any person or organization
+contemplating export to obtain such a license before exporting.
+
+WITHIN THAT CONSTRAINT, permission to copy, modify, and distribute
+this software and its documentation in source and binary forms is
+hereby granted, provided that any documentation or other materials
+related to such distribution or use acknowledge that the software
+was developed by the University of Southern California.
+
+DISCLAIMER OF WARRANTY.  THIS SOFTWARE IS PROVIDED "AS IS".  The
+University of Southern California MAKES NO REPRESENTATIONS OR
+WARRANTIES, EXPRESS OR IMPLIED.  By way of example, but not
+limitation, the University of Southern California MAKES NO
+REPRESENTATIONS OR WARRANTIES OF MERCHANTABILITY OR FITNESS FOR ANY
+PARTICULAR PURPOSE. The University of Southern California shall not
+be held liable for any liability nor for any direct, indirect, or
+consequential damages with respect to any claim by the user or
+distributor of the ksu software.
+
+======================================================================
+
+Copyright (C) 1995
+The President and Fellows of Harvard University
+
+This code is derived from software contributed to Harvard by Jeremy
+Rassen.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. All advertising materials mentioning features or use of this
+software must display the following acknowledgement:
+
+This product includes software developed by the University of
+California, Berkeley and its contributors.
+
+4. Neither the name of the University nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+======================================================================
+
+Copyright (C) 2008 by the Massachusetts Institute of Technology.
+Copyright 1995 by Richard P. Basch.  All Rights Reserved.
+Copyright 1995 by Lehman Brothers, Inc.  All Rights Reserved.
+
+Export of this software from the United States of America may
+require a specific license from the United States Government. It
+is the responsibility of any person or organization
+contemplating export to obtain such a license before exporting.
+
+WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+distribute this software and its documentation for any purpose and
+without fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright notice and
+this permission notice appear in supporting documentation, and that
+the name of Richard P. Basch, Lehman Brothers and M.I.T. not be
+used in advertising or publicity pertaining to distribution of the
+software without specific, written prior permission.  Richard P.
+Basch, Lehman Brothers and M.I.T. make no representations about the
+suitability of this software for any purpose.  It is provided "as
+is" without express or implied warranty.
+
+======================================================================
+
+The following notice applies to "src/lib/krb5/krb/strptime.c" and
+"src/include/k5-queue.h".
+
+Copyright (C) 1997, 1998 The NetBSD Foundation, Inc.
+All rights reserved.
+
+This code was contributed to The NetBSD Foundation by Klaus Klein.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. All advertising materials mentioning features or use of this
+software must display the following acknowledgement:
+
+This product includes software developed by the NetBSD
+Foundation, Inc. and its contributors.
+
+4. Neither the name of The NetBSD Foundation nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+======================================================================
+
+The following notice applies to Unicode library files in
+"src/lib/krb5/unicode":
+
+Copyright 1997, 1998, 1999 Computing Research Labs,
+New Mexico State University
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use, copy,
+modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT.  IN NO EVENT SHALL THE COMPUTING RESEARCH LAB OR
+NEW MEXICO STATE UNIVERSITY BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE
+OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+======================================================================
+
+The following notice applies to "src/util/support/strlcpy.c":
+
+Copyright (C) 1998 Todd C. Miller "Todd.Miller@courtesan.com"
+
+Permission to use, copy, modify, and distribute this software for
+any purpose with or without fee is hereby granted, provided that
+the above copyright notice and this permission notice appear in all
+copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS
+OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+======================================================================
+
+The following notice applies to "src/util/profile/argv_parse.c" and
+"src/util/profile/argv_parse.h":
+
+Copyright 1999 by Theodore Ts'o.
+
+Permission to use, copy, modify, and distribute this software for
+any purpose with or without fee is hereby granted, provided that
+the above copyright notice and this permission notice appear in all
+copies.  THE SOFTWARE IS PROVIDED "AS IS" AND THEODORE TS'O (THE
+AUTHOR) DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS. IN
+NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.  (Isn't
+it sick that the U.S. culture of lawsuit-happy lawyers requires
+this kind of disclaimer?)
+
+======================================================================
+
+The following notice applies to SWIG-generated code in
+"src/util/profile/profile_tcl.c":
+
+Copyright (C) 1999-2000, The University of Chicago
+
+This file may be freely redistributed without license or fee
+provided this copyright message remains intact.
+
+======================================================================
+
+The following notice applies to portiions of "src/lib/rpc" and
+"src/include/gssrpc":
+
+Copyright (C) 2000 The Regents of the University of Michigan. All
+rights reserved.
+
+Copyright (C) 2000 Dug Song "dugsong@UMICH.EDU". All rights
+reserved, all wrongs reversed.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of the University nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+======================================================================
+
+Implementations of the MD4 algorithm are subject to the following
+notice:
+
+Copyright (C) 1990, RSA Data Security, Inc. All rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD4 Message Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD4 Message Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose.  It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+
+======================================================================
+
+Implementations of the MD5 algorithm are subject to the following
+notice:
+
+Copyright (C) 1990, RSA Data Security, Inc. All rights reserved.
+
+License to copy and use this software is granted provided that it
+is identified as the "RSA Data Security, Inc. MD5 Message- Digest
+Algorithm" in all material mentioning or referencing this software
+or this function.
+
+License is also granted to make and use derivative works provided
+that such works are identified as "derived from the RSA Data
+Security, Inc. MD5 Message-Digest Algorithm" in all material
+mentioning or referencing the derived work.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose.  It is provided "as is"
+without express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+
+======================================================================
+
+The following notice applies to
+"src/lib/crypto/crypto_tests/t_mddriver.c":
+
+Copyright (C) 1990-2, RSA Data Security, Inc. Created 1990. All
+rights reserved.
+
+RSA Data Security, Inc. makes no representations concerning either
+the merchantability of this software or the suitability of this
+software for any particular purpose. It is provided "as is" without
+express or implied warranty of any kind.
+
+These notices must be retained in any copies of any part of this
+documentation and/or software.
+
+======================================================================
+
+Portions of "src/lib/krb5" are subject to the following notice:
+
+Copyright (C) 1994 CyberSAFE Corporation.
+Copyright 1990,1991,2007,2008 by the Massachusetts Institute of Technology.
+All Rights Reserved.
+
+Export of this software from the United States of America may
+require a specific license from the United States Government. It
+is the responsibility of any person or organization
+contemplating export to obtain such a license before exporting.
+
+WITHIN THAT CONSTRAINT, permission to use, copy, modify, and
+distribute this software and its documentation for any purpose and
+without fee is hereby granted, provided that the above copyright
+notice appear in all copies and that both that copyright notice and
+this permission notice appear in supporting documentation, and that
+the name of M.I.T. not be used in advertising or publicity
+pertaining to distribution of the software without specific,
+written prior permission.  Furthermore if you modify this software
+you must label your software as modified software and not
+distribute it in such a fashion that it might be confused with the
+original M.I.T. software. Neither M.I.T., the Open Computing
+Security Group, nor CyberSAFE Corporation make any representations
+about the suitability of this software for any purpose.  It is
+provided "as is" without express or implied warranty.
+
+======================================================================
+
+Portions contributed by PADL Software are subject to the following
+license:
+
+Copyright (c) 2011, PADL Software Pty Ltd. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials provided
+with the distribution.
+
+3. Neither the name of PADL Software nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY PADL SOFTWARE AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL PADL SOFTWARE
+OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF
+USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT
+OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+======================================================================
+
+The bundled libev source code is subject to the following license:
+
+All files in libev are Copyright (C)2007,2008,2009 Marc Alexander
+Lehmann.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+Alternatively, the contents of this package may be used under the
+terms of the GNU General Public License ("GPL") version 2 or any
+later version, in which case the provisions of the GPL are
+applicable instead of the above. If you wish to allow the use of
+your version of this package only under the terms of the GPL and
+not to allow others to use your version of this file under the BSD
+license, indicate your decision by deleting the provisions above
+and replace them with the notice and other provisions required by
+the GPL in this and the other files of this package. If you do not
+delete the provisions above, a recipient may use your version of
+this file under either the BSD or the GPL.
+
+======================================================================
+
+Files copied from the Intel AESNI Sample Library are subject to the
+following license:
+
+Copyright (C) 2010, Intel Corporation
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+* Neither the name of Intel Corporation nor the names of its
+contributors may be used to endorse or promote products
+derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE
+COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+> GPL 2.0
+
+krb5-1.17-1.ph2.src.rpm\krb5-1.17-1.ph2.src.cpio\krb5-1.17.tar.gz\krb5-1.17.tar\krb5-1.17\src\util\send-pr\send-pr.1
+
+man page for send-pr (by Heinz G. Seidl, hgs@cygnus.com)
+updated Feb 1993 for GNATS 3.00 by Jeffrey Osier, jeffrey@cygnus.com
+
+This file is part of the Problem Report Management System (GNATS)
+Copyright 1992 Cygnus Support
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this program; if not, write to the Free
+Software Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA
+
+
+> Public Domain
+
+krb5-1.17-1.ph2.src.rpm\krb5-1.17-1.ph2.src.cpio\krb5-1.17.tar.gz\krb5-1.17.tar\krb5-1.17\src\util\support\gmt_mktime.c
+
+This code placed in the public domain by Mark W. Eichin
+
+>>> libarchive-3.3.1-4.ph2
+
+Copyright (c) 2003-2009 <author(s)>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer
+in this position and unchanged.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR(S) ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+>MIT Style
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\build\autoconf\ax_require_defined.m4
+
+Copyright (c) 2014 Mike Frysinger <vapier@gentoo.org>
+
+Copying and distribution of this file, with or without modification, are
+permitted in any medium without royalty provided the copyright notice
+and this notice are preserved. This file is offered as-is, without any
+warranty.
+
+>Apache 2.0
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\contrib\android\Android.mk
+
+Copyright (C) 2014 Trevor Drake
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+>BSD – 4Clause
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\contrib\shar\shar.1
+
+Copyright (c) 1990, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+This product includes software developed by the University of
+California, Berkeley and its contributors.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+>MIT
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\doc\mdoc2man.awk
+
+Copyright (c) 2003 Peter Stuge <stuge-mdoc2man@cdy.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+>Public Domain
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\libarchive\archive_getdate.c
+
+This code is in the public domain and has no copyright.
+
+This is a plain C recursive-descent translation of an old
+public-domain YACC grammar that has been used for parsing dates in
+very many open-source projects.
+
+Since the original authors were generous enough to donate their
+work to the public domain, I feel compelled to match their
+generosity.
+
+Tim Kientzle, February 2009.
+
+>BSD – 3Clause
+
+libarchive-3.3.1.tar.gz\libarchive-3.3.1.tar\libarchive-3.3.1\libarchive\mtree.5
+
+Copyright (c) 1989, 1990, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+>>> libcap-2.25-7.ph2
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD-3.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Unless otherwise *explicitly* stated the following text describes the
+licensed conditions under which the contents of this module release
+may be distributed:
+
+-------------------------------------------------------------------------
+Redistribution and use in source and binary forms of this module, with
+or without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistributions of source code must retain any existing copyright
+   notice, and this entire permission notice in its entirety,
+   including the disclaimer of warranties.
+
+2. Redistributions in binary form must reproduce all prior and current
+   copyright notices, this list of conditions, and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+
+3. The name of any author may not be used to endorse or promote
+   products derived from this software without their specific prior
+   written permission.
+
+ALTERNATIVELY, this product may be distributed under the terms of the
+GNU Library General Public License, in which case the provisions of
+the GNU LGPL are required INSTEAD OF the above restrictions.  (This
+clause is necessary due to a potential conflict between the GNU LGPL
+and the restrictions contained in a BSD-style copyright.)
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+>>> libdb-5.3.28-1.ph2
+
+The following is the license that applies to this copy of the Berkeley DB
+software.  For a license to use the Berkeley DB software under conditions
+other than those described here, or to purchase support for this software,
+please contact Oracle at berkeleydb-info_us@oracle.com.
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+Copyright (c) 1990, 2013 Oracle and/or its affiliates.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Redistributions in any form must be accompanied by information on
+how to obtain complete source code for the DB software and any
+accompanying software that uses the DB software.  The source code
+must either be included in the distribution or be available for no
+more than the cost of distribution plus a nominal fee, and must be
+freely redistributable under reasonable conditions.  For an
+executable file, complete source code means the source code for all
+modules it contains.  It does not include source code for modules or
+files that typically accompany the major components of the operating
+system on which the executable file runs.
+
+THIS SOFTWARE IS PROVIDED BY ORACLE ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, OR
+NON-INFRINGEMENT, ARE DISCLAIMED.  IN NO EVENT SHALL ORACLE BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+Copyright (c) 1990, 1993, 1994, 1995
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+
+Copyright (c) 1995, 1996
+The President and Fellows of Harvard University.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY HARVARD AND ITS CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL HARVARD OR ITS CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+
+ASM: a very small and fast Java bytecode manipulation framework
+Copyright (c) 2000-2005 INRIA, France Telecom
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holders nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF
+THE POSSIBILITY OF SUCH DAMAGE.
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+>BSD-4
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\src\clib\atol.c
+
+Copyright (c) 1988, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+This product includes software developed by the University of
+California, Berkeley and its contributors.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+>ARTISTIC 2.0
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\src\crypto\mersenne\mt19937db.c
+
+This library is free software under the Artistic license:
+see the file COPYING distributed together with this code.
+For the verification of the code, its output sequence file
+mt19937int.out is attached (2001/4/2)
+
+>PUBLIC DOMAIN
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\src\crypto\rijndael\rijndael-alg-fst.c
+
+
+rijndael-alg-fst.c
+
+@version 3.0 (December 2000)
+
+Optimised ANSI C code for the Rijndael cipher (now AES)
+
+@author Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
+@author Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
+@author Paulo Barreto <paulo.barreto@terra.com.br>
+
+This code is hereby placed in the public domain.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ''AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+>PUBLIC DOMAIN
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\src\hmac\sha1.c
+
+SHA-1 in C
+By Steve Reid <sreid@sea-to-sky.net>
+100% Public Domain
+>MS-PL
+
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\docs\csharp\TOC.js
+
+
+Note    : Copyright 2006-2009, Eric Woodruff, All rights reserved
+Compiler: JavaScript
+
+This file contains the methods necessary to implement a simple tree view
+for the table of content with a resizable splitter and Ajax support to
+load tree nodes on demand.  It also contains the script necessary to do
+full-text searches.
+
+This code is published under the Microsoft Public License (Ms-PL).  A copy
+of the license should be distributed with the code.  It can also be found
+at the project website: http://SHFB.CodePlex.com.   This notice, the
+author's name, and all copyright notices must remain intact in all
+applications, documentation, and source files.
+
+>MIT
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\dist\aclocal\ltoptions.m4
+
+Copyright (C) 2004, 2005, 2007, 2008, 2009 Free Software Foundation,
+Inc.
+Written by Gary V. Vaughan, 2004
+
+This file is free software; the Free Software Foundation gives
+unlimited permission to copy and/or distribute it, with or without
+modifications, as long as this notice is preserved.
+
+>GPL 2.0
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\lang\perl\BerkeleyDB\BerkeleyDB.pm
+
+[VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBCOMPONENT UNDER THE TERMS OF THE GPL v2  LICENSE THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (c) 1997-2011 Paul Marquess. All rights reserved.
+This program is free software; you can redistribute it and/or
+modify it under the same terms as Perl itself.
+
+
+>APACHE 2.0
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\lang\php_db4\db4.cpp
+
+Copyright (c) 2004, 2013 Oracle and/or its affiliates.  All rights reserved.
+
+http://www.apache.org/licenses/LICENSE-2.0.txt
+
+authors: George Schlossnagle george@omniti.com
+
+>MIT STYLE
+
+libdb-5.3.28-1.ph2.src.rpm\libdb-5.3.28-1.ph2.src.cpio\db-5.3.28.tar.gz\db-5.3.28.tar\db-5.3.28\lang\sql\jdbc\license.terms
+
+This software is copyrighted by Christian Werner <chw@ch-werner.de> and others.
+The following terms apply to all files associated with the software
+unless explicitly disclaimed in individual files.
+
+The authors hereby grant permission to use, copy, modify, distribute,
+and license this software and its documentation for any purpose, provided
+that existing copyright notices are retained in all copies and that this
+notice is included verbatim in any distributions. No written agreement,
+license, or royalty fee is required for any of the authorized uses.
+Modifications to this software may be copyrighted by their authors
+and need not follow the licensing terms described here, provided that
+the new terms are clearly indicated on the first page of each file where
+they apply.
+
+IN NO EVENT SHALL THE AUTHORS OR DISTRIBUTORS BE LIABLE TO ANY PARTY
+FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES
+ARISING OUT OF THE USE OF THIS SOFTWARE, ITS DOCUMENTATION, OR ANY
+DERIVATIVES THEREOF, EVEN IF THE AUTHORS HAVE BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+THE AUTHORS AND DISTRIBUTORS SPECIFICALLY DISCLAIM ANY WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT.  THIS SOFTWARE
+IS PROVIDED ON AN "AS IS" BASIS, AND THE AUTHORS AND DISTRIBUTORS HAVE
+NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR
+MODIFICATIONS.
+
+>>> libffi-3.2.1-5.ph2
+
+libffi - Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+See source files for details.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+``Software''), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 2.0
+
+libffi-3.2.1.tar.gz\libffi-3.2.1.tar\libffi-3.2.1\libtool-ldflags
+
+Copyright (C) 2005 Free Software Foundation, Inc.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+ 
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, 
+MA 02110-1301, USA. 
+
+
+> LGPL 2.1
+
+libffi-3.2.1.tar.gz\libffi-3.2.1.tar\libffi-3.2.1\msvcc.sh
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE LGPL 2.1 LICENSE.  PLEASE SEE APPENDIX FOR THE FULL TEXT OF THE LGPL 2.1 LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+***** BEGIN LICENSE BLOCK *****
+Version: MPL 1.1/GPL 2.0/LGPL 2.1
+
+The contents of this file are subject to the Mozilla Public License Version
+1.1 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+for the specific language governing rights and limitations under the
+License.
+
+The Original Code is the MSVC wrappificator.
+
+The Initial Developer of the Original Code is
+Timothy Wall <twalljava@dev.java.net>.
+Portions created by the Initial Developer are Copyright (C) 2009
+the Initial Developer. All Rights Reserved.
+
+Contributor(s):
+Daniel Witte <dwitte@mozilla.com>
+
+Alternatively, the contents of this file may be used under the terms of
+either the GNU General Public License Version 2 or later (the "GPL"), or
+the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+in which case the provisions of the GPL or the LGPL are applicable instead
+of those above. If you wish to allow use of your version of this file only
+under the terms of either the GPL or the LGPL, and not to allow others to
+use your version of this file under the terms of the MPL, indicate your
+decision by deleting the provisions above and replace them with the notice
+and other provisions required by the GPL or the LGPL. If you do not delete
+the provisions above, a recipient may use your version of this file under
+the terms of any one of the MPL, the GPL or the LGPL.
+
+***** END LICENSE BLOCK *****
+
+
+> Public Domain
+
+libffi-3.2.1.tar.gz\libffi-3.2.1.tar\libffi-3.2.1\src\dlmalloc.c
+
+This is a version (aka dlmalloc) of malloc/free/realloc written by
+Doug Lea and released to the public domain, as explained at
+http://creativecommons.org/licenses/publicdomain.  Send questions,
+comments, complaints, performance data, etc to dl@cs.oswego.edu
+
+>>> libsolv-0.6.26-4.ph2
+
+Copyright (c) 2000-2001, Aaron D. Gifford
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the copyright holder nor the names of contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTOR(S) ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTOR(S) BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Public Domain
+
+libsolv-0.6.26.tar.gz\libsolv-0.6.26.tar\libsolv-0.6.26\src\sha1.h
+
+this file is in the public domain
+
+>>> libssh2-1.8.2-1.ph2
+
+Copyright (c) 2004-2007 Sara Golemon <sarag@libssh2.org>
+Copyright (c) 2005,2006 Mikhail Gusarov <dottedmag@dottedmag.net>
+Copyright (c) 2006-2007 The Written Word, Inc.
+Copyright (c) 2007 Eli Fant <elifantu@mail.ru>
+Copyright (c) 2009-2014 Daniel Stenberg
+Copyright (C) 2008, 2009 Simon Josefsson
+All rights reserved.
+
+Redistribution and use in source and binary forms,
+with or without modification, are permitted provided
+that the following conditions are met:
+
+Redistributions of source code must retain the above
+copyright notice, this list of conditions and the
+following disclaimer.
+
+Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+Neither the name of the copyright holder nor the names
+of any other contributors may be used to endorse or
+promote products derived from this software without
+specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND
+CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY
+OF SUCH DAMAGE.
+
+>>> libtirpc-1.0.1-8.ph2
+
+Copyright (c) Copyright (c) Bull S.A.  2005  All Rights Reserved.
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+ADDITIONAL LICENSE INFORMATION:
+
+>GPL 2.0
+
+libtirpc-1.0.1\src\debug.h
+
+Copyright (C) 2014  Red Hat, Steve Dickson <steved@redhat.com>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor,
+Boston, MA 02110-1301, USA.
+
+>LGPL 2.1
+
+libtirpc-1.0.1\src\des_impl.c
+
+Copyright (C) 1992 Eric Young
+Collected from libdes and modified for SECURE RPC by Martin Kuck 1994
+This file is distributed under the terms of the GNU Lesser General
+Public License, version 2.1 or later - see the file COPYING.LIB for details.
+If you did not receive a copy of the license with this program, please
+see <http://www.gnu.org/licenses/> to obtain a copy.
+
+>Sun Microsystem (MIT-Style)
+
+libtirpc-1.0.1\tirpc\rpc\key_prot.h
+
+Sun RPC is a product of Sun Microsystems, Inc. and is provided for
+unrestricted use provided that this legend is included on all tape
+media and as a part of the software program in whole or part.  Users
+may copy or modify Sun RPC without charge, but are not authorized
+to license or distribute it to anyone else except as part of a product or
+program developed by the user.
+SUN RPC IS PROVIDED AS IS WITH NO WARRANTIES OF ANY KIND INCLUDING THE
+WARRANTIES OF DESIGN, MERCHANTIBILITY AND FITNESS FOR A PARTICULAR
+PURPOSE, OR ARISING FROM A COURSE OF DEALING, USAGE OR TRADE PRACTICE.
+Sun RPC is provided with no support and without any obligation on the
+part of Sun Microsystems, Inc. to assist in its use, correction,
+modification or enhancement.
+SUN MICROSYSTEMS, INC. SHALL HAVE NO LIABILITY WITH RESPECT TO THE
+INFRINGEMENT OF COPYRIGHTS, TRADE SECRETS OR ANY PATENTS BY SUN RPC
+OR ANY PART THEREOF.
+In no event will Sun Microsystems, Inc. be liable for any lost revenue
+or profits or other special, indirect and consequential damages, even if
+Sun has been advised of the possibility of such damages.
+Sun Microsystems, Inc.
+2550 Garcia Avenue
+Mountain View, California  94043.
+
+>>> linux-pam-1.3.0-1.ph2
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD-3 LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Unless otherwise *explicitly* stated the following text describes the
+licensed conditions under which the contents of this Linux-PAM release
+may be distributed:
+
+-------------------------------------------------------------------------
+Redistribution and use in source and binary forms of Linux-PAM, with
+or without modification, are permitted provided that the following
+conditions are met:
+
+1. Redistributions of source code must retain any existing copyright
+   notice, and this entire permission notice in its entirety,
+   including the disclaimer of warranties.
+
+2. Redistributions in binary form must reproduce all prior and current
+   copyright notices, this list of conditions, and the following
+   disclaimer in the documentation and/or other materials provided
+   with the distribution.
+
+3. The name of any author may not be used to endorse or promote
+   products derived from this software without their specific prior
+   written permission.
+
+ALTERNATIVELY, this product may be distributed under the terms of the
+GNU General Public License, in which case the provisions of the GNU
+GPL are required INSTEAD OF the above restrictions.  (This clause is
+necessary due to a potential conflict between the GNU GPL and the
+restrictions contained in a BSD-style copyright.)
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR(S) BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS
+OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR
+TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+-------------------------------------------------------------------------
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 3.0 with Bison Parser Exception
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\conf\pam_conv1\pam_conv_y.c
+
+Bison implementation for Yacc-like parsers in C
+
+Copyright (C) 1984, 1989-1990, 2000-2012 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+As a special exception, you may create a larger work that contains
+part or all of the Bison parser skeleton and distribute that work
+under terms of your choice, so long as that work isn't itself a
+parser generator using the skeleton or a modified version thereof
+as a parser skeleton.  Alternatively, if you modify or redistribute
+the parser skeleton itself, you may (at your option) remove this
+special exception, which will cause the skeleton and the resulting
+Bison output files to be licensed under the GNU General Public
+License without this special exception.
+
+This special exception was added by the Free Software Foundation in
+version 2.2 of Bison.
+
+
+> BSD
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\modules\pam_access\pam_access.c
+
+Copyright 1995 by Wietse Venema. All rights reserved. Individual files
+may be covered by other copyrights (as noted in the file itself.)
+
+This material was originally written and compiled by Wietse Venema at
+Eindhoven University of Technology, The Netherlands, in 1990, 1991,
+1992, 1993, 1994 and 1995.
+
+Redistribution and use in source and binary forms are permitted
+provided that this entire copyright notice is duplicated in all such
+copies.
+
+This software is provided "as is" and without any expressed or implied
+warranties, including, without limitation, the implied warranties of
+merchantibility and fitness for any particular purpose.
+
+
+> LGPL 2.0
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\modules\pam_issue\pam_issue.c
+
+Copyright 1999 by Ben Collins <bcollins@debian.org>
+Released under the GNU LGPL version 2 or later
+
+
+> GPL 2.0
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\modules\pam_loginuid\pam_loginuid.c
+
+Copyright 2005 Red Hat Inc., Durham, North Carolina.
+All Rights Reserved.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Suite 500
+Boston, MA 02110-1335 USA
+
+
+> Public Domain
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\modules\pam_namespace\md5.c
+
+This code implements the MD5 message-digest algorithm.
+The algorithm is due to Ron Rivest.  This code was
+written by Colin Plumb in 1993, no copyright is claimed.
+This code is in the public domain; do with it what you wish.
+
+
+> MIT
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\modules\pam_namespace\argv_parse.c
+
+Copyright 1999 by Theodore Ts'o.
+
+Permission to use, copy, modify, and distribute this software for
+any purpose with or without fee is hereby granted, provided that
+the above copyright notice and this permission notice appear in all
+copies.  THE SOFTWARE IS PROVIDED "AS IS" AND THEODORE TS'O (THE
+AUTHOR) DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER
+RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR
+IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+
+> BSD-3
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\modules\pam_tally2\pam_tally2.c
+
+Portions Copyright 2006, Red Hat, Inc.
+Portions Copyright 1989 - 1993, Julianne Frances Haugh
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of Julianne F. Haugh nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY JULIE HAUGH AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL JULIE HAUGH OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+
+> Beer-Ware License (MIT-Style)
+
+Linux-PAM-1.3.0.tar.bz2\Linux-PAM-1.3.0.tar\Linux-PAM-1.3.0\modules\pam_unix\md5_crypt.c
+
+"THE BEER-WARE LICENSE" (Revision 42):
+<phk@login.dknet.dk> wrote this file.  As long as you retain this notice you
+can do whatever you want with this stuff. If we meet some day, and you think
+this stuff is worth it, you can buy me a beer in return.   Poul-Henning Kamp
+
+>>> lsof-4.89-2.ph2
+
+Copyright 1994 Purdue Research Foundation, West Lafayette, Indiana
+47907.  All rights reserved.
+
+Written by Victor A. Abell
+
+This software is not subject to any license of the American Telephone
+and Telegraph Company or the Regents of the University of California.
+
+Permission is granted to anyone to use this software for any purpose on
+any computer system, and to alter it and redistribute it freely, subject
+to the following restrictions:
+
+1. Neither the authors nor Purdue University are responsible for any
+consequences of the use of this software.
+
+2. The origin of this software must not be misrepresented, either by
+explicit claim or by omission.  Credit to the authors and Purdue
+University must appear in documentation and sources.
+
+3. Altered versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+
+4. This notice may not be removed or altered.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD
+
+lsof_4.89.tar.gz\lsof_4.89.tar\lsof_4.89\lsof_4.89_src.tar\lsof_4.89_src\dialects\freebsd\include\procfs\pfsnode.h
+
+Copyright (c) 1993 Paul Kranenburg
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+This product includes software developed by Paul Kranenburg.
+4. The name of the author may not be used to endorse or promote products
+derived from this software withough specific prior written permission
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+> GPL 2.0
+
+lsof_4.89.tar.gz\lsof_4.89.tar\lsof_4.89\lsof_4.89_src.tar\lsof_4.89_src\scripts\sort_res.perl5
+
+Copyright (c) 2004, 2005 - Fabian Frederick <fabian.frederick@gmx.fr>
+
+This program/include file is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program/include file is distributed in the hope that it will be
+useful, but WITHOUT ANY WARRANTY; without even the implied warranty
+of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (in the main directory of the Linux-NTFS
+distribution in the file COPYING); if not, write to the Free Software
+Foundation,Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+
+>>> ncurses-6.0-14.ph2
+
+Upstream source http://invisible-island.net/ncurses/ncurses-examples.html
+
+Current ncurses maintainer: Thomas Dickey <dickey@invisible-island.net>
+
+-------------------------------------------------------------------------------
+Files: *
+Copyright: 1998-2016,2017 Free Software Foundation, Inc.
+Licence: X11
+
+Files: aclocal.m4 package
+Copyright: 2010-2016,2017 by Thomas E. Dickey
+Licence: X11
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the
+    "Software"), to deal in the Software without restriction, including
+    without limitation the rights to use, copy, modify, merge, publish,
+    distribute, distribute with modifications, sublicense, and/or sell
+    copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included
+    in all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+    OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+    MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+    IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+    DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+    OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+    THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+    Except as contained in this notice, the name(s) of the above copyright
+    holders shall not be used in advertising or otherwise to promote the
+    sale, use or other dealings in this Software without prior written
+    authorization.
+
+-------------------------------------------------------------------------------
+Files: install-sh
+Copyright:  1994 X Consortium
+Licence: X11
+
+    Permission is hereby granted, free of charge, to any person obtaining a copy
+    of this software and associated documentation files (the "Software"), to
+    deal in the Software without restriction, including without limitation the
+    rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+    sell copies of the Software, and to permit persons to whom the Software is
+    furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+    X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+    AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNEC-
+    TION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+    Except as contained in this notice, the name of the X Consortium shall not
+    be used in advertising or otherwise to promote the sale, use or other deal-
+    ings in this Software without prior written authorization from the X Consor-
+    tium.
+
+    FSF changes to this file are in the public domain.
+
+    Calling this script install-sh is preferred over install.sh, to prevent
+    `make' implicit rules from creating a file called install from it
+    when there is no Makefile.
+
+    This script is compatible with the BSD install script, but was written
+    from scratch.  It can only install one file at a time, a restriction
+    shared with many OS's install programs.
+
+On Debian systems, the complete text of the GNU General
+Public License can be found in '/usr/share/common-licenses/GPL-2'
+
+-- vile: txtmode file-encoding=utf-8
+
+>>> openssh-7.5p1-14.ph2
+
+This file is part of the OpenSSH software.
+
+The licences which components of this software fall under are as
+follows.  First, we will summarize and say that all components
+are under a BSD licence, or a licence more free than that.
+
+OpenSSH contains no GPL code.
+
+1)
+Copyright (c) 1995 Tatu Ylonen <ylo@cs.hut.fi>, Espoo, Finland
+All rights reserved
+
+As far as I am concerned, the code I have written for this software
+can be used freely for any purpose.  Any derived versions of this
+software must be clearly marked as such, and if the derived work is
+incompatible with the protocol description in the RFC file, it must be
+called by a name other than "ssh" or "Secure Shell".
+
+[Tatu continues]
+However, I am not implying to give any licenses to any patents or
+copyrights held by third parties, and the software includes parts that
+are not under my direct control.  As far as I know, all included
+source code is used in accordance with the relevant license agreements
+and can be used freely for any purpose (the GNU license being the most
+restrictive); see below for details.
+
+[However, none of that term is relevant at this point in time.  All of
+these restrictively licenced software components which he talks about
+have been removed from OpenSSH, i.e.,
+
+- RSA is no longer included, found in the OpenSSL library
+- IDEA is no longer included, its use is deprecated
+- DES is now external, in the OpenSSL library
+- GMP is no longer used, and instead we call BN code from OpenSSL
+- Zlib is now external, in a library
+- The make-ssh-known-hosts script is no longer included
+- TSS has been removed
+- MD5 is now external, in the OpenSSL library
+- RC4 support has been replaced with ARC4 support from OpenSSL
+- Blowfish is now external, in the OpenSSL library
+
+[The licence continues]
+
+Note that any information and cryptographic algorithms used in this
+software are publicly available on the Internet and at any major
+bookstore, scientific library, and patent office worldwide.  More
+information can be found e.g. at "http://www.cs.hut.fi/crypto".
+
+The legal status of this program is some combination of all these
+permissions and restrictions.  Use only at your own responsibility.
+You will be responsible for any legal consequences yourself; I am not
+making any claims whether possessing or using this is legal or not in
+your country, and I am not taking any responsibility on your behalf.
+
+
+NO WARRANTY
+
+BECAUSE THE PROGRAM IS LICENSED FREE OF CHARGE, THERE IS NO WARRANTY
+FOR THE PROGRAM, TO THE EXTENT PERMITTED BY APPLICABLE LAW.  EXCEPT WHEN
+OTHERWISE STATED IN WRITING THE COPYRIGHT HOLDERS AND/OR OTHER PARTIES
+PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED
+OR IMPLIED, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE.  THE ENTIRE RISK AS
+TO THE QUALITY AND PERFORMANCE OF THE PROGRAM IS WITH YOU.  SHOULD THE
+PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF ALL NECESSARY SERVICING,
+REPAIR OR CORRECTION.
+
+IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
+WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MAY MODIFY AND/OR
+REDISTRIBUTE THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES,
+INCLUDING ANY GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING
+OUT OF THE USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED
+TO LOSS OF DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY
+YOU OR THIRD PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER
+PROGRAMS), EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGES.
+
+2)
+The 32-bit CRC compensation attack detector in deattack.c was
+contributed by CORE SDI S.A. under a BSD-style license.
+
+Cryptographic attack detector for ssh - source code
+
+Copyright (c) 1998 CORE SDI S.A., Buenos Aires, Argentina.
+
+All rights reserved. Redistribution and use in source and binary
+forms, with or without modification, are permitted provided that
+this copyright notice is retained.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES ARE DISCLAIMED. IN NO EVENT SHALL CORE SDI S.A. BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY OR
+CONSEQUENTIAL DAMAGES RESULTING FROM THE USE OR MISUSE OF THIS
+SOFTWARE.
+
+Ariel Futoransky <futo@core-sdi.com>
+<http://www.core-sdi.com>
+
+3)
+ssh-keyscan was contributed by David Mazieres under a BSD-style
+license.
+
+Copyright 1995, 1996 by David Mazieres <dm@lcs.mit.edu>.
+
+Modification and redistribution in source and binary forms is
+permitted provided that due credit is given to the author and the
+OpenBSD project by leaving this copyright notice intact.
+
+4)
+The Rijndael implementation by Vincent Rijmen, Antoon Bosselaers
+and Paulo Barreto is in the public domain and distributed
+with the following license:
+
+@version 3.0 (December 2000)
+
+Optimised ANSI C code for the Rijndael cipher (now AES)
+
+@author Vincent Rijmen <vincent.rijmen@esat.kuleuven.ac.be>
+@author Antoon Bosselaers <antoon.bosselaers@esat.kuleuven.ac.be>
+@author Paulo Barreto <paulo.barreto@terra.com.br>
+
+This code is hereby placed in the public domain.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHORS ''AS IS'' AND ANY EXPRESS
+OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+5)
+One component of the ssh source code is under a 3-clause BSD license,
+held by the University of California, since we pulled these parts from
+original Berkeley code.
+
+Copyright (c) 1983, 1990, 1992, 1993, 1995
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+6)
+Remaining components of the software are provided under a standard
+2-term BSD licence with the following names as copyright holders:
+
+Markus Friedl
+Theo de Raadt
+Niels Provos
+Dug Song
+Aaron Campbell
+Damien Miller
+Kevin Steves
+Daniel Kouril
+Wesley Griffin
+Per Allansson
+Nils Nordman
+Simon Wilkinson
+
+Portable OpenSSH additionally includes code from the following copyright
+holders, also under the 2-term BSD license:
+
+Ben Lindstrom
+Tim Rice
+Andre Lucas
+Chris Adams
+Corinna Vinschen
+Cray Inc.
+Denis Parker
+Gert Doering
+Jakob Schlyter
+Jason Downs
+Juha Yrjölä
+Michael Stone
+Networks Associates Technology, Inc.
+Solar Designer
+Todd C. Miller
+Wayne Schroeder
+William Jones
+Darren Tucker
+Sun Microsystems
+The SCO Group
+Daniel Walsh
+Red Hat, Inc
+Simon Vallet / Genoscope
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+8) Portable OpenSSH contains the following additional licenses:
+
+a) md5crypt.c, md5crypt.h
+
+"THE BEER-WARE LICENSE" (Revision 42):
+<phk@login.dknet.dk> wrote this file.  As long as you retain this
+notice you can do whatever you want with this stuff. If we meet
+some day, and you think this stuff is worth it, you can buy me a
+beer in return.   Poul-Henning Kamp
+
+b) snprintf replacement
+
+Copyright Patrick Powell 1995
+This code is based on code written by Patrick Powell
+(papowell@astart.com) It may be used for any purpose as long as this
+notice remains intact on all source code distributions
+
+c) Compatibility code (openbsd-compat)
+
+Apart from the previously mentioned licenses, various pieces of code
+in the openbsd-compat/ subdirectory are licensed as follows:
+
+Some code is licensed under a 3-term BSD license, to the following
+copyright holders:
+
+Todd C. Miller
+Theo de Raadt
+Damien Miller
+Eric P. Allman
+The Regents of the University of California
+Constantin S. Svintsoff
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+Some code is licensed under an ISC-style license, to the following
+copyright holders:
+
+Internet Software Consortium.
+Todd C. Miller
+Reyk Floeter
+Chad Mynhier
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND TODD C. MILLER DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL TODD C. MILLER BE LIABLE
+FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION
+OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN
+CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Some code is licensed under a MIT-style license to the following
+copyright holders:
+
+Free Software Foundation, Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, distribute with modifications, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included
+in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS
+OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE ABOVE COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM,
+DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR
+OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR
+THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name(s) of the above copyright
+holders shall not be used in advertising or otherwise to promote the
+sale, use or other dealings in this Software without prior written
+authorization.
+------
+$OpenBSD: LICENCE,v 1.19 2004/08/30 09:18:08 markus Exp $
+
+>>> openssl-1.0.2s-1.ph2
+
+LICENSE ISSUES
+
+
+The OpenSSL toolkit stays under a double license, i.e. both the conditions of
+the OpenSSL License and the original SSLeay license apply to the toolkit.
+See below for the actual license texts. Actually both licenses are BSD-style
+Open Source licenses. In case of any license issues related to OpenSSL
+please contact openssl-core@openssl.org.
+
+OpenSSL License
+
+Copyright (c) 1998-2018 The OpenSSL Project.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+3. All advertising materials mentioning features or use of this
+software must display the following acknowledgment:
+"This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit. (http://www.openssl.org/)"
+
+4. The names "OpenSSL Toolkit" and "OpenSSL Project" must not be used to
+endorse or promote products derived from this software without
+prior written permission. For written permission, please contact
+openssl-core@openssl.org.
+
+5. Products derived from this software may not be called "OpenSSL"
+nor may "OpenSSL" appear in their names without prior written
+permission of the OpenSSL Project.
+
+6. Redistributions of any form whatsoever must retain the following
+acknowledgment:
+"This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit (http://www.openssl.org/)"
+
+THIS SOFTWARE IS PROVIDED BY THE OpenSSL PROJECT ``AS IS'' AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE OpenSSL PROJECT OR
+ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+This product includes cryptographic software written by Eric Young
+(eay@cryptsoft.com).  This product includes software written by Tim
+Hudson (tjh@cryptsoft.com).
+
+
+
+Original SSLeay License
+
+
+ Copyright (C) 1995-1998 Eric Young (eay@cryptsoft.com)
+All rights reserved.
+
+This package is an SSL implementation written
+by Eric Young (eay@cryptsoft.com).
+The implementation was written so as to conform with Netscapes SSL.
+
+This library is free for commercial and non-commercial use as long as
+the following conditions are aheared to.  The following conditions
+apply to all code found in this distribution, be it the RC4, RSA,
+lhash, DES, etc., code; not just the SSL code.  The SSL documentation
+included with this distribution is covered by the same copyright terms
+except that the holder is Tim Hudson (tjh@cryptsoft.com).
+
+Copyright remains Eric Young's, and as such any Copyright notices in
+the code are not to be removed.
+If this package is used in a product, Eric Young should be given attribution
+as the author of the parts of the library used.
+This can be in the form of a textual message at program startup or
+in documentation (online or textual) provided with the package.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+"This product includes cryptographic software written by
+Eric Young (eay@cryptsoft.com)"
+The word 'cryptographic' can be left out if the rouines from the library
+being used are not cryptographic related :-).
+4. If you include any Windows specific code (or a derivative thereof) from
+the apps directory (application code) you must include an acknowledgement:
+"This product includes software written by Tim Hudson (tjh@cryptsoft.com)"
+
+THIS SOFTWARE IS PROVIDED BY ERIC YOUNG ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+The licence and distribution terms for any publically available version or
+derivative of this code cannot be changed.  i.e. this code cannot simply be
+copied and put under another distribution licence
+[including the GNU Public Licence.]
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Apache2.0
+
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\ec\ec_curve.c
+
+Written by Bodo Moeller for the OpenSSL project.
+/
+/ Copyright 2011 Google Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+> BSD
+
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\camellia\asm\ cmll-x86_64.pl
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (c) 2008 Andy Polyakov <appro@openssl.org>
+
+This module may be used under the terms of either the GNU General
+Public License version 2 or later, the GNU Lesser General Public
+License version 2.1 or later, the Mozilla Public License version
+1.1 or the BSD License. The exact terms of either license are
+distributed along with this module. For further details see
+http://www.openssl.org/~appro/camellia/.
+
+> BSD-2
+
+openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\seed\seed.c
+
+Copyright (c) 2007 KISA(Korea Information Security Agency). All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Neither the name of author nor the names of its contributors may
+be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL AUTHOR OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> BSD-3
+
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\x509v3\ v3_pci.c
+
+Copyright (c) 2004 Kungliga Tekniska Högskolan
+(Royal Institute of Technology, Stockholm, Sweden).
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+3. Neither the name of the Institute nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE INSTITUTE AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE INSTITUTE OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> BSD-4
+
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\demos\demos\easy_tls\easy-tls.c
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-4 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+(c) Copyright 1999 Bodo Moeller.  All rights reserved.
+
+This is free software; you can redistributed and/or modify it
+unter the terms of either
+-  the GNU General Public License as published by the
+Free Software Foundation, version 1, or (at your option)
+any later version,
+or
+-  the following license:
+/
+/-
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that each of the following
+conditions is met:
+
+1. Redistributions qualify as "freeware" or "Open Source Software" under
+one of the following terms:
+
+(a) Redistributions are made at no charge beyond the reasonable cost of
+materials and delivery.
+
+(b) Redistributions are accompanied by a copy of the Source Code
+or by an irrevocable offer to provide a copy of the Source Code
+for up to three years at the cost of materials and delivery.
+Such redistributions must allow further use, modification, and
+redistribution of the Source Code under substantially the same
+terms as this license.
+
+2. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+3. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+4. All advertising materials mentioning features or use of this
+software must display the following acknowledgment:
+"This product includes software developed by Bodo Moeller."
+(If available, substitute umlauted o for oe.)
+
+5. Redistributions of any form whatsoever must retain the following
+acknowledgment:
+"This product includes software developed by Bodo Moeller."
+
+THIS SOFTWARE IS PROVIDED BY BODO MOELLER ``AS IS'' AND ANY
+EXPRESSED OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL BODO MOELLER OR
+HIS CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT
+NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+/
+/-
+Attribution for OpenSSL library:
+
+This product includes cryptographic software written by Eric Young
+(eay@cryptsoft.com).  This product includes software written by Tim
+Hudson (tjh@cryptsoft.com).
+This product includes software developed by the OpenSSL Project
+for use in the OpenSSL Toolkit. (http://www.openssl.org/)
+
+> MIT
+
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\\crypto\md5\asm\ md5-ia64.S
+
+Copyright (c) 2005 Hewlett-Packard Development Company, L.P.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE
+
+> OpenSSL
+
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\aes\asm\bsaes-armv7.pl
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE OPENSSL LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Written by Andy Polyakov <appro@openssl.org> for the OpenSSL
+project. The module is, however, dual licensed under OpenSSL and
+CRYPTOGAMS licenses depending on where you obtain it. For further
+details see http://www.openssl.org/~appro/cryptogams/.
+
+Specific modes and adaptation for Linux kernel by Ard Biesheuvel
+<ard.biesheuvel@linaro.org>. Permission to use under GPL terms is
+granted.
+
+> PublicDomain
+
+openssl-1.0.2s-1.ph2.src.rpm\openssl-1.0.2s-1.ph2.src.cpio\openssl-1.0.2s.tar.gz\openssl-1.0.2s.tar\openssl-1.0.2s\crypto\aes\asm\vpaes-x86.pl
+
+Constant-time SSSE3 AES core implementation.
+version 0.1
+
+By Mike Hamburg (Stanford University), 2009
+Public domain.
+
+For details see http://shiftleft.org/papers/vector_aes/ and
+http://crypto.stanford.edu/vpaes/.
+
+>>> pcre-8.41-1.ph2
+
+PCRE LICENCE
+------------
+
+PCRE is a library of functions to support regular expressions whose syntax
+and semantics are as close as possible to those of the Perl 5 language.
+
+Release 8 of PCRE is distributed under the terms of the "BSD" licence, as
+specified below. The documentation for PCRE, supplied in the "doc"
+directory, is distributed under the same terms as the software itself. The data
+in the testdata directory is not copyrighted and is in the public domain.
+
+The basic library functions are written in C and are freestanding. Also
+included in the distribution is a set of C++ wrapper functions, and a
+just-in-time compiler that can be used to optimize pattern matching. These
+are both optional features that can be omitted when the library is built.
+
+
+THE BASIC LIBRARY FUNCTIONS
+---------------------------
+
+Written by:       Philip Hazel
+Email local part: ph10
+Email domain:     cam.ac.uk
+
+University of Cambridge Computing Service,
+Cambridge, England.
+
+Copyright (c) 1997-2017 University of Cambridge
+All rights reserved.
+
+
+PCRE JUST-IN-TIME COMPILATION SUPPORT
+-------------------------------------
+
+Written by:       Zoltan Herczeg
+Email local part: hzmester
+Emain domain:     freemail.hu
+
+Copyright(c) 2010-2017 Zoltan Herczeg
+All rights reserved.
+
+
+STACK-LESS JUST-IN-TIME COMPILER
+--------------------------------
+
+Written by:       Zoltan Herczeg
+Email local part: hzmester
+Emain domain:     freemail.hu
+
+Copyright(c) 2009-2017 Zoltan Herczeg
+All rights reserved.
+
+
+THE C++ WRAPPER FUNCTIONS
+-------------------------
+
+Contributed by:   Google Inc.
+
+Copyright (c) 2007-2012, Google Inc.
+All rights reserved.
+
+
+THE "BSD" LICENCE
+-----------------
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of the University of Cambridge nor the name of Google
+Inc. nor the names of their contributors may be used to endorse or
+promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+End
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD 2 clause
+
+pcre-8.41.tar.bz2\pcre-8.41.tar\pcre-8.41\sljit\sljitConfigInternal.h
+
+Copyright Zoltan Herczeg (hzmester@freemail.hu). All rights reserved.
+
+Redistribution and use in source and binary forms, with or without modification, are
+permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this list of
+conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice, this list
+of conditions and the following disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDER(S) AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT
+SHALL THE COPYRIGHT HOLDER(S) OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED
+TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>MIT STYLE
+
+pcre-8.41.tar.bz2\pcre-8.41.tar\pcre-8.41\aclocal.m4
+
+Copyright (C) 1996-2014 Free Software Foundation, Inc.
+
+Copyright (C) 1996-2014 Free Software Foundation, Inc.
+
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+>>> popt-1.16-5.ph2
+
+Copyright (c) 1998  Red Hat Software
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the X Consortium shall not be
+used in advertising or otherwise to promote the sale, use or other dealings
+in this Software without prior written authorization from the X Consortium.
+
+>>> shadow-4.2.1-16.ph2
+
+Copyright (c) 1991 - 1994, Julianne Frances Haugh
+Copyright (c) 1996 - 2000, Marek Michalkiewicz
+Copyright (c) 2000 - 2006, Tomasz Kloczko
+Copyright (c) 2007 - 2011, Nicolas François
+All rights reserved
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1 Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer
+2 Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution
+3 The name of the copyright holders or contributors may not be used to
+endorse or promote products derived from this software without
+specific prior written permission
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A
+PARTICULAR PURPOSE ARE DISCLAIMED  IN NO EVENT SHALL THE COPYRIGHT
+HOLDERS OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 2.0
+
+shadow-421tarxz\shadow-421tar\shadow-421\src\vipwc
+
+Copyright (c) 1997       , Guy Maor <maor@eceutexasedu>
+Copyright (c) 1999 - 2000, Marek Michalkiewicz
+Copyright (c) 2002 - 2006, Tomasz Kloczko
+Copyright (c) 2007 - 2013, Nicolas François
+All rights reserved
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE See the GNU
+General Public License for more details
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc, 51 Franklin Street, Fifth Floor,
+Boston, MA 02110-1301, USA
+
+
+udbachktgz
+
+
+> BSD Style
+
+shadow-421tarxz\shadow-421tar\shadow-421\src\login_nopamc
+
+Copyright 1995 by Wietse Venema  All rights reserved Individual files
+may be covered by other copyrights (as noted in the file itself)
+
+This material was originally written and compiled by Wietse Venema at
+Eindhoven University of Technology, The Netherlands, in 1990, 1991,
+1992, 1993, 1994 and 1995
+
+Redistribution and use in source and binary forms are permitted
+provided that this entire copyright notice is duplicated in all such
+copies
+
+This software is provided "as is" and without any expressed or implied
+warranties, including, without limitation, the implied warranties of
+merchantibility and fitness for any particular purpose
+
+
+> Public Domain
+
+shadow-421tarxz\shadow-421tar\shadow-421\man\zh_TW\man1\newgrp1
+
+Original author unknown  This man page is in the public domain
+Modified Sat Oct  9 17:46:48 1993 by faith@csuncedu
+TH NEWGRP 1 "9 October 1993" "Linux 12" "Linux Programmer's Manual"
+
+
+> GPL 3.0
+
+shadow-421tarxz\shadow-421tar\shadow-421\man\tr\man1\chfn.1
+
+chfn.1 -- change your finger information
+(c) 1994 by salvatore valente <svalente@athena.mit.edu>
+this program is free software.  you can redistribute it and
+modify it under the terms of the gnu general public license.
+there is no warranty.
+
+> MIT-Style
+
+shadow-421tarxz\shadow-421tar\shadow-421\aclocalm4
+
+Copyright (C) 1996, 1997, 1998, 1999, 2000, 2001, 2002, 2003, 2004,
+2005, 2006, 2007, 2008, 2009, 2010, 2011 Free Software Foundation,
+Inc
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE
+
+
+> BSD
+
+[PLEASE NOTE:  VMWARE, INC ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD LICENSE THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE]
+
+shadow-421tarxz\shadow-421tar\shadow-421\man\tr\man1\passwd1
+
+Copyright Red Hat, Inc, 1998, 1999, 2002
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1 Redistributions of source code must retain the above copyright
+notice, and the entire permission notice in its entirety,
+including the disclaimer of warranties
+2 Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution
+3 The name of the author may not be used to endorse or promote
+products derived from this software without specific prior
+written permission
+
+ALTERNATIVELY, this product may be distributed under the terms of
+the GNU Public License, in which case the provisions of the GPL are
+required INSTEAD OF the above restrictions  (This clause is
+necessary due to a potential bad interaction between the GPL and
+the restrictions contained in a BSD-style copyright)
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE
+
+Copyright (c) Cristian Gafton, 1998, <gafton@redhatcom>
+
+
+
+>  LDP General Public License 1.0
+
+shadow-421tarxz\shadow-421tar\shadow-421\man\hu\man1\su1
+
+You may copy, distribute and modify under the terms of the LDP General
+Public License as specified in the LICENSE file that comes with the
+gnumaniak distribution
+
+The author kindly requests that no comments regarding the "better"
+suitability or up\-to\-date notices of any info documentation alternative
+is added without contacting him first
+
+(C) 1999 Ragnar Hojland Espinosa <ragnar@maculanet>
+
+GNU su man page
+man pages are NOT obsolete!
+<ragnar@maculanet>
+TH su 1 "18 August 1999" "GNU Shell Utilities 20"
+
+>>> sqlite-3.27.2-3.ph2
+
+The author disclaims copyright to this source code.  In place of
+a legal notice, here is a blessing:
+
+May you do good and not evil.
+May you find forgiveness for yourself and forgive others.
+May you share freely, never taking more than you give.
+
+>>> sudo-1.8.20p2-5.ph2
+
+Sudo is distributed under the following license:
+
+Copyright (c) 1994-1996, 1998-2017
+Todd C. Miller <Todd.Miller@courtesan.com>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+Sponsored in part by the Defense Advanced Research Projects
+Agency (DARPA) and Air Force Research Laboratory, Air Force
+Materiel Command, USAF, under agreement number F39502-99-1-0512.
+
+The file redblack.c bears the following license:
+
+Copyright (c) 2001 Emin Martinian
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that neither the name of Emin
+Martinian nor the names of any contributors are be used to endorse or
+promote products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The file reallocarray.c bears the following license:
+
+Copyright (c) 2008 Otto Moerbeek <otto@drijf.net>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+The files getcwd.c, glob.c, glob.h, snprintf.c and sudo_queue.h bear the
+following license:
+
+Copyright (c) 1989, 1990, 1991, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+The file fnmatch.c bears the following license:
+
+Copyright (c) 2011, VMware, Inc.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+Neither the name of the VMware, Inc. nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL VMWARE, INC. OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF
+THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+The file getopt_long.c bears the following license:
+
+
+Copyright (c) 2000 The NetBSD Foundation, Inc.
+All rights reserved.
+
+This code is derived from software contributed to The NetBSD Foundation
+by Dieter Baron and Thomas Klausner.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE NETBSD FOUNDATION, INC. AND CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED
+TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE FOUNDATION OR CONTRIBUTORS
+BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+
+The file inet_pton.c bears the following license:
+
+Copyright (c) 1996 by Internet Software Consortium.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+
+The embedded copy of zlib bears the following license:
+
+Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly        Mark Adler
+jloup@gzip.org          madler@alumni.caltech.edu
+
+> PUBLIC DOMAIN
+
+sudo-1.8.20p2.tar.gz\sudo-1.8.20p2.tar\sudo-1.8.20p2\lib\util\regress\glob\globtest.c
+
+Public domain, 2008, Todd C. Miller Todd.Miller@courtesan.com
+
+>>> vim-8.0.0533-7.ph2
+
+Vim is Charityware.  You can use and copy it as much as you like, but you are
+encouraged to make a donation to help orphans in Uganda.  Please read the file
+`runtime/doc/uganda.txt` for details (do `:help uganda` inside Vim).
+
+Summary of the license: There are no restrictions on using or distributing an
+unmodified copy of Vim.  Parts of Vim may also be distributed, but the license
+text must always be included.  For modified versions a few restrictions apply.
+The license is GPL compatible, you may compile Vim with GPL libraries and
+distribute it.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL2.0
+
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\runtime\tools\efm_perl.pl
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GPL2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (c) 2001 by Joerg Ziefle <joerg.ziefle@gmx.de>
+You may use and distribute this software under the same terms as Perl itself.
+
+> GPL3.0
+
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\runtime\plugin\tarPlugin.vim
+
+tarPlugin.vim -- a Vim plugin for browsing tarfiles
+Original was copyright (c) 2002, Michael C. Toren <mct@toren.net>
+Modified by Charles E. Campbell
+Distributed under the GNU General Public License.
+
+> MIT
+
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\runtime\autoload\netrwFileHandlers.vim
+
+Copyright (C) 1999-2012 Charles E. Campbell {{{1
+Permission is hereby granted to use and distribute this code,
+with or without modifications, provided that this copyright
+notice is copied with it. Like anything else that's free,
+netrwFileHandlers.vim is provided *as is* and comes with no
+warranty of any kind, either expressed or implied. In no
+event will the copyright holder be liable for any damages
+resulting from the use of this software.
+
+> PublicDomain
+
+vim-8.0.0533-7.ph2.src.rpm\vim-8.0.0533-7.ph2.src.cpio\vim-8.0.0533.tar.gz\vim-8.0.0533.tar\vim-8.0.0533\src\tee\tee.c
+
+Copyright (c) 1996, Paul Slootman
+
+Author: Paul Slootman
+(paul@wurtel.hobby.nl, paul@murphy.nl, paulS@toecompst.nl)
+Modifications for MSVC: Yasuhiro Matsumoto
+
+This source code is released into the public domain. It is provided on an
+as-is basis and no responsibility is accepted for its failure to perform
+as expected. It is worth at least as much as you paid for it!
+
+>>> xz-5.2.3-2.ph2
+
+Author: Lasse Collin
+This file has been put into the public domain.
+You can do whatever you want with this file.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 2.0
+
+xz-5.2.3.tar.xz\xz-5.2.3.tar\xz-5.2.3\src\scripts\xzmore.in
+
+Copyright (C) 2001, 2002, 2007 Free Software Foundation
+Copyright (C) 1992, 1993 Jean-loup Gailly
+
+Modified for XZ Utils by Andrew Dudman and Lasse Collin.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+> MIT-Style
+
+xz-5.2.3.tar.xz\xz-5.2.3.tar\xz-5.2.3\m4\visibility.m4
+
+Copyright (C) 2005, 2008-2010 Free Software Foundation, Inc.
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+> LGPL 2.1
+
+xz-5.2.3.tar.xz\xz-5.2.3.tar\xz-5.2.3\lib\ getopt1.c
+
+Copyright (C) 1987,88,89,90,91,92,93,94,96,97,98,2004,2006
+Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License along
+with this program; if not, write to the Free Software Foundation,
+Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+ 
+> GPL 3.0
+
+xz-5.2.3.tar.xz\xz-5.2.3.tar\xz-5.2.3\COPYING.GPLv3
+
+License: GPL 3.0
+
+>>> zlib-1.2.11-1.ph2
+
+Copyright (C) 1995-2017 Jean-loup Gailly and Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly        Mark Adler
+jloup@gzip.org          madler@alumni.caltech.edu
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 2.0
+
+zlib-1.2.11.tar.gz\zlib-1.2.11.tar\zlib-1.2.11\contrib\ada\zlib.ads
+
+Copyright (C) 20022004 Dmitriy Anisimkov
+
+This library is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or (at
+your option) any later version.
+
+This library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this library; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place  Suite 330, Boston, MA 021111307, USA.
+
+As a special exception, if other files instantiate generics from this
+unit, or you link this unit with other files to produce an executable,
+this  unit  does not  by itself cause  the resulting executable to be
+covered by the GNU General Public License. This exception does not
+however invalidate any other reasons why the executable file  might be
+covered by the  GNU Public License.
+
+> BSD-Style
+
+zlib-1.2.11.tar.gz\zlib-1.2.11.tar\zlib-1.2.11\contrib\amd64\ amd64-match.S
+
+This is free software; you can redistribute it and/or modify it
+under the terms of the BSD License. Use by owners of Che Guevarra
+parafernalia is prohibited, where possible, and highly discouraged
+elsewhere.
+
+> MIT-Style (Boost Software License)
+
+zlib-1.2.11.tar.gz\zlib-1.2.11.tar\zlib-1.2.11\contrib\dotzlib\LICENSE_1_0.txt
+
+Boost Software License - Version 1.0 - August 17th, 2003
+
+Permission is hereby granted, free of charge, to any person or organization
+obtaining a copy of the software and accompanying documentation covered by
+this license (the "Software") to use, reproduce, display, distribute,
+execute, and transmit the Software, and to prepare derivative works of the
+Software, and to permit third-parties to whom the Software is furnished to
+do so, all subject to the following:
+
+The copyright notices in the Software and this entire statement, including
+the above license grant, this restriction and the following disclaimer,
+must be included in all copies of the Software, in whole or in part, and
+all derivative works of the Software, unless such copies or derivative
+works are solely in the form of machine-executable object code generated by
+a source language processor.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE, TITLE AND NON-INFRINGEMENT. IN NO EVENT
+SHALL THE COPYRIGHT HOLDERS OR ANYONE DISTRIBUTING THE SOFTWARE BE LIABLE
+FOR ANY DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+
+> Public Domain
+
+zlib-1.2.11.tar.gz\zlib-1.2.11.tar\zlib-1.2.11\examples\ fitblk.c
+
+fitblk.c: example of fitting compressed output to a specified size
+Not copyrighted -- provided to the public domain
+Version 1.1  25 November 2004  Mark Adler
+
+--------------- SECTION 4: GNU General Public License, V2.0 ----------
+
+GNU General Public License, V2.0 is applicable to the following component(s).
+
+
+>>> ca-certificates-20190521-1.ph2
+
+Copyright (C) 2009 Philipp Kern <pkern@debian.org>
+
+ This program is free software; you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation; either version 2 of the License, or
+ (at your option) any later version.
+
+ This program is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with this program; if not, write to the Free Software
+ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301,
+ USA.
+
+>>> e2fsprogs-1.43.4-2.ph2
+
+Written by Theodore Ts'o, Copyright 2007, 2008, 2009.
+
+This file may be redistributed under the terms of the  GNU Public License, version 2.
+
+ADDITIONAL LICENSE INFORMATION :
+
+> GPL 3.0
+
+e2fsprogs-1.43.4.tar.gz\e2fsprogs-1.43.4.tar\e2fsprogs-1.43.4\contrib\fallocate.c
+
+Copyright (C) 2008 Red Hat, Inc. All rights reserved.
+Written by Eric Sandeen <sandeen@redhat.com>
+
+cvtnum routine taken from xfsprogs,
+Copyright (c) 2003-2005 Silicon Graphics, Inc.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation.
+
+This program is distributed in the hope that it would be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA.
+
+> Public Domain
+
+e2fsprogs-1.43.4.tar.gz\e2fsprogs-1.43.4.tar\e2fsprogs-1.43.4\config\mkinstalldirs
+
+mkinstalldirs --- make directory hierarchy
+Author: Noah Friedman <friedman@prep.ai.mit.edu>
+Created: 1993-05-16
+Public domain.
+
+> LGPL 2.0
+
+e2fsprogs-1.43.4.tar.gz\e2fsprogs-1.43.4.tar\e2fsprogs-1.43.4\e2fsck\mtrace.c
+
+Copyright (C) 1991, 1992 Free Software Foundation, Inc.
+Written April 2, 1991 by John Gilmore of Cygnus Support.
+Based on mcheck.c by Mike Haertel.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this library; see the file COPYING.LIB.  If
+not, write to the Free Software Foundation, Inc., 675 Mass Ave,
+Cambridge, MA 02139, USA.
+
+> MIT-Style
+
+e2fsprogs-1.43.4.tar.gz\e2fsprogs-1.43.4.tar\e2fsprogs-1.43.4\aclocal.m4
+
+Copyright (C) 1996-2013 Free Software Foundation, Inc.
+
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+> BSD-3 Clause
+
+e2fsprogs-1.43.4.tar.gz\e2fsprogs-1.43.4.tar\e2fsprogs-1.43.4\lib\uuid\COPYING
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+   notice, and the entire permission notice in its entirety,
+   including the disclaimer of warranties.
+2. Redistributions in binary form must reproduce the above copyright
+   notice, this list of conditions and the following disclaimer in the
+   documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote
+   products derived from this software without specific prior
+   written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+> LGPL 3.0
+
+e2fsprogs-1.43.4.tar.gz\e2fsprogs-1.43.4.tar\e2fsprogs-1.43.4\lib\blkid\blkid.h.in
+
+Copyright (C) 2001 Andreas Dilger
+Copyright (C) 2003 Theodore Ts'o
+
+This file may be redistributed under the terms of the GNU Lesser General Public License.
+
+>>> gcc-6.3.0-7.ph2
+
+Copyright (C) 1999, 2000, 2001, 2003 Free Software Foundation, Inc.
+
+This file is part of GCC.
+
+GCC is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+GCC is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with GCC; see the file COPYING.  If not, write to
+the Free Software Foundation, 51 Franklin Street, Fifth Floor,
+Boston MA 02110-1301, USA.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> MIT-Style
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\boehm-gc\cord\cordbscs.c
+
+Copyright (c) 1993-1994 by Xerox Corporation.  All rights reserved.
+
+THIS MATERIAL IS PROVIDED AS IS, WITH ABSOLUTELY NO WARRANTY EXPRESSED
+OR IMPLIED.  ANY USE IS AT YOUR OWN RISK.
+
+Permission is hereby granted to use or copy this program
+for any purpose,  provided the above notices are retained on all copies.
+Permission to modify the code and to distribute modified code is granted,
+provided the above notices are retained, and a notice that the code was
+modified is included with the above copyright notice.
+
+> GPL 3.0
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\boehm-gc\testsuite\boehm-gc.c\c.exp
+
+Copyright (C) 2011 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; see the file COPYING3.  If not see
+<http://www.gnu.org/licenses/>.
+
+> GFDL 1.3
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\gcc\doc\gcov.texi
+
+Copyright (C) 1996-2013 Free Software Foundation, Inc.
+This is part of the GCC manual.
+For copying conditions, see the file gcc.texi.
+
+Copyright @copyright{} 1996-2013 Free Software Foundation, Inc.
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.3 or
+any later version published by the Free Software Foundation; with the
+Invariant Sections being ``GNU General Public License'' and ``Funding
+Free Software'', the Front-Cover texts being (a) (see below), and with
+the Back-Cover Texts being (b) (see below).  A copy of the license is
+included in the gfdl(7) man page.
+
+> BSD with Patent grant
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\gcc\go\gofrontend\LICENSE
+
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.
+
+> LGPL 2.1
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\gcc\testsuite\gcc.dg\compat\generate-random.h
+
+Copyright (C) 2004 Free Software Foundation
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with the GNU C Library; if not, write to the Free
+Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301 USA.
+
+> LGPL 3.0
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\gcc\stab.def
+
+Table of DBX symbol codes for the GNU system.
+Copyright (C) 1988-2013 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public License as
+published by the Free Software Foundation; either version 3 of the
+License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with the GNU C Library; see the file COPYING3.  If
+not see <http://www.gnu.org/licenses/>.
+
+> LGPL 2.0
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\include\demangle.h
+
+Copyright 1992, 1993, 1994, 1995, 1996, 1997, 1998, 2000, 2001, 2002,
+2003, 2004, 2005, 2007, 2008, 2009, 2010 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public License
+as published by the Free Software Foundation; either version 2, or
+(at your option) any later version.
+
+In addition to the permissions in the GNU Library General Public
+License, the Free Software Foundation gives you unlimited
+permission to link the compiled version of this file into
+combinations with other programs, and to distribute those
+combinations without any restriction coming from the use of this
+file.  (The Library Public License restrictions do apply in other
+respects; for example, they cover modification of the file, and
+distribution when not linked into a combined executable.)
+
+This program is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA
+02110-1301, USA.
+
+> Public Domain
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libffi\src\dlmalloc.c
+
+This is a version (aka dlmalloc) of malloc/free/realloc written by
+Doug Lea and released to the public domain, as explained at
+http://creativecommons.org/licenses/publicdomain.  Send questions,
+comments, complaints, performance data, etc to dl@cs.oswego.edu.
+
+> MIT
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libffi\LICENSE
+
+Copyright (c) 1996-2014  Anthony Green, Red Hat, Inc and others.
+See source files for details.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+``Software''), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED ``AS IS'', WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT,
+TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE
+SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+> LGPL 2.1
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libffi\msvcc.sh
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE LGPL 2.1 LICENSE THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+BEGIN LICENSE BLOCK
+Version: MPL 1.1/GPL 2.0/LGPL 2.1
+
+The contents of this file are subject to the Mozilla Public License Version
+1.1 (the "License"); you may not use this file except in compliance with
+the License. You may obtain a copy of the License at
+http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS IS" basis,
+WITHOUT WARRANTY OF ANY KIND, either express or implied. See the License
+for the specific language governing rights and limitations under the
+License.
+
+The Original Code is the MSVC wrappificator.
+
+The Initial Developer of the Original Code is
+Timothy Wall <twalljava@dev.java.net>.
+Portions created by the Initial Developer are Copyright (C) 2009
+the Initial Developer. All Rights Reserved.
+
+Contributor(s):
+Daniel Witte <dwitte@mozilla.com>
+
+Alternatively, the contents of this file may be used under the terms of
+either the GNU General Public License Version 2 or later (the "GPL"), or
+the GNU Lesser General Public License Version 2.1 or later (the "LGPL"),
+in which case the provisions of the GPL or the LGPL are applicable instead
+of those above. If you wish to allow use of your version of this file only
+under the terms of either the GPL or the LGPL, and not to allow others to
+use your version of this file under the terms of the MPL, indicate your
+decision by deleting the provisions above and replace them with the notice
+and other provisions required by the GPL or the LGPL. If you do not delete
+the provisions above, a recipient may use your version of this file under
+the terms of any one of the MPL, the GPL or the LGPL.
+
+END LICENSE BLOCK
+
+> GPL 3.0 (with runtime library exception)
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libgcc\config\aarch64\crti.S
+
+Machine description for AArch64 architecture.
+Copyright (C) 2009-2013 Free Software Foundation, Inc.
+Contributed by ARM Ltd.
+
+This file is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 3, or (at your option) any
+later version.
+
+This file is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+Under Section 7 of GPL version 3, you are granted additional
+permissions described in the GCC Runtime Library Exception, version
+3.1, as published by the Free Software Foundation.
+
+You should have received a copy of the GNU General Public License and
+a copy of the GCC Runtime Library Exception along with this program;
+see the files COPYING3 and COPYING.RUNTIME respectively.  If not, see
+<http://www.gnu.org/licenses/>.
+
+> LGPL 2.1(with linking exception)
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libgcc\config\c6x\sfp-machine.h
+
+Copyright (C) 2010-2013 Free Software Foundation, Inc.
+
+This files is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+In addition to the permissions in the GNU Lesser General Public
+License, the Free Software Foundation gives you unlimited
+permission to link the compiled version of this file into
+combinations with other programs, and to distribute those
+combinations without any restriction coming from the use of this
+file.  (The Lesser General Public License restrictions do apply in
+other respects; for example, they cover modification of the file,
+and distribution when not linked into a combine executable.)
+
+This file is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with GCC; see the file COPYING.LIB.  If not see
+<http://www.gnu.org/licenses/>.
+
+> GPL 2.0 (with linking exception)
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libiberty\testsuite\test-expandargv.c
+
+Copyright (C) 2006 Free Software Foundation, Inc.
+Written by Carlos O'Donell <carlos@codesourcery.com>
+
+This file is part of the libiberty library, which is part of GCC.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+In addition to the permissions in the GNU General Public License, the
+Free Software Foundation gives you unlimited permission to link the
+compiled version of this file into combinations with other programs,
+and to distribute those combinations without any restriction coming
+from the use of this file.  (The General Public License restrictions
+do apply in other respects; for example, they cover modification of
+the file, and distribution when not linked into a combined
+executable.)
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+
+> MIT-Style
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libjava\classpath\external\jsr166\readme
+
+Copyright 2002-2004 Sun Microsystems, Inc. All rights reserved. Use is
+subject to the following license terms.
+
+"Sun hereby grants you a non-exclusive, worldwide, non-transferrable
+license to use and distribute the Java Software technologies as part
+of a larger work in source and binary forms, with or without
+modification, provided that the following conditions are met:
+
+-Neither the name of or trademarks of Sun may be used to endorse or
+promote products derived from the Java Software technology without
+specific prior written permission.
+
+-Redistributions of source or binary code must be accompanied by the
+following notice and disclaimers:
+
+Portions copyright Sun Microsystems, Inc. Used with kind permission.
+
+This software is provided AS IS, without a warranty of any kind.  ALL
+EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND
+WARRANTIES, INCLUDING ANY IMPLIED WARRANTY OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PUPOSE OR
+NON-INFRINGEMENT, ARE HEREBY EXCLUDED. SUN
+MICROSYSTEMS, INC. AND ITS LICENSORS SHALL NOT BE LIABLE
+FOR ANY DAMAGES SUFFERED BY LICENSEE AS A RESULT OF
+USING, MODIFYING OR DISTRIBUTING THE SOFTWARE OR ITS
+DERIVATIVES. IN NO EVENT WILL SUN MICROSYSTEMS, INC. OR
+ITS LICENSORS BE LIABLE FOR ANY LOST REVENUE, PROFIT OR
+DATA, OR FOR DIRECT, INDIRECT,CONSQUENTIAL, INCIDENTAL
+OR PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF
+THE THEORY OR LIABILITY, ARISING OUT OF THE USE OF OR
+INABILITY TO USE SOFTWARE, EVEN IF SUN MICROSYSTEMS, INC.
+HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+You acknowledge that Software is not designed, licensed or intended for
+use in the design, construction, operation or maintenance of any nuclear
+facility."
+
+> MIT
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libsanitizer\LICENSE.TXT
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE MIT LICENSE. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+==============================================================================
+compiler_rt License
+==============================================================================
+The compiler_rt library is dual licensed under both the University of Illinois
+"BSD-Like" license and the MIT license.  As a user of this code you may choose
+to use it under either license.  As a contributor, you agree to allow your code
+to be used under both.
+
+Full text of the relevant licenses is included below.
+==============================================================================
+University of Illinois/NCSA
+Open Source License
+
+Copyright (c) 2009-2012 by the contributors listed in CREDITS.TXT
+
+All rights reserved.
+
+Developed by:
+
+LLVM Team
+
+University of Illinois at Urbana-Champaign
+
+http://llvm.org
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal with
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies
+of the Software, and to permit persons to whom the Software is furnished to do
+so, subject to the following conditions:
+
+Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimers.
+
+Redistributions in binary form must reproduce the above copyright notice,
+this list of conditions and the following disclaimers in the
+documentation and/or other materials provided with the distribution.
+
+Neither the names of the LLVM Team, University of Illinois at
+Urbana-Champaign, nor the names of its contributors may be used to
+endorse or promote products derived from this Software without specific
+prior written permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+CONTRIBUTORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+==============================================================================
+Copyright (c) 2009-2012 by the contributors listed in CREDITS.TXT
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+==============================================================================
+Copyrights and Licenses for Third Party Software Distributed with LLVM:
+==============================================================================
+The LLVM software contains code written by third parties.  Such software will
+have its own individual LICENSE.TXT file in the directory in which it appears.
+This file will describe the copyrights, license, and restrictions which apply
+to that code.
+
+The disclaimer of warranty in the University of Illinois Open Source License
+applies to all code in the LLVM Distribution, and nothing in any of the
+other licenses gives permission to use the names of the LLVM Team or the
+University of Illinois to endorse or promote products derived from this
+Software.
+
+The following pieces of software have additional or alternate copyrights,
+licenses, and/or restrictions:
+
+Program             Directory
+-------             ---------
+mach_override       lib/interception/mach_override
+
+> GFDL 1.2
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libstdc++-v3\doc\html\index.html
+
+Permission is granted to copy, distribute and/or modify this
+document under the terms of the GNU Free Documentation
+License, Version 1.2 or any later version published by the
+Free Software Foundation; with no Invariant Sections, with no
+Front-Cover Texts, and with no Back-Cover Texts.
+
+> Project Gutenberg license
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\libgo\go\compress\testdata\Mark.Twain-
+Tom.Sawyer.txt
+
+The Project Gutenberg EBook of The Adventures of Tom Sawyer, Complete
+by Mark Twain (Samuel Clemens)
+
+This eBook is for the use of anyone anywhere at no cost and with
+almost no restrictions whatsoever.  You may copy it, give it away or
+re-use it under the terms of the Project Gutenberg License included
+with this eBook or online at www.gutenberg.net
+
+> BSD
+
+gcc-6.3.0.tar.bz2\gcc-6.3.0.tar\gcc-6.3.0\mkdep
+
+Copyright (c) 1987 Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms are permitted
+provided that the above copyright notice and this paragraph are
+duplicated in all such forms and that any documentation,
+advertising materials, and other materials related to such
+distribution and use acknowledge that the software was developed
+by the University of California, Berkeley.  The name of the
+University may not be used to endorse or promote products derived
+from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+>>> iproute2-4.10.0-4.ph2
+
+Copyright (C) 1999  Pavel Golubev <pg@ksi-linux.com>
+Copyright (C) 2001-2004  Lubomir Bulej <pallas@kadan.cz>
+
+chkconfig:   2345 11 89
+description: sets up CBQ-based traffic control
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 3.0
+
+iproute2-4.10.0.tar.xz\iproute2-4.10.0.tar\iproute2-4.10.0\include\linux\if_bonding.h
+
+(c) Copyright 1999, Thomas Davis, tadavis@lbl.gov
+
+This software may be used and distributed according to the terms
+of the GNU Public License, incorporated herein by reference.
+
+> BSD- 3 Clause
+
+iproute2-4.10.0.tar.xz\iproute2-4.10.0.tar\iproute2-4.10.0\include\linux\can.h
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD- 3 CLAUSE LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Authors: Oliver Hartkopp <oliver.hartkopp@volkswagen.de>
+Urs Thuermann   <urs.thuermann@volkswagen.de>
+Copyright (c) 2002-2007 Volkswagen Group Electronic Research
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of Volkswagen nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+Alternatively, provided that this notice is retained in full, this
+software may be distributed under the terms of the GNU General
+Public License ("GPL") version 2, in which case the provisions of the
+GPL apply INSTEAD OF those given above.
+
+The provided data structures and external interfaces from this code
+are not restricted to be used by modules with a GPL compatible license.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+> BSD- 3 Clause
+
+iproute2-4.10.0.tar.xz\iproute2-4.10.0.tar\iproute2-4.10.0\include\netinet\tcp.h
+
+Copyright (c) 1982, 1986, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> Public Domain
+
+iproute2-4.10.0.tar.xz\iproute2-4.10.0.tar\iproute2-4.10.0\ip\routel
+
+Script created by: Stephen R. van den Berg <srb@cuci.nl>, 1999/04/18
+Donated to the public domain.
+
+>>> iptables-1.6.1-4.ph2
+
+Copyright (C) 2000-2002 Joakim Axelsson <gozem@linux.nu>
+Patrick Schaaf <bof@bof.de>
+Martin Josefsson <gandalf@wlug.westbo.se>
+Copyright (C) 2003-2011 Jozsef Kadlecsik <kadlec@blackhole.kfki.hu>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License version 2 as
+published by the Free Software Foundation.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 3.0
+
+iptables-1.6.1.tar.bz2\iptables-1.6.1.tar\iptables-1.6.1\extensions\libip6t_HL.c
+
+IPv6 Hop Limit Target module
+Maciej Soltysiak <solt@dns.toxicfilms.tv>
+Based on HW's ttl target
+This program is distributed under the terms of GNU GPL.
+
+> LGPL 2.0
+
+iptables-1.6.1.tar.bz2\iptables-1.6.1.tar\iptables-1.6.1\iptables\getethertype.c
+
+This file was part of the NYS Library.
+
+The NYS Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+> Artistic 2.0
+
+iptables-1.6.1.tar.bz2\iptables-1.6.1.tar\iptables-1.6.1\iptables\iptables-apply
+
+Copyright © Martin F. Krafft <madduck@madduck.net>
+Released under the terms of the Artistic Licence 2.0
+
+> MIT
+
+iptables-1.6.1.tar.bz2\iptables-1.6.1.tar\iptables-1.6.1\utils\pf.os
+
+SYN signatures. Those signatures work for SYN packets only (duh!).
+
+(C) Copyright 2000-2003 by Michal Zalewski <lcamtuf@coredump.cx>
+(C) Copyright 2003 by Mike Frantzen <frantzen@w4g.org>
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+
+>>> linux-esx-4.9.182-1.ph2
+
+Copyright (C) Paul Mackerras 1997.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version
+2 of the License, or (at your option) any later version.
+
+ADDITIONAL LICENSE INFORMATION:
+
+
+> Third Party
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\microblaze\lib\memcpy.c
+
+Copyright (C) 2008-2009 Michal Simek <monstr@monstr.eu>
+Copyright (C) 2008-2009 PetaLogix
+Copyright (C) 2007 John Williams
+
+Reasonably optimised generic C-code for memcpy on Microblaze
+This is generic C code to do efficient, alignment-aware memcpy.
+
+It is based on demo code originally Copyright 2001 by Intel Corp, taken from
+http://www.embedded.com/showArticle.jhtml?articleID=19205567
+
+Attempts were made, unsuccessfully, to contact the original
+author of this code (Michael Morrow, Intel).  Below is the original
+copyright notice.
+
+This software has been developed by Intel Corporation.
+Intel specifically disclaims all warranties, express or
+implied, and all liability, including consequential and
+other indirect damages, for the use of this program, including
+liability for infringement of any proprietary rights,
+and including the warranties of merchantability and fitness
+for a particular purpose. Intel does not assume any
+responsibility for and errors which may appear in this program
+not any responsibility to update it.
+
+> Apache2.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\staging\android\ashmem.h
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE APACHE2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright 2008 Google Inc.
+Author: Robert Love
+
+This file is dual licensed.  It may be redistributed and/or modified
+under the terms of the Apache 2.0 License OR version 2 of the GNU
+General Public License.
+
+> BSD
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\nwfpe\milieu.h
+
+This C header file is part of the SoftFloat IEC/IEEE Floating-point
+Arithmetic Package, Release 2.
+
+Written by John R. Hauser.  This work was made possible in part by the
+International Computer Science Institute, located at Suite 600, 1947 Center
+Street, Berkeley, California 94704.  Funding was partially provided by the
+National Science Foundation under grant MIP-9311980.  The original version
+of this code was written as part of a project to build a fixed-point vector
+processor in collaboration with the University of California at Berkeley,
+overseen by Profs. Nelson Morgan and John Wawrzynek.  More information
+is available through the Web page
+http://www.jhauser.us/arithmetic/SoftFloat-2b/SoftFloat-source.txt
+
+THIS SOFTWARE IS DISTRIBUTED AS IS, FOR FREE.  Although reasonable effort
+has been made to avoid it, THIS SOFTWARE MAY CONTAIN FAULTS THAT WILL AT
+TIMES RESULT IN INCORRECT BEHAVIOR.  USE OF THIS SOFTWARE IS RESTRICTED TO
+PERSONS AND ORGANIZATIONS WHO CAN AND WILL TAKE FULL RESPONSIBILITY FOR ANY
+AND ALL LOSSES, COSTS, OR OTHER PROBLEMS ARISING FROM ITS USE.
+
+Derivative works are acceptable, even for commercial purposes, so long as
+(1) they include prominent notice that the work is derivative, and (2) they
+include prominent notice akin to these three paragraphs for those parts of
+this code that are retained.
+
+> BSD
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\scsi\dpti.txt
+
+Redistribution and use in source form, with or without modification, are
+permitted provided that redistributions of source code must retain the
+above copyright notice, this list of conditions and the following disclaimer.
+
+This software is provided `as is' by Adaptec and
+any express or implied warranties, including, but not limited to, the
+implied warranties of merchantability and fitness for a particular purpose,
+are disclaimed. In no event shall Adaptec be
+liable for any direct, indirect, incidental, special, exemplary or
+consequential damages (including, but not limited to, procurement of
+substitute goods or services; loss of use, data, or profits; or business
+interruptions) however caused and on any theory of liability, whether in
+contract, strict liability, or tort (including negligence or otherwise)
+arising in any way out of the use of this driver software, even if advised
+of the possibility of such damage.
+
+> BSD
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\mips\sgi-ip22\ip22-eisa.c
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+(C) 2002 Pascal Dameme <netinet@freesurf.fr>
+and Marc Zyngier <mzyngier@freesurf.fr>
+
+This code is released under both the GPL version 2 and BSD
+licenses.  Either license may be used.
+
+This code offers a very basic support for this EISA bus present in
+the SGI Indigo-2. It currently only supports PIO (forget about DMA
+for the time being). This is enough for a low-end ethernet card,
+but forget about your favorite SCSI card...
+
+> BSD-2
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\input\keyboard\hil_kbd.c
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-2 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (c) 2001 Brian S. Julin
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions, and the following disclaimer,
+without modification.
+2. The name of the author may not be used to endorse or promote products
+derived from this software without specific prior written permission.
+
+Alternatively, this software may be distributed under the terms of the
+GNU General Public License ("GPL").
+
+THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+
+> BSD-2
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\mips\include\asm\netlogic\xlp-hal\bridge.h
+
+Copyright 2003-2011 NetLogic Microsystems, Inc. (NetLogic). All rights
+reserved.
+
+This software is available to you under a choice of one of two
+licenses.  You may choose to be licensed under the terms of the GNU
+General Public License (GPL) Version 2, available from the file
+COPYING in the main directory of this source tree, or the NetLogic
+license below:
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in
+the documentation and/or other materials provided with the
+distribution.
+
+THIS SOFTWARE IS PROVIDED BY NETLOGIC ``AS IS'' AND ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL NETLOGIC OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+> BSD-2
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\cris\arch-v10\lib\memset.c
+
+Copyright (C) 1999-2005 Axis Communications.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+2. Neither the name of Axis Communications nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY AXIS COMMUNICATIONS AND ITS CONTRIBUTORS
+``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL AXIS
+COMMUNICATIONS OR ITS CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING
+IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+> BSD-3
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\crypto\drbg.c
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-3 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright Stephan Mueller <smueller@chronox.de>, 2014
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, and the entire permission notice in its entirety,
+including the disclaimer of warranties.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote
+products derived from this software without specific prior
+written permission.
+
+ALTERNATIVELY, this product may be distributed under the terms of
+the GNU General Public License, in which case the provisions of the GPL are
+required INSTEAD OF the above restrictions.  (This clause is
+necessary due to a potential bad interaction between the GPL and
+the restrictions contained in a BSD-style copyright.)
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+> BSD-3
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\blackfin\ Clear_BSD.txt
+
+Copyright (c) 2012, Analog Devices, Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted (subject to the limitations in the
+disclaimer below) provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the
+distribution.
+
+* Neither the name of Analog Devices, Inc.  nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+NO EXPRESS OR IMPLIED LICENSES TO ANY PARTY'S PATENT RIGHTS ARE
+GRANTED BY THIS LICENSE.  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT
+HOLDERS AND CONTRIBUTORS "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE
+OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+> BSD-3
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\blackfin\include\asm\bfin_pfmon.h
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE BSD-3 LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright 2005-2011 Analog Devices Inc.
+
+Licensed under the Clear BSD license or GPL-2 (or later).
+
+> BSD-4
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\net\ppp\drivers\net\ppp\bsd_comp.c
+
+Copyright (c) 1985, 1986 The Regents of the University of California.
+All rights reserved.
+
+This code is derived from software contributed to Berkeley by
+James A. Woods, derived from original work by Spencer Thomas
+and Joseph Orost.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+This product includes software developed by the University of
+California, Berkeley and its contributors.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> CC-Attribution-ShareAlike2.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\PCI\pci.txt
+
+A more complete resource is the third edition of "Linux Device Drivers"
+by Jonathan Corbet, Alessandro Rubini, and Greg Kroah-Hartman.
+LDD3 is available for free (under Creative Commons License) from:
+
+http://lwn.net/Kernel/LDD3/
+
+However, keep in mind that all documents are subject to "bit rot".
+Refer to the source code if things are not working as described here.
+
+Please send questions/comments/patches about Linux PCI API to the
+"Linux PCI" <linux-pci@atrey.karlin.mff.cuni.cz> mailing list.
+
+> GFDL1.1
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\parport\ieee1284.c
+
+Authors: Phil Blundell <philb@gnu.org>
+Carsten Gross <carsten@sol.wohnheim.uni-ulm.de>
+Jose Renau <renau@acm.org>
+Tim Waugh <tim@cyberelk.demon.co.uk> (largely rewritten)
+
+This file is responsible for IEEE 1284 negotiation, and for handing
+read/write requests to low-level drivers.
+
+Any part of this program may be used in documents licensed under
+the GNU Free Documentation License, Version 1.1 or any later version
+published by the Free Software Foundation.
+
+> GFDL1.2
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\trace\ftrace.txt
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GFDL1.2 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright 2008 Red Hat Inc.
+Author:   Steven Rostedt <srostedt@redhat.com>
+License:   The GNU Free Documentation License, Version 1.2
+(dual licensed under the GPL v2)
+
+> GPL1.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\powerpc\xmon\ppc.h
+
+Copyright 1994, 1995, 1999, 2000, 2001, 2002, 2003, 2004, 2005, 2006
+Free Software Foundation, Inc.
+Written by Ian Lance Taylor, Cygnus Support
+
+This file is part of GDB, GAS, and the GNU binutils.
+
+GDB, GAS, and the GNU binutils are free software; you can redistribute
+them and/or modify them under the terms of the GNU General Public
+License as published by the Free Software Foundation; either version
+1, or (at your option) any later version.
+
+GDB, GAS, and the GNU binutils are distributed in the hope that they
+will be useful, but WITHOUT ANY WARRANTY; without even the implied
+warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See
+the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this file; see the file COPYING.  If not, write to the Free
+Software Foundation, 51 Franklin Street - Fifth Floor, Boston, MA 02110-1301, USA.
+
+> GPL2.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\m68k\lib\divsi3.S
+
+Copyright (C) 1994, 1996, 1997, 1998 Free Software Foundation, Inc.
+
+This file is part of GNU CC.
+
+GNU CC is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+In addition to the permissions in the GNU General Public License, the
+Free Software Foundation gives you unlimited permission to link the
+compiled version of this file with other programs, and to distribute
+those programs without any restriction coming from the use of this
+file.  (The General Public License restrictions do apply in other
+respects; for example, they cover modification of the file, and
+distribution when not linked into another program.)
+
+This file is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; see the file COPYING.  If not, write to
+the Free Software Foundation, 59 Temple Place - Suite 330,
+Boston, MA 02111-1307, USA.
+
+As a special exception, if you link this library with files
+compiled with GCC to produce an executable, this does not cause
+the resulting executable to be covered by the GNU General Public License.
+This exception does not however invalidate any other reasons why
+the executable file might be covered by the GNU General Public License.
+
+> GPL2.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\fs\jffs2\LICENCE
+
+Copyright Â© 2001-2007 Red Hat, Inc. and others
+
+JFFS2 is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free
+Software Foundation; either version 2 or (at your option) any later
+version.
+
+JFFS2 is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received a copy of the GNU General Public License along
+with JFFS2; if not, write to the Free Software Foundation, Inc.,
+59 Temple Place, Suite 330, Boston, MA 02111-1307 USA.
+
+As a special exception, if other files instantiate templates or use
+macros or inline functions from these files, or you compile these
+files and link them with other works to produce a work based on these
+files, these files do not by themselves cause the resulting work to be
+covered by the GNU General Public License. However the source code for
+these files must still be made available in accordance with section (3)
+of the GNU General Public License.
+
+This exception does not invalidate any other reasons why a work based on
+this file might be covered by the GNU General Public License.
+
+> GPL2.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\drivers\ide\ide-cs.c
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GPL2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+The contents of this file are subject to the Mozilla Public
+License Version 1.1 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of
+the License at http://www.mozilla.org/MPL/
+
+Software distributed under the License is distributed on an "AS
+IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+implied. See the License for the specific language governing
+rights and limitations under the License.
+
+The initial developer of the original code is David A. Hinds
+<dahinds@users.sourceforge.net>.  Portions created by David A. Hinds
+are Copyright (C) 1999 David A. Hinds.  All Rights Reserved.
+
+Alternatively, the contents of this file may be used under the
+terms of the GNU General Public License version 2 (the "GPL"), in
+which case the provisions of the GPL are applicable instead of the
+above.  If you wish to allow the use of your version of this file
+only under the terms of the GPL and not to allow others to use
+your version of this file under the MPL, indicate your decision
+by deleting the provisions above and replace them with the notice
+and other provisions required by the GPL.  If you do not delete
+the provisions above, a recipient may use your version of this
+file under either the MPL or the GPL.
+
+> GPL3.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\mach-imx\pm-imx27.c
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License.
+
+> LGPL2.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\mach-orion5x\dns323-setup.c
+
+Copyright (C) 2010 Benjamin Herrenschmidt <benh@kernel.crashing.org>
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+> LGPL2.1
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\parisc\lib\memset.c
+
+Copyright (C) 1991, 1997 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with the GNU C Library; if not, write to the Free
+Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+02111-1307 USA.
+
+> LGPL3.0
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\include\uapi\linux\dm-ioctl.h
+
+Copyright (C) 2001 - 2003 Sistina Software (UK) Limited.
+Copyright (C) 2004 - 2009 Red Hat, Inc. All rights reserved.
+
+This file is released under the LGPL.
+
+> MIT
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\include\dt-bindings\clock\sun4i-a10-pll2.h
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE MIT LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright 2015 Maxime Ripard
+
+Maxime Ripard <maxime.ripard@free-electrons.com>
+
+This file is dual-licensed: you can use it either under the terms
+of the GPL or the X11 license, at your option. Note that this dual
+licensing only applies to this file, and not this project as a
+whole.
+
+a) This file is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+This file is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+Or, alternatively,
+
+b) Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+> MIT
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\m68k\fpsp040\README
+
+M68040 Software Package Copyright (c) 1993, 1994 Motorola Inc.
+All rights reserved.
+
+THE SOFTWARE is provided on an "AS IS" basis and without warranty.
+To the maximum extent permitted by applicable law,
+MOTOROLA DISCLAIMS ALL WARRANTIES WHETHER EXPRESS OR IMPLIED,
+INCLUDING IMPLIED WARRANTIES OF MERCHANTABILITY OR FITNESS FOR A
+PARTICULAR PURPOSE and any warranty against infringement with
+regard to the SOFTWARE (INCLUDING ANY MODIFIED VERSIONS THEREOF)
+and any accompanying written materials.
+
+To the maximum extent permitted by applicable law,
+IN NO EVENT SHALL MOTOROLA BE LIABLE FOR ANY DAMAGES WHATSOEVER
+(INCLUDING WITHOUT LIMITATION, DAMAGES FOR LOSS OF BUSINESS
+PROFITS, BUSINESS INTERRUPTION, LOSS OF BUSINESS INFORMATION, OR
+OTHER PECUNIARY LOSS) ARISING OF THE USE OR INABILITY TO USE THE
+SOFTWARE.  Motorola assumes no responsibility for the maintenance
+and support of the SOFTWARE.
+
+You are hereby granted a copyright license to use, modify, and
+distribute the SOFTWARE so long as this entire notice is retained
+without alteration in any modified and/or redistributed versions,
+and that such modified versions are clearly identified as such.
+No licenses are granted by implication, estoppel or otherwise
+under any patents or trademarks of Motorola, Inc.
+
+> MIT
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\boot\dts\arm-realview-pb1176.dts
+
+Copyright 2014 Linaro Ltd
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+> MIT
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\m68k\math-emu\fp_log.c
+
+Copyright (c) 1998-1999 David Huggins-Daines / Roman Zippel.
+
+I hereby give permission, free of charge, to copy, modify, and
+redistribute this software, in source or binary form, provided that
+the above copyright notice and the following disclaimer are included
+in all such copies.
+
+THIS SOFTWARE IS PROVIDED "AS IS", WITH ABSOLUTELY NO WARRANTY, REAL
+OR IMPLIED.
+
+> MS-LPL
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\usb\linux-cdc-acm.inf
+
+Based on INF template which was:
+Copyright (c) 2000 Microsoft Corporation
+Copyright (c) 2007 Microchip Technology Inc.
+likely to be covered by the MLPL as found at:
+<http://msdn.microsoft.com/en-us/cc300390.aspx#MLPL>
+
+> OpenSSL
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\arch\arm\crypto\aes-armv4.S
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE OPENSSL LICENSE, THE TEXT OF WHICH IS SET FORTH BELOW. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Written by Andy Polyakov <approfy.chalmers.se> for the OpenSSL
+project. The module is, however, dual licensed under OpenSSL and
+CRYPTOGAMS licenses depending on where you obtain it. For further
+details see http://www.openssl.org/~appro/cryptogams/.
+
+> OSL1.1
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\Documentation\DocBook\libata.tmpl
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE OSL1.1 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright
+
+The contents of this file are subject to the Open Software License version 1.1 that can be found at
+"http://fedoraproject.org/wiki/Licensing:OSL1.1" and is included herein by reference.
+
+Alternatively, the contents of this file may be used under the terms
+of the GNU General Public License version 2 (the "GPL") as distributed
+in the kernel source COPYING file, in which case the provisions of
+the GPL are applicable instead of the above.  If you wish to allow
+the use of your version of this file only under the terms of the
+GPL and not to allow others to use your version of this file under
+the OSL, indicate your decision by deleting the provisions above and
+replace them with the notice and other provisions required by the GPL.
+If you do not delete the provisions above, a recipient may use your
+version of this file under either the OSL or the GPL.
+
+> PublicDomain
+
+linux-esx-4.9.182-1.ph2.src.rpm\linux-esx-4.9.182-1.ph2.src.cpio\linux-4.9.182.tar.xz\linux-4.9.182.tar\linux-4.9.182\crypto\md4.c
+
+MD4 Message Digest Algorithm (RFC1320).
+
+Implementation derived from Andrew Tridgell and Steve French's
+CIFS MD4 implementation, and the cryptoapi implementation
+originally based on the public domain implementation written
+by Colin Plumb in 1993.
+
+>>> logrotate-3.11.0-3.ph2
+
+Copyright (c) 2006-2012 Novell, Inc. All Rights Reserved.
+
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of version 2 of the GNU General Public License as published by the
+Free Software Foundation.
+
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program; if not, contact Novell, Inc.
+
+To contact Novell about this file by physical or electronic mail, you may find
+current contact information at www.novell.com.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+logrotate-3.11.0-3.ph2.src-1.rpm\logrotate-3.11.0-3.ph2.src.cpio\logrotate-3.11.0.tar.gz\logrotate-3.11.0.tar\logrotate-3.11.0\queue.h
+
+
+Copyright (c) 1991, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> GPL 3.0
+
+logrotate-3.11.0-3.ph2.src-1.rpm\logrotate-3.11.0-3.ph2.src.cpio\logrotate-3.11.0.tar.gz\logrotate-3.11.0.tar\logrotate-3.11.0\logrotate.c
+
+
+Copyright (C) 1995-2001 Red Hat, Inc.\n");
+fprintf(stderr,
+"This may be freely redistributed under the terms of "
+"the GNU Public License
+
+>>> mingetty-1.08-2.ph2
+
+Copyright (C) 1996 Florian La Roche  <laroche@redhat.com>
+Copyright (C) 2002, 2003 Red Hat, Inc
+This getty can only be used as a small console getty. Look at mgetty
+for a real modem getty.
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version
+2 of the License, or (at your option) any later version.
+
+>>> net-tools-1.60-11.ph2
+
+Version: $Id: ax25_gr.c,v 1.4 1999/01/05 20:53:21 philip Exp $
+
+Author: Bernd Eckenfels, <ecki@lina.inka.de>
+Copyright 1999 Bernd Eckenfels, Germany
+base on Code from Jonathan Naylor <jsn@Cs.Nott.AC.UK>
+
+This program is free software; you can redistribute it
+and/or  modify it under  the terms of  the GNU General
+Public  License as  published  by  the  Free  Software
+Foundation;  either  version 2 of the License, or  (at
+your option) any later version.
+
+>>> procps-ng-3.3.15-2.ph2
+
+Copyright (C) 2010 Karel Zak <kzak@redhat.com>
+Copyright (C) 2010 Davidlohr Bueso <dave@gnu.org>
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU General Public License
+as published by the Free Software Foundation; either version 2
+of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Public Domain
+
+procps-ng-3.3.15.tar.xz\procps-ng-3.3.15.tar\procps-ng-3.3.15\mkinstalldirs
+
+mkinstalldirs --- make directory hierarchy
+Author: Noah Friedman <friedman@prep.ai.mit.edu>
+Created: 1993-05-16
+Public domain
+
+
+> LGPL 2.1
+
+procps-ng-3.3.15.tar.xz\procps-ng-3.3.15.tar\procps-ng-3.3.15\pmap.c
+
+pmap.c - print process memory mapping
+Copyright 2002 Albert Cahalan
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA.
+
+
+> LGPL 2.0
+
+procps-ng-3.3.15.tar.xz\procps-ng-3.3.15.tar\procps-ng-3.3.15\proc\sig.h
+
+Copyright 1998-2003 by Albert Cahalan; all rights resered.
+This file may be used subject to the terms and conditions of the
+GNU Library General Public License Version 2, or any later version
+at your option, as published by the Free Software Foundation.
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+GNU Library General Public License for more details.
+
+
+> GPL 3.0
+
+procps-ng-3.3.15.tar.xz\procps-ng-3.3.15.tar\procps-ng-3.3.15\misc\git-version-gen
+
+Copyright (C) 2007-2011 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+>>> rpm-4.13.0.2-1.ph2
+
+Copyright (C) 1993, 1995, 1996, 1997 Free Software Foundation, Inc.
+
+NOTE: The canonical source of this file is maintained with the GNU C Library.
+Bugs can be reported to bug-glibc@prep.ai.mit.edu.
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published by the
+Free Software Foundation; either version 2, or (at your option) any
+later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+USA.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3 
+
+rpm-4.13.0.2-1.ph2.src.rpm\rpm-4.13.0.2-1.ph2.src.cpio\rpm-4.13.0.2-release.tar.gz\rpm-4.13.0.2-release.tar\rpm-rpm-4.13.0.2-release\misc\fts.h
+
+Copyright (c) 1989, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> LGPL 2.1
+
+rpm-4.13.0.2-1.ph2.src.rpm\rpm-4.13.0.2-1.ph2.src.cpio\rpm-4.13.0.2-release.tar.gz\rpm-4.13.0.2-release.tar\rpm-rpm-4.13.0.2-release\misc\fnmatch.h
+
+Copyright (C) 1991,92,93,96,97,98,99,2001 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with the GNU C Library; if not, write to the Free
+Software Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA
+02111-1307 USA.
+
+> LGPL 2.0
+
+rpm-4.13.0.2-1.ph2.src.rpm\rpm-4.13.0.2-1.ph2.src.cpio\rpm-4.13.0.2-release.tar.gz\rpm-4.13.0.2-release.tar\rpm-rpm-4.13.0.2-release\misc\fnmatch.c
+
+Copyright (C) 1991-1993, 1996-1999, 2000 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this library; see the file COPYING.LIB.  If not,
+write to the Free Software Foundation, Inc., 59 Temple Place - Suite 330,
+Boston, MA 02111-1307, USA.
+
+> GPL 3.0
+
+rpm-4.13.0.2-1.ph2.src.rpm\rpm-4.13.0.2-1.ph2.src.cpio\rpm-4.13.0.2-release.tar.gz\rpm-4.13.0.2-release.tar\rpm-rpm-4.13.0.2-release\tools\sepdebugcrcfix.c
+
+Copyright (C) 2013 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+> Public Domain
+
+rpm-4.13.0.2-1.ph2.src.rpm\rpm-4.13.0.2-1.ph2.src.cpio\rpm-4.13.0.2-release.tar.gz\rpm-4.13.0.2-release.tar\rpm-rpm-4.13.0.2-release\tools\mkinstalldirs
+
+Original author: Noah Friedman <friedman@prep.ai.mit.edu>
+Created: 1993-05-16
+Public domain.
+
+>>> tdnf-1.2.3-8.ph2
+
+Copyright (C) 2015 VMware, Inc. All Rights Reserved.
+
+Licensed under the GNU General Public License v2 (the "License");
+you may not use this file except in compliance with the License. The terms
+of the License are located in the COPYING file of this distribution.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> LGPL2.1
+
+tdnf-1.2.3.tar.gz\tdnf-1.2.3.tar\tdnf-1.2.3\tools\cli\lib\api.c
+
+Copyright (C) 2017 VMware, Inc. All Rights Reserved.
+
+Licensed under the GNU Lesser General Public License v2.1 (the "License");
+you may not use this file except in compliance with the License. The terms
+of the License are located in the COPYING file of this distribution.
+
+>>> util-linux-2.32-1.ph2
+
+Copyright (C) 2008, Karel Zak <kzak@redhat.com>
+Copyright (C) 2008, James Youngman <jay@gnu.org>
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This file is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+
+Based on scriptreplay.pl by Joey Hess <joey@kitenet.net>
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 3.0
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\tools\git-version-gen
+
+Copyright (C) 2007-2011 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+> BSD 4
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\text-utils\ul.c
+
+Copyright (c) 1980, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+This product includes software developed by the University of
+California, Berkeley and its contributors.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> PUBLIC DOMAIN
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\text-utils\line.c
+
+line - read one line
+
+Gunnar Ritter, Freiburg i. Br., Germany, December 2000.
+
+Public Domain.
+
+
+> BSD
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\text-utils\more.c
+
+Copyright (C) 1980 The Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms are permitted
+provided that the above copyright notice and this paragraph are
+duplicated in all such forms and that any documentation,
+advertising materials, and other materials related to such
+distribution and use acknowledge that the software was developed
+by the University of California, Berkeley.  The name of the
+University may not be used to endorse or promote products derived
+from this software without specific prior written permission.
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND WITHOUT ANY EXPRESS OR
+IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+> MIT
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\sys-utils\flock.1
+
+Copyright 2003-2006 H. Peter Anvin - All Rights Reserved
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation
+files (the "Software"), to deal in the Software without
+restriction, including without limitation the rights to use,
+copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom
+the Software is furnished to do so, subject to the following
+conditions:
+
+The above copyright notice and this permission notice shall
+be included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
+WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+> BSD 3
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\misc-utils\uuidparse.c
+
+uuidparse.c --- Interpret uuid encoded information.  This program
+violates the UUID abstraction barrier by reaching into the
+guts of a UUID.
+
+Based on libuuid/src/uuid_time.c
+Copyright (C) 1998, 1999 Theodore Ts'o.
+
+All alterations (C) 2017 Sami Kerola
+The 3-Clause BSD License
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, and the entire permission notice in its entirety,
+including the disclaimer of warranties.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote
+products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+> MIT STYLE
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\m4\compiler.m4
+
+Copyright (C) 2008-2011 Free Software Foundation, Inc.
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+From Simon Josefsson
+-- derivated from coreutils m4/warnings.m4
+
+> LGPL 2.0
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\login-utils\setpwnam.c
+setpwnam.c -- edit an entry in a password database.
+
+(c) 1994 Salvatore Valente <svalente@mit.edu>
+This file is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+Edited 11/10/96 (DD/MM/YY ;-) by Nicolai Langfeldt (janl@math.uio.no)
+to read /etc/passwd directly so that passwd, chsh and chfn can work on
+machines that run NIS (previously YP).  Changes will not be made to
+usernames starting with +.
+
+This file is distributed with no warranty.
+
+Usage:
+1) get a struct passwd  from getpwnam().
+You should assume a struct passwd has an infinite number of fields, so
+you should not try to create one from scratch.
+2) edit the fields you want to edit.
+3) call setpwnam() with the edited struct passwd.
+
+A _normal user_ program should never directly manipulate etc/passwd but
+/use getpwnam() and (family, as well as) setpwnam().
+
+But, setpwnam was made to _edit_ the password file.  For use by chfn,
+chsh and passwd.  _I_ _HAVE_ to read and write /etc/passwd directly.  Let
+those who say nay be forever silent and think about how getpwnam (and
+family) works on a machine running YP.
+
+Added checks for failure of malloc() and removed error reporting to
+stderr, this is a library function and should not print on the screen,
+but return appropriate error codes.
+27-Jan-97  - poe@daimi.aau.dk
+
+Thanks to "two guys named Ian".
+
+$Author: poer $
+$Revision: 1.13 $
+$Date: 1997/06/23 08:26:29 $
+
+> LGPL 2.1
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\libsmartcols\COPYING
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later
+version.
+
+The complete text of the license is available in the
+../Documentation/licenses/COPYING.LGPLv2.1 file.
+
+> LGPL 3.0
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\libmount\python\pylibmount.c
+
+Python bindings for the libmount library.
+
+Copyright (C) 2013, Red Hat, Inc. All rights reserved.
+Written by Ondrej Oprala and Karel Zak
+
+This file is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 3 of the License, or (at your option) any later version.
+
+This file is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this file; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+> GPL 3.0 WITH BISON PARSER EXCEPTION
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\lib\parse-date.c
+
+Bison implementation for Yacc-like parsers in C
+
+Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+As a special exception, you may create a larger work that contains
+part or all of the Bison parser skeleton and distribute that work
+under terms of your choice, so long as that work isn't itself a
+parser generator using the skeleton or a modified version thereof
+as a parser skeleton.  Alternatively, if you modify or redistribute
+the parser skeleton itself, you may (at your option) remove this
+special exception, which will cause the skeleton and the resulting
+Bison output files to be licensed under the GNU General Public
+License without this special exception.
+
+This special exception was added by the Free Software Foundation in
+version 2.2 of Bison.  
+
+> GPL 1.0
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\disk-utils\fdisk.c
+
+Copyright (C) 1992  A. V. Le Blanc (LeBlanc@mcc.ac.uk)
+Copyright (C) 2012  Davidlohr Bueso <dave@gnu.org>
+
+Copyright (C) 2007-2013 Karel Zak <kzak@redhat.com>
+
+This program is free software.  You can redistribute it and/or
+modify it under the terms of the GNU General Public License as
+published by the Free Software Foundation: either version 1 or
+(at your option) any later version.
+
+> MIT STYLE
+
+util-linux-2.32-1.ph2.src.rpm\util-linux-2.32-1.ph2.src.cpio\util-linux-2.32.tar.xz\util-linux-2.32.tar\util-linux-2.32\disk-utils\cfdisk.8
+
+Copyright 1994 Kevin E. Martin (martin@cs.unc.edu)
+Copyright (C) 2014 Karel Zak <kzak@redhat.com>
+
+Permission is granted to make and distribute verbatim copies of this
+manual provided the copyright notice and this permission notice are
+preserved on all copies.
+
+Permission is granted to copy and distribute modified versions of this
+manual under the conditions for verbatim copying, provided that the
+entire resulting derived work is distributed under the terms of a
+permission notice identical to this one.
+
+--------------- SECTION 5: GNU General Public License, V3.0 ----------
+
+GNU General Public License, V3.0 is applicable to the following component(s).
+
+
+>>> bash-4.4.12-3.ph2
+
+error.c -- Functions for handling errors.
+
+Copyright (C) 1993-2009 Free Software Foundation, Inc.
+
+This file is part of GNU Bash, the Bourne Again SHell.
+
+Bash is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Bash is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Bash.  If not, see <http://www.gnu.org/licenses/>.
+
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+
+>GPL 3.0 WITH BISON PARSER EXCEPTION
+
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\parser-built
+
+
+A Bison parser, made by GNU Bison 3.0.4.
+
+Bison interface for Yacc-like parsers in C
+
+Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+As a special exception, you may create a larger work that contains
+part or all of the Bison parser skeleton and distribute that work
+under terms of your choice, so long as that work isn't itself a
+parser generator using the skeleton or a modified version thereof
+as a parser skeleton.  Alternatively, if you modify or redistribute
+the parser skeleton itself, you may (at your option) remove this
+special exception, which will cause the skeleton and the resulting
+Bison output files to be licensed under the GNU General Public
+License without this special exception.
+
+This special exception was added by the Free Software Foundation in
+version 2.2 of Bison.
+
+
+>MIT STYLE
+
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\README
+
+
+Copying and distribution of this file, with or without modification,
+are permitted in any medium without royalty provided the copyright
+notice and this notice are preserved.  This file is offered as-is,
+without any warranty.
+
+
+>GFDL 1.3
+
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\doc\bashref.texi
+
+
+Copyright @copyright{} 1988--2016 Free Software Foundation, Inc.
+
+@quotation
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.3 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, no Front-Cover Texts, and no Back-Cover Texts.
+A copy of the license is included in the section entitled
+``GNU Free Documentation License''.
+@end quotation
+
+
+>SIL OPEN FONT LICENSE 1.1
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\doc\bashref.ps
+
+Copyright: Copyright (c) 1997, 2009 American Mathematical Society
+Copyright: (<http://www.ams.org>), with Reserved Font Name CMR9.
+This Font Software is licensed under the SIL Open Font License, Version 1.1.
+This license is in the accompanying file OFL.txt, and is also
+available with a FAQ at: http://scripts.sil.org/OFL.
+
+
+>GPL 2.0
+
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\examples\complete\complete-examples
+
+
+
+Copyright 2002 Chester Ramey
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+TThis program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, write to the Free Software Foundation,
+Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA.
+
+
+>PUBLIC DOMAIN
+
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\support\mkinstalldirs
+
+
+Author: Noah Friedman <friedman@prep.ai.mit.edu>
+Created: 1993-05-16
+Public domain
+
+
+>BSD-4
+
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\lib\sh\inet_aton.c
+
+
+Copyright (c) 1983, 1990, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. All advertising materials mentioning features or use of this software
+must display the following acknowledgement:
+This product includes software developed by the University of
+California, Berkeley and its contributors.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+-
+
+
+
+>BSD
+
+
+bash-4.4.tar.gz\bash-4.4.tar\bash-4.4\lib\sh\inet_aton.
+
+
+Portions Copyright (c) 1993 by Digital Equipment Corporation.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies, and that
+the name of Digital Equipment Corporation not be used in advertising or
+publicity pertaining to distribution of the document or software without
+specific, written prior permission.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND DIGITAL EQUIPMENT CORP. DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS.   IN NO EVENT SHALL DIGITAL EQUIPMENT
+CORPORATION BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+-
+
+>>> coreutils-8.27-3.ph2
+
+Copyright (C) 2003-2017 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+>GFDL 1.3
+
+coreutils-8.27.tar.xz\coreutils-8.27.tar\coreutils-8.27\README
+
+
+Copyright (C) 1998-2017 Free Software Foundation, Inc.
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.3 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with no Front-Cover Texts, and with no Back-Cover
+Texts.  A copy of the license is included in the "GNU Free
+Documentation License" file as part of this distribution.
+	
+>MIT
+
+coreutils-8.27.tar.xz\coreutils-8.27.tar\coreutils-8.27\gnulib-tests\inet_pton.c
+
+
+Copyright (c) 1996,1999 by Internet Software Consortium.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+
+>BSD-3
+
+coreutils-8.27.tar.xz\coreutils-8.27.tar\coreutils-8.27\lib\fts.c
+
+Copyright (c) 1990, 1993, 1994
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+
+>GPL 3.0 WITH BISON PARSER EXCEPTION
+
+
+coreutils-8.27.tar.xz\coreutils-8.27.tar\coreutils-8.27\lib\parse-datetime.c
+
+/ Bison implementation for Yacc-like parsers in C
+
+Copyright (C) 1984, 1989-1990, 2000-2015 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.  /
+
+/ As a special exception, you may create a larger work that contains
+part or all of the Bison parser skeleton and distribute that work
+under terms of your choice, so long as that work isn't itself a
+parser generator using the skeleton or a modified version thereof
+as a parser skeleton.  Alternatively, if you modify or redistribute
+the parser skeleton itself, you may (at your option) remove this
+special exception, which will cause the skeleton and the resulting
+Bison output files to be licensed under the GNU General Public
+License without this special exception.
+
+This special exception was added by the Free Software Foundation in
+version 2.2 of Bison.  /
+
+>PUBLIC DOMAIN
+
+coreutils-8.27.tar.xz\coreutils-8.27.tar\coreutils-8.27\lib\alloca.c
+
+(Mostly) portable public-domain implementation -- D A Gwyn
+
+This implementation of the PWB library alloca function,
+which is used to allocate space off the run-time stack so
+that it is automatically reclaimed upon procedure exit,
+was inspired by discussions with J. Q. Johnson of Cornell.
+J.Otto Tennant <jot@cray.com> contributed the Cray support.
+
+There are some preprocessor constants that can
+be defined when compiling for your specific system, for
+improved efficiency; however, the defaults should be okay.
+
+The general concept of this implementation is to keep
+track of all alloca-allocated blocks, and reclaim any
+that are found to be deeper in the stack than the current
+invocation.  This heuristic does not reclaim storage as
+soon as it becomes invalid, but it will do so eventually.
+
+>>> elfutils-0.176-1.ph2
+
+Copyright (C) 2012 Red Hat, Inc.
+
+This file is part of elfutils.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+elfutils is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> LGPL2.1
+
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\libelf\elf.h
+
+Copyright (C) 1995-2013 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with the GNU C Library; if not, see
+<http://www.gnu.org/licenses/>.
+
+> LGPL3.0
+
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\libelf\version.h
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE LGPL3.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (C) 2013 Red Hat, Inc.
+This file is part of elfutils.
+
+This file is free software; you can redistribute it and/or modify
+it under the terms of either
+
+the GNU Lesser General Public License as published by the Free
+Software Foundation; either version 3 of the License, or (at
+your option) any later version
+
+or
+
+the GNU General Public License as published by the Free
+Software Foundation; either version 2 of the License, or (at
+your option) any later version
+
+or both in parallel, as here.
+
+elfutils is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received copies of the GNU General Public License and
+the GNU Lesser General Public License along with this program.  If
+not, see <http://www.gnu.org/licenses/>.
+
+> MIT
+
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\aclocal.m4
+
+Copyright (C) 1996-2013 Free Software Foundation, Inc.
+
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+> PublicDomain
+
+elfutils-0.176-1.ph2.src.rpm\elfutils-0.176-1.ph2.src.cpio\elfutils-0.176.tar.bz2\elfutils-0.176.tar\elfutils-0.176\lib\md5.c
+
+These are the four functions used in the four steps of the MD5 algorithm
+and defined in the RFC 1321.  The first function is a little bit optimized
+(as found in Colin Plumbs public domain implementation).
+
+>>> grep-3.0-4.ph2
+
+Copyright (C) 2002-2017 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> MIT- Style
+
+grep-3.0.tar.xz\grep-3.0.tar\grep-3.0\aclocal.m4
+
+Copyright (C) 1996-2015 Free Software Foundation, Inc.
+
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+> GFDL 1.3
+
+grep-3.0.tar.xz\grep-3.0.tar\grep-3.0\doc\grep.info
+
+Copyright Â© 1999-2002, 2005, 2008-2017 Free Software Foundation, Inc.
+
+Permission is granted to copy, distribute and/or modify this
+document under the terms of the GNU Free Documentation License,
+Version 1.3 or any later version published by the Free Software
+Foundation; with no Invariant Sections, with no Front-Cover Texts,
+and with no Back-Cover Texts.  A copy of the license is included in
+the section entitled â€œGNU Free Documentation Licenseâ€.
+
+> Public Domain
+
+grep-3.0.tar.xz\grep-3.0.tar\grep-3.0\lib\alloca.c
+
+alloca.c -- allocate automatically reclaimed memory
+(Mostly) portable public-domain implementation -- D A Gwyn
+
+This implementation of the PWB library alloca function,
+which is used to allocate space off the run-time stack so
+that it is automatically reclaimed upon procedure exit,
+was inspired by discussions with J. Q. Johnson of Cornell.
+J.Otto Tennant <jot@cray.com> contributed the Cray support.
+
+There are some preprocessor constants that can
+be defined when compiling for your specific system, for
+improved efficiency; however, the defaults should be okay.
+
+The general concept of this implementation is to keep
+track of all alloca-allocated blocks, and reclaim any
+that are found to be deeper in the stack than the current
+invocation.  This heuristic does not reclaim storage as
+soon as it becomes invalid, but it will do so eventually.
+
+As a special case, alloca(0) reclaims storage without
+allocating any.  It is a good idea to use alloca(0) in
+your main control loop, etc. to force garbage collection.
+
+> BSD- 3 Clause
+
+grep-3.0.tar.xz\grep-3.0.tar\grep-3.0\lib\fts.c
+
+
+Copyright (c) 1990, 1993, 1994
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+>>> gzip-1.8-1.ph2
+
+Copyright (C) 2010-2016 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify it
+under the terms of the GNU General Public License as published
+by the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GFDL 1.3
+
+gzip-1.8.tar.xz\gzip-1.8.tar\gzip-1.8\doc\gzip.info
+
+Copyright © 1992, 1993 Jean-loup Gailly
+
+Permission is granted to copy, distribute and/or modify this
+document under the terms of the GNU Free Documentation License,
+Version 1.3 or any later version published by the Free Software
+Foundation; with no Invariant Sections, with no Front-Cover Texts,
+and with no Back-Cover Texts.  A copy of the license is included in
+the section entitled “GNU Free Documentation License”.
+
+> MIT-Style
+
+gzip-1.8.tar.xz\gzip-1.8.tar\gzip-1.8\zless.1
+
+Copyright \(co 2006-2007, 2015-2016 Free Software Foundation, Inc.
+
+Copyright \(co 1992, 1993 Jean-loup Gailly
+
+Permission is granted to make and distribute verbatim copies of
+this manual provided the copyright notice and this permission notice
+are preserved on all copies.
+
+Permission is granted to process this file through troff and print the
+results, provided the printed document carries copying permission
+notice identical to this one except for the removal of this paragraph
+(this paragraph not being relevant to the printed manual).
+
+Permission is granted to copy and distribute modified versions of this
+manual under the conditions for verbatim copying, provided that the entire
+resulting derived work is distributed under the terms of a permission
+notice identical to this one.
+
+Permission is granted to copy and distribute translations of this manual
+into another language, under the above conditions for modified versions,
+except that this permission notice may be stated in a translation approved
+by the Foundation.
+
+> Public Domain
+
+gzip-1.8.tar.xz\gzip-1.8.tar\gzip-1.8\unlzh.c
+
+The code in this file is directly derived from the public domain 'ar002'
+written by Haruhiko Okumura.
+
+>>> haveged-1.9.1-4.ph2
+
+Copyright 2009-2011 Gary Wuertz gary@issiweb.com
+Copyright 2011 BenEleventh Consulting manolson@beneleventh.com
+ 
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> MIT-Style
+
+haveged-1.9.1.tar.gz\haveged-1.9.1.tar\haveged-1.9.1\aclocal.m4
+
+Copyright (C) 1996-2012 Free Software Foundation, Inc.
+
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+
+> LGPL 2.1
+
+haveged-1.9.1.tar.gz\haveged-1.9.1.tar\haveged-1.9.1\src\oneiteration.h
+
+This source is an adaptation of work released as
+ 
+Copyright (C) 2006 - André Seznec - Olivier Rochecouste
+
+under version 2.1 of the GNU Lesser General Public License
+
+The original form is retained with minor variable renames for
+more consistent macro itilization. See havegecollect.c for
+details.
+
+>>> readline-7.0-2.ph2
+
+Copyright (C) 1987-2015 Free Software Foundation, Inc.
+
+This file is part of the GNU Readline Library (Readline), a library
+for reading lines of text with interactive input and history editing.
+
+Readline is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+Readline is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with Readline.  If not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GFDL 1.3
+
+readline-7.0.tar.gz\readline-7.0.tar\readline-7.0\doc\history.info
+
+Copyright (C) 1988-2016 Free Software Foundation, Inc.
+
+Permission is granted to copy, distribute and/or modify this
+document under the terms of the GNU Free Documentation License,
+Version 1.3 or any later version published by the Free Software
+Foundation; with no Invariant Sections, no Front-Cover Texts, and
+no Back-Cover Texts.  A copy of the license is included in the
+section entitled "GNU Free Documentation License".
+
+
+> GPL 2.0
+
+readline-7.0.tar.gz\readline-7.0.tar\readline-7.0\examples\rlfe\extern.h
+
+Copyright (c) 1993-2002
+Juergen Weigert (jnweiger@immd4.informatik.uni-erlangen.de)
+Michael Schroeder (mlschroe@immd4.informatik.uni-erlangen.de)
+Copyright (c) 1987 Oliver Laumann
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program (see the file COPYING); if not, write to the
+Free Software Foundation, Inc.,
+59 Temple Place - Suite 330, Boston, MA  02111-1307, USA
+
+rlwrap-0.30.tar.gz
+
+> LGPL 2.1
+
+readline-7.0.tar.gz\readline-7.0.tar\readline-7.0\examples\rlwrap-0.30.tar.gz\rlwrap-0.30.tar\rlwrap-0.30\src\redblack.h
+
+Copyright (C) Damian Ivereigh 2000
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version. See the file COPYING for details.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this program; if not, write to the Free Software
+Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+
+> Public Domain
+
+readline-7.0.tar.gz\readline-7.0.tar\readline-7.0\support\mkinstalldirs
+
+Author: Noah Friedman <friedman@prep.ai.mit.edu>
+Created: 1993-05-16
+Public domain
+
+readline-7.0.tar.gz
+
+> MIT
+
+readline-7.0.tar.gz\readline-7.0.tar\readline-7.0\support\wcwidth.c
+
+Markus Kuhn -- 2007-05-26 (Unicode 5.0)
+
+Permission to use, copy, modify, and distribute this software
+for any purpose and without fee is hereby granted. The author
+disclaims all warranties with regard to this software.
+
+Latest version: http://www.cl.cam.ac.uk/~mgk25/ucs/wcwidth.c
+
+--------------- SECTION 6: GNU Lesser General Public License, V2.1 ----------
+
+GNU Lesser General Public License, V2.1 is applicable to the following component(s).
+
+
+>>> cracklib-2.9.6-8.ph2
+
+A Python binding for cracklib.
+
+Parts of this code are based on work Copyright (c) 2003 by Domenico
+Andreoli.
+
+Copyright (c) 2008, 2009, 2012 Jan Dittberner <jan@dittberner.info>
+
+This file is part of cracklib.
+
+This library is free software; you can redistribute it and/or modify it under
+the terms of the GNU Lesser General Public License as published by the Free
+Software Foundation; either version 2.1 of the License, or (at your option)
+any later version.
+
+This library is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+FOR A PARTICULAR PURPOSE.  See the GNU Lesser General Public License for more
+details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with this library; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Public Domain
+
+cracklib-2.9.6.tar.gz\cracklib-2.9.6.tar\cracklib-2.9.6\po\es.po
+
+translation of cracklib.po to
+This file is put in the public domain.
+, 2003
+
+>>> glibc-2.26-16.ph2
+
+Copyright (C) 1991-2017 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with the GNU C Library; if not, see
+<http://www.gnu.org/licenses/>.
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+>
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\LICENSES
+
+This file contains the copying permission notices for various files in the
+GNU C Library distribution that have copyright owners other than the Free
+Software Foundation.  These notices all require that a copy of the notice
+be included in the accompanying documentation and be distributed with
+binary distributions of the code, so be sure to include this file along
+with any binary distributions derived from the GNU C Library.
+All code incorporated from 4.4 BSD is distributed under the following
+license:
+
+Copyright (C) 1991 Regents of the University of California.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. [This condition was removed.]
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+The DNS resolver code, taken from BIND 4.9.5, is copyrighted by UC
+Berkeley, by Digital Equipment Corporation and by Internet Software
+Consortium.  The DEC portions are under the following license:
+
+Portions Copyright (C) 1993 by Digital Equipment Corporation.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies, and
+that the name of Digital Equipment Corporation not be used in
+advertising or publicity pertaining to distribution of the document or
+software without specific, written prior permission.
+
+THE SOFTWARE IS PROVIDED ``AS IS'' AND DIGITAL EQUIPMENT CORP.
+DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS.  IN NO EVENT SHALL
+DIGITAL EQUIPMENT CORPORATION BE LIABLE FOR ANY SPECIAL, DIRECT,
+INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING
+FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT,
+NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION
+WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+The ISC portions are under the following license:
+
+Portions Copyright (c) 1996-1999 by Internet Software Consortium.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND INTERNET SOFTWARE CONSORTIUM DISCLAIMS
+ALL WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL INTERNET SOFTWARE
+CONSORTIUM BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+The Sun RPC support (from rpcsrc-4.0) is covered by the following
+license:
+
+Copyright (c) 2010, Oracle America, Inc.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimer in the documentation and/or other materials
+provided with the distribution.
+
+Neither the name of the "Oracle America, Inc." nor the names of its
+contributors may be used to endorse or promote products derived
+from this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The following CMU license covers some of the support code for Mach,
+derived from Mach 3.0:
+
+Mach Operating System
+Copyright (C) 1991,1990,1989 Carnegie Mellon University
+All Rights Reserved.
+
+Permission to use, copy, modify and distribute this software and its
+documentation is hereby granted, provided that both the copyright
+notice and this permission notice appear in all copies of the
+software, derivative works or modified versions, and any portions
+thereof, and that both notices appear in supporting documentation.
+
+CARNEGIE MELLON ALLOWS FREE USE OF THIS SOFTWARE IN ITS ``AS IS''
+CONDITION.  CARNEGIE MELLON DISCLAIMS ANY LIABILITY OF ANY KIND FOR
+ANY DAMAGES WHATSOEVER RESULTING FROM THE USE OF THIS SOFTWARE.
+
+Carnegie Mellon requests users of this software to return to
+
+Software Distribution Coordinator
+School of Computer Science
+Carnegie Mellon University
+Pittsburgh PA 15213-3890
+
+or Software.Distribution@CS.CMU.EDU any improvements or
+extensions that they make and grant Carnegie Mellon the rights to
+redistribute these changes.
+The file if_ppp.h is under the following CMU license:
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY CARNEGIE MELLON UNIVERSITY AND
+CONTRIBUTORS ``AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES,
+INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF
+MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED.
+IN NO EVENT SHALL THE UNIVERSITY OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER
+IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR
+OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN
+IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The following license covers the files from Intel's "Highly Optimized
+Mathematical Functions for Itanium" collection:
+
+Intel License Agreement
+
+Copyright (c) 2000, Intel Corporation
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+The name of Intel Corporation may not be used to endorse or promote
+products derived from this software without specific prior written
+permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+The files inet/getnameinfo.c and sysdeps/posix/getaddrinfo.c are copyright
+(C) by Craig Metz and are distributed under the following license:
+
+/ The Inner Net License, Version 2.00
+
+The author(s) grant permission for redistribution and use in source and
+binary forms, with or without modification, of the software and documentation
+provided that the following conditions are met:
+
+0. If you receive a version of the software that is specifically labelled
+as not being for redistribution (check the version message and/or README),
+you are not permitted to redistribute that version of the software in any
+way or form.
+1. All terms of the all other applicable copyrights and licenses must be
+followed.
+2. Redistributions of source code must retain the authors' copyright
+notice(s), this list of conditions, and the following disclaimer.
+
+3. Redistributions in binary form must reproduce the authors' copyright
+notice(s), this list of conditions, and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+4. [The copyright holder has authorized the removal of this clause.]
+
+5. Neither the name(s) of the author(s) nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY ITS AUTHORS AND CONTRIBUTORS ``AS IS'' AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE AUTHORS OR CONTRIBUTORS BE LIABLE FOR ANY
+DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+If these license terms cause you a real problem, contact the author.  /
+The file sunrpc/des_impl.c is copyright Eric Young:
+
+Copyright (C) 1992 Eric Young
+
+Collected from libdes and modified for SECURE RPC by Martin Kuck 1994
+This file is distributed under the terms of the GNU Lesser General
+Public License, version 2.1 or later - see the file COPYING.LIB for details.
+If you did not receive a copy of the license with this program, please
+see <http://www.gnu.org/licenses/> to obtain a copy.
+
+The libidn code is copyright Simon Josefsson, with portions copyright
+The Internet Society, Tom Tromey and Red Hat, Inc.:
+
+Copyright (C) 2002, 2003, 2004, 2011  Simon Josefsson
+
+This file is part of GNU Libidn.
+
+GNU Libidn is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+GNU Libidn is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with GNU Libidn; if not, see <http://www.gnu.org/licenses/>.
+
+The following notice applies to portions of libidn/nfkc.c:
+
+This file contains functions from GLIB, including gutf8.c and
+gunidecomp.c, all licensed under LGPL and copyright hold by:
+
+Copyright (C) 1999, 2000 Tom Tromey
+Copyright 2000 Red Hat, Inc.
+
+The following applies to portions of libidn/punycode.c and
+libidn/punycode.h:
+
+This file is derived from RFC 3492bis written by Adam M. Costello.
+
+Disclaimer and license: Regarding this entire document or any
+portion of it (including the pseudocode and C code), the author
+makes no guarantees and is not responsible for any damage resulting
+from its use.  The author grants irrevocable permission to anyone
+to use, modify, and distribute it in any way that does not diminish
+the rights of anyone else to use, modify, and distribute it,
+provided that redistributed derivative works do not contain
+misleading author or version information.  Derivative works need
+not be licensed under similar terms.
+Copyright (C) The Internet Society (2003).  All Rights Reserved.
+
+This document and translations of it may be copied and furnished to
+others, and derivative works that comment on or otherwise explain it
+or assist in its implementation may be prepared, copied, published
+and distributed, in whole or in part, without restriction of any
+kind, provided that the above copyright notice and this paragraph are
+included on all such copies and derivative works.  However, this
+document itself may not be modified in any way, such as by removing
+the copyright notice or references to the Internet Society or other
+Internet organizations, except as needed for the purpose of
+developing Internet standards in which case the procedures for
+copyrights defined in the Internet Standards process must be
+followed, or as required to translate it into languages other than
+English.
+
+The limited permissions granted above are perpetual and will not be
+revoked by the Internet Society or its successors or assigns.
+
+This document and the information contained herein is provided on an
+"AS IS" basis and THE INTERNET SOCIETY AND THE INTERNET ENGINEERING
+TASK FORCE DISCLAIMS ALL WARRANTIES, EXPRESS OR IMPLIED, INCLUDING
+BUT NOT LIMITED TO ANY WARRANTY THAT THE USE OF THE INFORMATION
+HEREIN WILL NOT INFRINGE ANY RIGHTS OR ANY IMPLIED WARRANTIES OF
+MERCHANTABILITY OR FITNESS FOR A PARTICULAR PURPOSE.
+The file inet/rcmd.c is under a UCB copyright and the following:
+
+Copyright (C) 1998 WIDE Project.
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. Neither the name of the project nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE PROJECT AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE PROJECT OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+The file posix/runtests.c is copyright Tom Lord:
+
+Copyright 1995 by Tom Lord
+
+All Rights Reserved
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted,
+provided that the above copyright notice appear in all copies and that
+both that copyright notice and this permission notice appear in
+supporting documentation, and that the name of the copyright holder not be
+used in advertising or publicity pertaining to distribution of the
+software without specific, written prior permission.
+
+Tom Lord DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS SOFTWARE,
+INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS, IN NO
+EVENT SHALL TOM LORD BE LIABLE FOR ANY SPECIAL, INDIRECT OR
+CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF
+USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR
+OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+The posix/rxspencer tests are copyright Henry Spencer:
+
+Copyright 1992, 1993, 1994, 1997 Henry Spencer.  All rights reserved.
+This software is not subject to any license of the American Telephone
+and Telegraph Company or of the Regents of the University of California.
+
+Permission is granted to anyone to use this software for any purpose on
+any computer system, and to alter it and redistribute it, subject
+to the following restrictions:
+
+1. The author is not responsible for the consequences of use of this
+software, no matter how awful, even if they arise from flaws in it.
+
+2. The origin of this software must not be misrepresented, either by
+explicit claim or by omission.  Since few users ever read sources,
+credits must appear in the documentation.
+
+3. Altered versions must be plainly marked as such, and must not be
+misrepresented as being the original software.  Since few users
+ever read sources, credits must appear in the documentation.
+
+4. This notice may not be removed or altered.
+
+The file posix/PCRE.tests is copyright University of Cambridge:
+
+Copyright (c) 1997-2003 University of Cambridge
+
+Permission is granted to anyone to use this software for any purpose on any
+computer system, and to redistribute it freely, subject to the following
+restrictions:
+
+1. This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+2. The origin of this software must not be misrepresented, either by
+explicit claim or by omission. In practice, this means that if you use
+PCRE in software that you distribute to others, commercially or
+otherwise, you must put a sentence like this
+
+Regular expression support is provided by the PCRE library package,
+which is open source software, written by Philip Hazel, and copyright
+by the University of Cambridge, England.
+
+somewhere reasonably visible in your documentation and in any relevant
+files or online help data or similar. A reference to the ftp site for
+the source, that is, to
+
+ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/
+
+should also be given in the documentation. However, this condition is not
+intended to apply to whole chains of software. If package A includes PCRE,
+it must acknowledge it, but if package B is software that includes package
+A, the condition is not imposed on package B (unless it uses PCRE
+independently).
+
+3. Altered versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+
+4. If PCRE is embedded in any software that is released under the GNU
+General Purpose Licence (GPL), or Lesser General Purpose Licence (LGPL),
+then the terms of that licence shall supersede any condition above with
+which it is incompatible.
+
+Files from Sun fdlibm are copyright Sun Microsystems, Inc.:
+
+Copyright (C) 1993 by Sun Microsystems, Inc. All rights reserved.
+
+Developed at SunPro, a Sun Microsystems, Inc. business.
+Permission to use, copy, modify, and distribute this
+software is freely granted, provided that this notice
+is preserved.
+
+Part of stdio-common/tst-printf.c is copyright C E Chew:
+
+(C) Copyright C E Chew
+
+Feel free to copy, use and distribute this software provided:
+
+1. you do not pretend that you wrote it
+2. you leave this copyright notice intact.
+
+Various long double libm functions are copyright Stephen L. Moshier:
+
+Copyright 2001 by Stephen L. Moshier <moshier@na-net.ornl.gov>
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, see
+<http://www.gnu.org/licenses/>.  /
+
+>LGPL 2.1 WITH SPECIAL EXCEPTION
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\wcsmbs\isoc99_vswscanf.c
+
+/ Copyright (C) 1993-2017 Free Software Foundation, Inc.
+This file is part of the GNU C Library.
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with the GNU C Library; if not, see
+<http://www.gnu.org/licenses/>.
+
+As a special exception, if you link the code in this file with
+files compiled with a GNU compiler to produce an executable,
+that does not cause the resulting executable to be covered by
+the GNU Lesser General Public License.  This exception does not
+however invalidate any other reasons why the executable file
+might be covered by the GNU Lesser General Public License.
+This exception applies to code released by its copyright holders
+in files containing the exception.
+
+>BSD-3
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\termios\sys\ttychars.h
+
+Copyright (c) 1982, 1986, 1990, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+
+>GPL 2.0
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\catgets\xopen-msg.awk
+
+Copyright (C) 2012-2017 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+>GPL 3.0 WITH BISON PARSER EXCEPTION
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\intl\plural.c
+
+/ A Bison parser, made by GNU Bison 2.7.  /
+
+/ Bison implementation for Yacc-like parsers in C
+
+Copyright (C) 1984, 1989-1990, 2000-2012 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.  /
+
+/ As a special exception, you may create a larger work that contains
+part or all of the Bison parser skeleton and distribute that work
+under terms of your choice, so long as that work isn't itself a
+parser generator using the skeleton or a modified version thereof
+as a parser skeleton.  Alternatively, if you modify or redistribute
+the parser skeleton itself, you may (at your option) remove this
+special exception, which will cause the skeleton and the resulting
+Bison output files to be licensed under the GNU General Public
+License without this special exception.
+
+This special exception was added by the Free Software Foundation in
+version 2.2 of Bison.  /
+
+>GFDL 1.3
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\manual\fdl-1.3.texi
+
+LICENSE: GFDL 1.3
+
+
+>LGPL 2.0
+
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\sysdeps\powerpc\power5+\fpu\s_modf.c
+
+
+Copyright (C) 2013-2017 Free Software Foundation, Inc.
+This file is part of the GNU C Library
+
+The GNU C Library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.
+
+The GNU C Library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with the GNU C Library; see the file COPYING.LIB.  If
+not, see <http://www.gnu.org/licenses/>.
+
+
+> PUBLIC DOMAIN
+
+glibc-2.26.tar.xz\glibc-2.26.tar\glibc-2.26\timezone\zone.tab
+
+<pre>
+@(#)zone.tab	8.28
+This file is in the public domain, so clarified as of
+2009-05-17 by Arthur David Olson.
+
+>>> hawkey-2017.1-6.ph2
+
+Copyright (C) 2014 Red Hat, Inc.
+
+Licensed under the GNU Lesser General Public License Version 2.1
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 2.0
+
+hawkey-2017.1.tar.gz\hawkey-2017.1.tar\hawkey-hawkey-0.6.4-1\doc\changes.rst
+
+Copyright (C) 2014-2015  Red Hat, Inc.
+
+This copyrighted material is made available to anyone wishing to use,
+modify, copy, or redistribute it subject to the terms and conditions of
+the GNU General Public License v.2, or (at your option) any later version.
+This program is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY expressed or implied, including the implied warranties of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General
+Public License for more details.  You should have received a copy of the
+GNU General Public License along with this program; if not, write to the
+Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA
+02110-1301, USA.  Any Red Hat trademarks that are incorporated in the
+source code or documentation are not subject to the GNU General Public
+License and may only be used or replicated with the express permission of
+Red Hat, Inc.
+
+>>> kmod-24-3.ph2
+
+Copyright (C) 2012-2013  ProFUSION embedded systems
+
+This program is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 2.0
+
+kmod-24.tar.xz\kmod-24.tar\kmod-24\tools\rmmod.c
+
+kmod-insert - insert a module into the kernel.
+
+Copyright (C) 2015 Intel Corporation. All rights reserved.
+Copyright (C) 2011-2013  ProFUSION embedded systems
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+>>> libgcrypt-1.8.1-2.ph2
+
+Copyright (C) 2013 g10 Code GmbH
+
+This file is part of Libgcrypt.
+
+Libgcrypt is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+Libgcrypt is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307, USA
+
+ADDITIONAL LICENSE INFORMATION:
+
+>
+
+libgcrypt-1.8.1.tar.bz2\libgcrypt-1.8.1.tar\libgcrypt-1.8.1\LICENSES
+
+Additional license notices for Libgcrypt.                    -- org --
+
+This file contains the copying permission notices for various files in
+the Libgcrypt distribution which are not covered by the GNU Lesser
+General Public License (LGPL) or the GNU General Public License (GPL).
+
+These notices all require that a copy of the notice be included
+in the accompanying documentation and be distributed with binary
+distributions of the code, so be sure to include this file along
+with any binary distributions derived from the GNU C Library.
+
+BSD_3Clause
+
+For files:
+- cipher/sha256-avx-amd64.S
+- cipher/sha256-avx2-bmi2-amd64.S
+- cipher/sha256-ssse3-amd64.S
+- cipher/sha512-avx-amd64.S
+- cipher/sha512-avx2-bmi2-amd64.S
+- cipher/sha512-ssse3-amd64.S
+
++begin_quote
+Copyright (c) 2012, Intel Corporation
+
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+
+Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the
+distribution.
+
+Neither the name of the Intel Corporation nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+
+THIS SOFTWARE IS PROVIDED BY INTEL CORPORATION "AS IS" AND ANY
+EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL INTEL CORPORATION OR
+CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
++end_quote
+
+
+For files:
+- random/jitterentropy-base.c
+- random/jitterentropy.h
+- random/rndjent.c (plus common Libgcrypt copyright holders)
+
++begin_quote
+Copyright Stephan Mueller <smueller@chronox.de>, 2013
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+License
+=======
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, and the entire permission notice in its entirety,
+including the disclaimer of warranties.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote
+products derived from this software without specific prior
+written permission.
+
+ALTERNATIVELY, this product may be distributed under the terms of
+the GNU General Public License, in which case the provisions of the GPL are
+required INSTEAD OF the above restrictions.  (This clause is
+necessary due to a potential bad interaction between the GPL and
+the restrictions contained in a BSD-style copyright.)
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
++end_quote
+
+X License
+
+For files:
+- install.sh
+
++begin_quote
+Copyright (C) 1994 X Consortium
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to
+deal in the Software without restriction, including without limitation the
+rights to use, copy, modify, merge, publish, distribute, sublicense, and/or
+sell copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL THE
+X CONSORTIUM BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN
+AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNEC-
+TION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+Except as contained in this notice, the name of the X Consortium shall not
+be used in advertising or otherwise to promote the sale, use or other deal-
+ings in this Software without prior written authorization from the X Consor-
+tium.
++end_quote
+
+Public domain
+
+For files:
+- cipher/arcfour-amd64.S
+
++begin_quote
+Author: Marc Bevand <bevand_m (at) epita.fr>
+Licence: I hereby disclaim the copyright on this code and place it
+in the public domain.
++end_quote
+
+OCB license 1
+
+For files:
+- cipher/cipher-ocb.c
+
++begin_quote
+OCB is covered by several patents but may be used freely by most
+software.  See http://web.cs.ucdavis.edu/~rogaway/ocb/license.htm .
+In particular license 1 is suitable for Libgcrypt: See
+http://web.cs.ucdavis.edu/~rogaway/ocb/license1.pdf for the full
+license document; it basically says:
+
+License 1 â€” License for Open-Source Software Implementations of OCB
+(Jan 9, 2013)
+
+Under this license, you are authorized to make, use, and
+distribute open-source software implementations of OCB. This
+license terminates for you if you sue someone over their
+open-source software implementation of OCB claiming that you have
+a patent covering their implementation.
+
+
+
+License for Open Source Software Implementations of OCB
+January 9, 2013
+
+1 Definitions
+
+1.1 â€œLicensorâ€ means Phillip Rogaway.
+
+1.2 â€œLicensed Patentsâ€ means any patent that claims priority to United
+States Patent Application No. 09/918,615 entitled â€œMethod and Apparatus
+for Facilitating Efficient Authenticated Encryption,â€ and any utility,
+divisional, provisional, continuation, continuations-in-part, reexamination,
+reissue, or foreign counterpart patents that may issue with respect to the
+aforesaid patent application. This includes, but is not limited to, United
+States Patent No. 7,046,802; United States Patent No. 7,200,227; United
+States Patent No. 7,949,129; United States Patent No. 8,321,675 ; and any
+patent that issues out of United States Patent Application No. 13/669,114.
+
+1.3 â€œUseâ€ means any practice of any invention claimed in the Licensed Patents.
+
+1.4 â€œSoftware Implementationâ€ means any practice of any invention
+claimed in the Licensed Patents that takes the form of software executing on
+a user-programmable, general-purpose computer or that takes the form of a
+computer-readable medium storing such software. Software Implementation does
+not include, for example, application-specific integrated circuits (ASICs),
+field-programmable gate arrays (FPGAs), embedded systems, or IP cores.
+
+1.5 â€œOpen Source Softwareâ€ means software whose source code is published
+and made available for inspection and use by anyone because either (a) the
+source code is subject to a license that permits recipients to copy, modify,
+and distribute the source code without payment of fees or royalties, or
+(b) the source code is in the public domain, including code released for
+public use through a CC0 waiver. All licenses certified by the Open Source
+Initiative at opensource.org as of January 9, 2013 and all Creative Commons
+licenses identified on the creativecommons.org website as of January 9,
+2013, including the Public License Fallback of the CC0 waiver, satisfy these
+requirements for the purposes of this license.
+
+1.6 â€œOpen Source Software Implementationâ€ means a Software
+Implementation in which the software implicating the Licensed Patents is
+Open Source Software. Open Source Software Implementation does not include
+any Software Implementation in which the software implicating the Licensed
+Patents is combined, so as to form a larger program, with software that is
+not Open Source Software.
+
+2 License Grant
+
+2.1 License. Subject to your compliance with the term s of this license,
+including the restriction set forth in Section 2.2, Licensor hereby
+grants to you a perpetual, worldwide, non-exclusive, non-transferable,
+non-sublicenseable, no-charge, royalty-free, irrevocable license to practice
+any invention claimed in the Licensed Patents in any Open Source Software
+Implementation.
+
+2.2 Restriction. If you or your affiliates institute patent litigation
+(including, but not limited to, a cross-claim or counterclaim in a lawsuit)
+against any entity alleging that any Use authorized by this license
+infringes another patent, then any rights granted to you under this license
+automatically terminate as of the date such litigation is filed.
+
+3 Disclaimer
+YOUR USE OF THE LICENSED PATENTS IS AT YOUR OWN RISK AND UNLESS REQUIRED
+BY APPLICABLE LAW, LICENSOR MAKES NO REPRESENTATIONS OR WARRANTIES OF ANY
+KIND CONCERNING THE LICENSED PATENTS OR ANY PRODUCT EMBODYING ANY LICENSED
+PATENT, EXPRESS OR IMPLIED, STATUT ORY OR OTHERWISE, INCLUDING, WITHOUT
+LIMITATION, WARRANTIES OF TITLE, MERCHANTIBILITY, FITNESS FOR A PARTICULAR
+PURPOSE, OR NONINFRINGEMENT. IN NO EVENT WILL LICENSOR BE LIABLE FOR ANY
+CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN CONTRACT, TORT OR OTHERWISE,
+ARISING FROM OR RELATED TO ANY USE OF THE LICENSED PATENTS, INCLUDING,
+WITHOUT LIMITATION, DIRECT, INDIRECT, INCIDENTAL, CONSEQUENTIAL, PUNITIVE
+OR SPECIAL DAMAGES, EVEN IF LICENSOR HAS BEEN ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGES PRIOR TO SUCH AN OCCURRENCE.
++end_quote
+
+
+>MIT
+
+
+Copyright 1997, 1998, 1999, 2001 Werner Koch (dd9jn)
+Copyright 2013 g10 Code GmbH
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+WERNER KOCH BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+>GPL 2.0
+
+libgcrypt-1.8.1.tar.bz2\libgcrypt-1.8.1.tar\libgcrypt-1.8.1\doc\gpl.texi
+
+LICENSE: GPL 2.0
+
+
+>GPL 3.0
+
+libgcrypt-1.8.1.tar.bz2\libgcrypt-1.8.1.tar\libgcrypt-1.8.1\doc\yat2m.c
+
+Copyright (C) 2005, 2013, 2015, 2016 g10 Code GmbH
+Copyright (C) 2006, 2008, 2011 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+>BSD-3
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+libgcrypt-1.8.1.tar.bz2\libgcrypt-1.8.1.tar\libgcrypt-1.8.1\random\jitterentropy-base.c
+
+Copyright Peter Gutmann, Paul Kendall, and Chris Wedgwood 1996-1999.
+Heavily modified for GnuPG by Werner Koch
+
+
+/
+
+/ This module is part of the cryptlib continuously seeded pseudorandom
+number generator.  For usage conditions, see lib_rand.c
+
+[Here is the notice from lib_rand.c:]
+
+This module and the misc/rnd.c modules represent the cryptlib
+continuously seeded pseudorandom number generator (CSPRNG) as described in
+my 1998 Usenix Security Symposium paper "The generation of random numbers
+for cryptographic purposes".
+
+The CSPRNG code is copyright Peter Gutmann (and various others) 1996,
+1997, 1998, 1999, all rights reserved.  Redistribution of the CSPRNG
+modules and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice
+and this permission notice in its entirety.
+
+2. Redistributions in binary form must reproduce the copyright notice in
+the documentation and/or other materials provided with the distribution.
+
+3. A copy of any bugfixes or enhancements made must be provided to the
+author, <pgut001@cs.auckland.ac.nz> to allow them to be added to the
+baseline version of the code.
+
+ALTERNATIVELY, the code may be distributed under the terms of the
+GNU Lesser General Public License, version 2.1 or any later version
+published by the Free Software Foundation, in which case the
+provisions of the GNU LGPL are required INSTEAD OF the above
+restrictions.
+
+Although not required under the terms of the LGPL, it would still be
+nice if you could make any changes available to the author to allow
+a consistent code base to be maintained.  /
+
+>BSD-3
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD LICENSE.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+libgcrypt-1.8.1.tar.bz2\libgcrypt-1.8.1.tar\libgcrypt-1.8.1\random\random-drbg.c
+
+Copyright 2014 Stephan Mueller <smueller@chronox.de>
+
+DRBG: Deterministic Random Bits Generator
+Based on NIST Recommended DRBG from NIST SP800-90A with the following
+properties:
+CTR DRBG with DF with AES-128, AES-192, AES-256 cores
+Hash DRBG with DF with SHA-1, SHA-256, SHA-384, SHA-512 cores
+HMAC DRBG with DF with SHA-1, SHA-256, SHA-384, SHA-512 cores
+with and without prediction resistance
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, and the entire permission notice in its entirety,
+including the disclaimer of warranties.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote
+products derived from this software without specific prior
+written permission.
+
+ALTERNATIVELY, this product may be distributed under the terms of
+LGPLv2+, in which case the provisions of the LGPL are
+required INSTEAD OF the above restrictions.  (This clause is
+necessary due to a potential bad interaction between the LGPL and
+the restrictions contained in a BSD-style copyright.)
+
+THIS SOFTWARE IS PROVIDED ``AS IS'' AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE, ALL OF
+WHICH ARE HEREBY DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT
+OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR
+BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE
+USE OF THIS SOFTWARE, EVEN IF NOT ADVISED OF THE POSSIBILITY OF SUCH
+DAMAGE.
+
+>>> libgpg-error-1.27-1.ph2
+
+Copyright (C) 2003-2004, 2010, 2013-2016 g10 Code GmbH
+
+This file is part of libgpg-error.
+
+libgpg-error is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public License
+as published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+libgpg-error is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+>GPL 2.0
+
+libgpg-error-1.27.tar.bz2\libgpg-error-1.27.tar\libgpg-error-1.27\doc\gpgrt.info
+
+Copyright (C) 2014 g10 Code GmbH
+
+Permission is granted to copy, distribute and/or modify this
+document under the terms of the GNU General Public License as
+published by the Free Software Foundation; either version 2 of the
+License, or (at your option) any later version.  The text of the
+license can be found in the section entitled "GNU General Public
+License".
+
+>GPL 3.0
+
+libgpg-error-1.27.tar.bz2\libgpg-error-1.27.tar\libgpg-error-1.27\doc\yat2m.c
+
+Copyright (C) 2005, 2013, 2015, 2016 g10 Code GmbH
+Copyright (C) 2006, 2008, 2011 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <https://www.gnu.org/licenses/>.
+
+>MIT STYLE
+
+libgpg-error-1.27.tar.bz2\libgpg-error-1.27.tar\libgpg-error-1.27\src\mkheader.c
+
+Copyright (C) 2010 Free Software Foundation, Inc.
+Copyright (C) 2014 g10 Code GmbH
+
+This file is free software; as a special exception the author gives
+unlimited permission to copy and/or distribute it, with or without
+modifications, as long as this notice is preserved.
+
+This file is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY, to the extent permitted by law; without even the
+implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+
+>BSD-3 Clause
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE BSD-3 CLAUSE LICENSE. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+libgpg-error-1.27.tar.bz2\libgpg-error-1.27.tar\libgpg-error-1.27\src\mkheader.c
+
+estream.c - Extended Stream I/O Library
+Copyright (C) 2004, 2005, 2006, 2007, 2009, 2010, 2011,
+2014, 2015, 2016, 2017 g10 Code GmbH
+
+This file is part of Libestream.
+
+Libestream is free software; you can redistribute it and/or modify
+it under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+Libestream is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with Libestream; if not, see <https://www.gnu.org/licenses/>.
+
+ALTERNATIVELY, Libestream may be distributed under the terms of the
+following license, in which case the provisions of this license are
+required INSTEAD OF the GNU General Public License. If you wish to
+allow use of your version of this file only under the terms of the
+GNU General Public License, and not to allow others to use your
+version of this file under the terms of the following license,
+indicate your decision by deleting this paragraph and the license
+below.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, and the entire permission notice in its entirety,
+including the disclaimer of warranties.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+3. The name of the author may not be used to endorse or promote
+products derived from this software without specific prior
+written permission.
+
+THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESS OR IMPLIED
+WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY DIRECT,
+INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+>LGPL 2.0
+
+libgpg-error-1.27.tar.bz2\libgpg-error-1.27.tar\libgpg-error-1.27\src\gettext.h
+
+Copyright (C) 1995-1998, 2000-2002 Free Software Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify it
+under the terms of the GNU Library General Public License as published
+by the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this program; if not, write to the Free Software
+Foundation, Inc., 59 Temple Place - Suite 330, Boston, MA 02111-1307,
+USA.
+
+>>> systemd-233-19.ph2
+
+This file is part of systemd.
+
+Copyright 2008-2011 Kay Sievers
+Copyright 2012 Lennart Poettering
+
+systemd is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as published by
+the Free Software Foundation; either version 2.1 of the License, or
+(at your option) any later version.
+
+systemd is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public License
+along with systemd; If not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL 2.0
+
+systemd-233.tar.gz\systemd-233.tar\systemd-233\LICENSE.GPL2
+
+License: GPL 2.0
+
+> MIT
+
+systemd-233.tar.gz\systemd-233.tar\systemd-233\man\glib-event-glue.c
+
+Copyright 2014 Tom Gundersen
+
+Permission is hereby granted, free of charge, to any person
+obtaining a copy of this software and associated documentation files
+(the "Software"), to deal in the Software without restriction,
+including without limitation the rights to use, copy, modify, merge,
+publish, distribute, sublicense, and/or sell copies of the Software,
+and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+
+> Public Domain
+
+systemd-233.tar.gz\systemd-233.tar\systemd-233\src\basic\MurmurHash2.c
+
+MurmurHash2 was written by Austin Appleby, and is placed in the public
+domain. The author hereby disclaims copyright to this source code.
+
+> LGPL 2.0
+
+systemd-233.tar.gz\systemd-233.tar\systemd-233\src\basic\utf8.c
+
+Copyright (C) 1999 Tom Tromey
+Copyright (C) 2000 Red Hat, Inc.
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Library General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Library General Public License for more details.
+
+You should have received a copy of the GNU Library General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+--------------- SECTION 7: GNU Lesser General Public License, V3.0 ----------
+
+GNU Lesser General Public License, V3.0 is applicable to the following component(s).
+
+
+>>> gmp-6.1.2-2.ph2
+
+'[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE LGPL 3.0.  PLEASE SEE APPENDIX FOR THE FULL TEXT OF THE LGPL3.0.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright 2000-2002, 2004 Free Software Foundation, Inc.
+
+This file is part of the GNU MP Library.
+
+The GNU MP Library is free software; you can redistribute it and/or modify
+it under the terms of either:
+
+* the GNU Lesser General Public License as published by the Free
+Software Foundation; either version 3 of the License, or (at your
+option) any later version.
+
+or
+
+* the GNU General Public License as published by the Free Software
+Foundation; either version 2 of the License, or (at your option) any
+later version.
+
+or both in parallel, as here.
+
+The GNU MP Library is distributed in the hope that it will be useful, but
+WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+for more details.
+
+You should have received copies of the GNU General Public License and the
+GNU Lesser General Public License along with the GNU MP Library.  If not,
+see https://www.gnu.org/licenses/.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> GPL3.0
+
+gmp-6.1.2.tar.xz\gmp-6.1.2.tar\gmp-6.1.2\demos\factorize.c
+
+Factoring with Pollard's rho method.
+
+Copyright 1995, 1997-2003, 2005, 2009, 2012, 2015 Free Software
+Foundation, Inc.
+
+This program is free software; you can redistribute it and/or modify it under
+the terms of the GNU General Public License as published by the Free Software
+Foundation; either version 3 of the License, or (at your option) any later
+version.
+
+This program is distributed in the hope that it will be useful, but WITHOUT ANY
+WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.  See the GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along with
+this program.  If not, see https://www.gnu.org/licenses/.
+
+> GPL3.0 with Bison Parser Exception
+
+gmp-6.1.2.tar.xz\gmp-6.1.2.tar\gmp-6.1.2\demos\calc\calc.c
+
+Bison implementation for Yacc-like parsers in C
+
+Copyright (C) 1984, 1989-1990, 2000-2013 Free Software Foundation, Inc.
+
+This program is free software: you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation, either version 3 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program.  If not, see <http://www.gnu.org/licenses/>.  */
+
+/* As a special exception, you may create a larger work that contains
+part or all of the Bison parser skeleton and distribute that work
+under terms of your choice, so long as that work isn't itself a
+parser generator using the skeleton or a modified version thereof
+as a parser skeleton.  Alternatively, if you modify or redistribute
+the parser skeleton itself, you may (at your option) remove this
+special exception, which will cause the skeleton and the resulting
+Bison output files to be licensed under the GNU General Public
+License without this special exception.
+
+This special exception was added by the Free Software Foundation in
+version 2.2 of Bison.
+
+> GFDL 1.3
+
+gmp-6.1.2.tar.xz\gmp-6.1.2.tar\gmp-6.1.2\doc\gmp.info
+
+Copyright 1991, 1993-2016 Free Software Foundation, Inc.
+
+Permission is granted to copy, distribute and/or modify this document
+under the terms of the GNU Free Documentation License, Version 1.3 or
+any later version published by the Free Software Foundation; with no
+Invariant Sections, with the Front-Cover Texts being "A GNU Manual", and
+with the Back-Cover Texts being "You have freedom to copy and modify
+this GNU Manual, like GNU software".  A copy of the license is included
+in *note GNU Free Documentation License::.
+
+> GPL2.0
+
+gmp-6.1.2.tar.xz\gmp-6.1.2.tar\gmp-6.1.2\mini-gmp\tests\run-tests
+
+Copyright (C) 2000-2002, 2004, 2005, 2011, 2012, 2016  Niels MÃ¶ller
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License along
+with this program; if not, write to the Free Software Foundation, Inc.,
+51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+
+> MIT Style
+
+gmp-6.1.2.tar.xz\gmp-6.1.2.tar\gmp-6.1.2\aclocal.m4
+
+Copyright (C) 1996-2014 Free Software Foundation, Inc.
+
+This file is free software; the Free Software Foundation
+gives unlimited permission to copy and/or distribute it,
+with or without modifications, as long as this notice is preserved.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY, to the extent permitted by law; without
+even the implied warranty of MERCHANTABILITY or FITNESS FOR A
+PARTICULAR PURPOSE.
+
+--------------- SECTION 8: GNU Library General Public License, V2.0 ----------
+
+GNU Library General Public License, V2.0 is applicable to the following component(s).
+
+
+>>> glib-2.52.1-4.ph2
+
+Copyright © 2015 Canonical Limited
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General
+Public License along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Public Domain
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\build\win32\dirent\dirent.h
+
+This file has no copyright assigned and is placed in the Public Domain.
+This file is a part of the mingw-runtime package.
+No warranty is given; refer to the file DISCLAIMER within the package.
+
+> LGPL 3.0
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\docs\reference\glib\html\glib-resources.html
+
+If you develop a bugfix or enhancement for GLib, please file that in Bugzilla as well. Bugzilla allows you to attach files; please attach a patch generated by the utility, using the option to make the patch more readable. All patches must be offered under the terms of the GNU LGPL license, so be sure you are authorized to give us the patch under those terms.
+
+> MIT
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\gio\kqueue\kqueue-sub.h
+
+Copyright (c) 2011, 2012 Dmitry Matveev <me@dmitrymatveev.co.uk>
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+
+> LGPL 2.0
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\gio\xdgmime\xdgmimeparent.c
+
+[PLEASE NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS COMPONENT UNDER THE TERMS OF THE LGPL 2.0.  PLEASE SEE THE APPENDIX TO REVIEW THE FULL TEXT OF THE LGPL 2.0.  THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Copyright (C) 2004  Red Hat, Inc.
+Copyright (C) 2004  Matthias Clasen <mclasen@redhat.com>
+
+Licensed under the Academic Free License version 2.0
+Or under the following terms:
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	 See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, see <http://www.gnu.org/licenses/>.
+
+> GPL 2.0
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\glib\gen-unicode-tables.pl
+
+Copyright (C) 1998, 1999 Tom Tromey
+Copyright (C) 2001 Red Hat Software
+
+This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2, or (at your option)
+any later version.
+
+This program is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with this program; if not, see <http://www.gnu.org/licenses/>.
+
+> LGPL 2.1
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\gio\win32\winhttp.h
+
+Copyright (C) 2007 Francois Gouget
+
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation; either
+version 2.1 of the License, or (at your option) any later version.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+
+> BSD-3 CLAUSE
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\glib\pcre\pcre.h
+
+Copyright (c) 1997-2012 University of Cambridge
+-----------------------------------------------------------------------------
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+* Neither the name of the University of Cambridge nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+POSSIBILITY OF SUCH DAMAGE.
+
+> BSD
+
+glib-2.52.1.tar.xz\glib-2.52.1.tar\glib-2.52.1\glib\valgrind.h
+
+   Notice that the following BSD-style license applies to this one
+   file (valgrind.h) only.  The rest of Valgrind is licensed under the
+   terms of the GNU General Public License, version 2, unless
+   otherwise indicated.  See the COPYING file in the source
+   distribution for details.
+---------------------------------------------------------------
+   This file is part of Valgrind, a dynamic binary instrumentation
+   framework.
+
+   Copyright (C) 2000-2013 Julian Seward.  All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met:
+
+   1. Redistributions of source code must retain the above copyright
+      notice, this list of conditions and the following disclaimer.
+
+   2. The origin of this software must not be misrepresented; you must 
+      not claim that you wrote the original software.  If you use this 
+      software in a product, an acknowledgment in the product 
+      documentation would be appreciated but is not required.
+
+   3. Altered source versions must be plainly marked as such, and must
+      not be misrepresented as being the original software.
+
+   4. The name of the author may not be used to endorse or promote 
+      products derived from this software without specific prior written 
+      permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE AUTHOR ``AS IS'' AND ANY EXPRESS
+   OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+   WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR ANY
+   DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+   DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE
+   GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY,
+   WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+   NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+   SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+----------------------------------------------------------------
+   Notice that the above BSD-style license applies to this one file
+   (valgrind.h) only.  The entire rest of Valgrind is licensed under
+   the terms of the GNU General Public License, version 2.  See the
+   COPYING file in the source distribution for details.
+
+--------------- SECTION 9: Mozilla Public License, V2.0 ----------
+
+Mozilla Public License, V2.0 is applicable to the following component(s).
+
+
+>>> nspr-4.21-1.ph2
+
+Copyright 2005 Sun Microsystems, Inc.  All rights reserved.
+Use is subject to license terms.
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> BSD-3
+
+nspr-4.21-1.ph2.src.rpm\nspr-4.21-1.ph2.src.cpio\nspr-4.21.tar.gz\..\stage\v4.21\src\nspr-4.21.tar\nspr-4.21\nspr\pr\src\misc\praton.c
+
+Copyright (c) 1983, 1990, 1993
+The Regents of the University of California.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions
+are met:
+1. Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+2. Redistributions in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+4. Neither the name of the University nor the names of its contributors
+may be used to endorse or promote products derived from this software
+without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE REGENTS AND CONTRIBUTORS ``AS IS'' AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ARE DISCLAIMED.  IN NO EVENT SHALL THE REGENTS OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+SUCH DAMAGE.
+
+> MIT
+
+nspr-4.21-1.ph2.src.rpm\nspr-4.21-1.ph2.src.cpio\nspr-4.21.tar.gz\..\stage\v4.21\src\nspr-4.21.tar\nspr-4.21\nspr\pr\src\misc\praton.c
+
+Portions Copyright (c) 1993 by Digital Equipment Corporation.
+
+Permission to use, copy, modify, and distribute this software for any
+purpose with or without fee is hereby granted, provided that the above
+copyright notice and this permission notice appear in all copies, and that
+the name of Digital Equipment Corporation not be used in advertising or
+publicity pertaining to distribution of the document or software without
+specific, written prior permission.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND DIGITAL EQUIPMENT CORP. DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES
+OF MERCHANTABILITY AND FITNESS.   IN NO EVENT SHALL DIGITAL EQUIPMENT
+CORPORATION BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS
+ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS
+SOFTWARE.
+
+> PublicDomain
+
+nspr-4.21-1.ph2.src.rpm\nspr-4.21-1.ph2.src.cpio\nspr-4.21.tar.gz\..\stage\v4.21\src\nspr-4.21.tar\nspr-4.21\nspr\config\nspr.m4
+
+Public domain - Chris Seawood <cls@seawood.org> 2001-04-05
+Based upon gtk.m4 (also PD) by Owen Taylor
+
+>>> nss-3.44-1.ph2
+
+This Source Code Form is subject to the terms of the Mozilla Public
+License, v. 2.0. If a copy of the MPL was not distributed with this
+file, You can obtain one at http://mozilla.org/MPL/2.0/.
+
+
+This script builds NSS with gyp and ninja.
+
+This build system is still under development.  It does not yet support all
+the features or platforms that NSS supports.
+
+ADDITIONAL LICENSE INFORMATION:
+
+> Apache2.0
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\automation\taskcluster\docker-hacl\license.txt
+
+Copyright 2016-2017 INRIA and Microsoft Corporation
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+
+> BSD-3
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\nss\cmd\libpkix\pkix_pl\module\test_socket.c
+
+Copyright 2004-2005 Sun Microsystems, Inc.  All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistribution of source code must retain the above copyright notice,
+this list of conditions and the following disclaimer.
+
+2. Redistribution in binary form must reproduce the above copyright
+notice, this list of conditions and the following disclaimer in the
+documentation and/or other materials provided with the distribution.
+
+Neither the name of Sun Microsystems, Inc. or the names of contributors may
+be used to endorse or promote products derived from this software without
+specific prior written permission.
+
+This software is provided "AS IS," without a warranty of any kind. ALL
+EXPRESS OR IMPLIED CONDITIONS, REPRESENTATIONS AND WARRANTIES, INCLUDING
+ANY IMPLIED WARRANTY OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE
+OR NON-INFRINGEMENT, ARE HEREBY EXCLUDED. SUN MICROSYSTEMS, INC. ("SUN")
+AND ITS LICENSORS SHALL NOT BE LIABLE FOR ANY DAMAGES SUFFERED BY LICENSEE
+AS A RESULT OF USING, MODIFYING OR DISTRIBUTING THIS SOFTWARE OR ITS
+DERIVATIVES. IN NO EVENT WILL SUN OR ITS LICENSORS BE LIABLE FOR ANY LOST
+REVENUE, PROFIT OR DATA, OR FOR DIRECT, INDIRECT, SPECIAL, CONSEQUENTIAL,
+INCIDENTAL OR PUNITIVE DAMAGES, HOWEVER CAUSED AND REGARDLESS OF THE THEORY
+OF LIABILITY, ARISING OUT OF THE USE OF OR INABILITY TO USE THIS SOFTWARE,
+EVEN IF SUN HAS BEEN ADVISED OF THE POSSIBILITY OF SUCH DAMAGES.
+
+> GPL2.0
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\freebl\mpi\montmulfv9.s
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE GPL2.0 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+The contents of this file are subject to the Mozilla Public
+License Version 1.1 (the "License"); you may not use this file
+except in compliance with the License. You may obtain a copy of
+the License at http://www.mozilla.org/MPL/
+Software distributed under the License is distributed on an "AS
+IS" basis, WITHOUT WARRANTY OF ANY KIND, either express or
+implied. See the License for the specific language governing
+rights and limitations under the License.
+The Original Code is SPARC optimized Montgomery multiply functions.
+The Initial Developer of the Original Code is Sun Microsystems Inc.
+Portions created by Sun Microsystems Inc. are
+Copyright (C) 1999-2000 Sun Microsystems Inc.  All Rights Reserved.
+Contributor(s):
+Netscape Communications Corporation
+Alternatively, the contents of this file may be used under the
+terms of the GNU General Public License Version 2 or later (the
+"GPL"), in which case the provisions of the GPL are applicable
+instead of those above.	If you wish to allow use of your
+version of this file only under the terms of the GPL and not to
+allow others to use your version of this file under the MPL,
+indicate your decision by deleting the provisions above and
+replace them with the notice and other provisions required by
+the GPL.  If you do not delete the provisions above, a recipient
+may use your version of this file under either the MPL or the
+GPL.
+
+> LGPL2.1
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\doc\html\derdump.html
+
+[NOTE:  VMWARE, INC. ELECTS TO USE AND DISTRIBUTE THIS SUBPACKAGE UNDER THE TERMS OF THE LGPL2.1 LICENSE, THE TEXT OF WHICH IS SET FORTH IN THE APPENDIX. THE ORIGINAL LICENSE TERMS ARE REPRODUCED BELOW ONLY AS A REFERENCE.]
+
+Licensed under the Mozilla Public License, version 1.1,
+and/or the GNU General Public License, version 2 or later,
+and/or the GNU Lesser General Public License, version 2.1 or later.
+
+> MIT
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\jar\jzlib.h
+
+Copyright (C) 1995-1996 Jean-loup Gailly and Mark Adler
+
+This software is provided 'as-is', without any express or implied
+warranty.  In no event will the authors be held liable for any damages
+arising from the use of this software.
+
+Permission is granted to anyone to use this software for any purpose,
+including commercial applications, and to alter it and redistribute it
+freely, subject to the following restrictions:
+
+1. The origin of this software must not be misrepresented; you must not
+claim that you wrote the original software. If you use this software
+in a product, an acknowledgment in the product documentation would be
+appreciated but is not required.
+2. Altered source versions must be plainly marked as such, and must not be
+misrepresented as being the original software.
+3. This notice may not be removed or altered from any source distribution.
+
+Jean-loup Gailly        Mark Adler
+gzip@prep.ai.mit.edu    madler@alumni.caltech.edu
+
+
+The data format used by the zlib library is described by RFCs (Request for
+Comments) 1950 to 1952 in the files ftp://ds.internic.net/rfc/rfc1950.txt
+(zlib format), rfc1951.txt (deflate format) and rfc1952.txt (gzip format).
+
+This file was modified since it was taken from the zlib distribution */
+
+> MIT
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\coreconf\mkdepend\ifparser.c
+
+Copyright 1992 Network Computing Devices, Inc.
+
+Permission to use, copy, modify, and distribute this software and its
+documentation for any purpose and without fee is hereby granted, provided
+that the above copyright notice appear in all copies and that both that
+copyright notice and this permission notice appear in supporting
+documentation, and that the name of Network Computing Devices may not be
+used in advertising or publicity pertaining to distribution of the software
+without specific, written prior permission.  Network Computing Devices makes
+no representations about the suitability of this software for any purpose.
+It is provided ``as is'' without express or implied warranty.
+
+NETWORK COMPUTING DEVICES DISCLAIMS ALL WARRANTIES WITH REGARD TO THIS
+SOFTWARE, INCLUDING ALL IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS,
+IN NO EVENT SHALL NETWORK COMPUTING DEVICES BE LIABLE FOR ANY SPECIAL,
+INDIRECT OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM
+LOSS OF USE, DATA OR PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE
+OR OTHER TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.
+
+> PublicDomain
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\dbm\src\dirent.h
+
+msd_dir.h 1.4 87/11/06   Public Domain.
+
+A public domain implementation of BSD directory routines for
+MS-DOS.  Written by Michael Rendell ({uunet,utai}michael@garfield),
+August 1897
+
+Extended by Peter Lim (lim@mullian.oz) to overcome some MS DOS quirks
+and returns 2 more pieces of information - file size & attribute.
+Plus a little reshuffling of some #define's positions    December 1987
+
+Some modifications by Martin Junius
+
+> RSA Data Security
+
+nss-3.44-1.ph2.src.rpm\nss-3.44-1.ph2.src.cpio\nss-3.44.tar.gz\nss-3.44.tar\nss-3.44\nss\lib\util\pkcs11p.h
+
+Copyright (C) 1994-1999 RSA Security Inc. Licence to copy this document
+is granted provided that it is identified as "RSA Security Inc. Public-Key
+Cryptography Standards (PKCS)" in all material mentioning or referencing
+this document.
+
+
 =============== APPENDIX. Standard License Files ============== 
+
 
 --------------- SECTION 1: Academic Free License, V2.1 -----------
 
@@ -57853,4 +66421,4 @@ Source Files is valid for three years from the date you acquired this
 Software product. Alternatively, the Source Files may accompany the
 VMware product.
 
-[VICPRODUCT153GASR061219]
+[VICPRODUCT153GASR062419]


### PR DESCRIPTION
Updating OSL to including the latest package update to fix the CVE-2019-11477.

