### PR TITLE
Rename shared datastore in the vic-multi-cls ruby file

### DIFF
--- a/tests/resources/nimbus-testbeds/vic-multi-cls.rb
+++ b/tests/resources/nimbus-testbeds/vic-multi-cls.rb
@@ -19,7 +19,7 @@ $testbed = Proc.new do
         "iScsi" => ["iscsi.#{idx%3+1}"],
         "clusterName" => "cls#{idx%3+1}",
         'localDatastoreNamePrefix' => "esx#{idx}-vmfs",
-        'sharedDatastoreNamePrefix' => "sharedVmfs-",
+        'sharedDatastoreNamePrefix' => "sharedVmfs#{idx}-",
       }
     end,
 


### PR DESCRIPTION
testing.
[skip ci]