### PR TITLE
Avoid dinv checking for unused certificate files

### DIFF
--- a/dinv/main.go
+++ b/dinv/main.go
@@ -95,9 +95,6 @@ func main() {
 				"/certs/docker.key",
 				"/certs/docker.crt",
 				"/certs/ca.crt",
-				"/certs/ca-key.pem",
-				"/certs/docker-client.key",
-				"/certs/docker-client.crt",
 			}
 
 			if err := certsExist(files); err != nil {


### PR DESCRIPTION
The ca-key.pem, docker-client.crt, and docker-client.key files are
generated when no certificates are present in /certs, but are not used
by docker at runtime and do not need to be checked at startup.

VIC Appliance Checklist:
- [x] Up to date with `master` branch
- [ ] Added tests
  - There appear to be no tests for providing TLS certificates currently
- [x] Considered impact to upgrade
  - Providing the extra files will continue to work, and providing no files also works as documented. Only changes behaviour for people trying to provide ca.crt/docker.key/docker.crt on their own.
- [ ] Tests passing
  - I could not find tests, but manually verified with `/dinv`, `/dinv -tls`, `/dinv -tlsverify` with and without certificates
- [ ] Updated documentation
  - This change brings the behaviour closer to the documentation
- [ ] Impact assessment checklist
  - I think the impact assessment checklist is only for the installer, so I have not completed one

Fixes #1930