### PR TITLE
Set a tag for skipping test cases used the tag

### DIFF
--- a/tests/manual-test-cases/Group5-Interoperability-Tests/5-05-Enhanced-Linked-Mode.robot
+++ b/tests/manual-test-cases/Group5-Interoperability-Tests/5-05-Enhanced-Linked-Mode.robot
@@ -19,6 +19,7 @@ Suite Setup  Nimbus Suite Setup  Enhanced Link Mode Setup
 Suite Teardown  Run Keyword And Ignore Error  Nimbus Pod Cleanup  ${nimbus_pod}  ${testbedname}
 Test Teardown  Run Keyword If  '${TEST STATUS}' != 'PASS'  Collect Appliance and VCH Logs  ${VCH-NAME}
 Test Timeout  90 minutes
+Force Tags  vsphere70-not-support
 
 *** Keywords ***
 Enhanced Link Mode Setup


### PR DESCRIPTION
Some test cases are not supported in the vsphere7.0,
so skipping the test cases using tag.
