### PR TITLE
Update go version for building dch image

### DIFF
--- a/dinv/dch-photon-18.06/Dockerfile
+++ b/dinv/dch-photon-18.06/Dockerfile
@@ -1,5 +1,5 @@
 # Build certgen in separate container
-FROM golang:1.8 AS build-env
+FROM golang:1.11 AS build-env
 # copy the non-version specific files first so version specific can overwrite
 ADD . /go/src/dinv
 ADD ./dch-photon-18.06/* /go/src/dinv/


### PR DESCRIPTION
For go 1.8, go get dependencies pkg failed, so
update go version to 1.11 for resolving the issue.
