### PR TITLE
Rotate log files of cron

### DIFF
--- a/installer/build/ova-manifest.json
+++ b/installer/build/ova-manifest.json
@@ -78,6 +78,11 @@
   },
   {
     "type": "file",
+    "source": "scripts/appliance/appliance-logrotate",
+    "destination": "/etc/logrotate.d/appliance"
+  },
+  {
+    "type": "file",
     "source": "scripts/harbor/harbor.service",
     "destination": "/usr/lib/systemd/system/harbor.service"
   },

--- a/installer/build/scripts/appliance/appliance-logrotate
+++ b/installer/build/scripts/appliance/appliance-logrotate
@@ -1,0 +1,7 @@
+/var/log/cron {
+    size 200M
+    rotate 5
+    compress
+    delaycompress
+    missingok
+}


### PR DESCRIPTION
Cron generate tons of logs so rotate log files whenever it reach
200M.

VIC Appliance Checklist:
- [ ] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [ ] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
