### PR TITLE
added missing parameter to docker run command

### DIFF
--- a/docs/user_doc/vic_vsphere_admin/volume_stores.md
+++ b/docs/user_doc/vic_vsphere_admin/volume_stores.md
@@ -82,7 +82,7 @@ ERROR op=363.7: dial tcp <i>nfs_server</i>:111: getsockopt: connection refused
 After you deploy a VCH, you can test that an NFS share point is configured correctly so that containers can access it by running the following commands:
 
 <pre>docker volume create --name test --opt VolumeStore=nfs
-docker run -it test:/mnt/test alpine /bin/ash</pre>
+docker run -it -v test:/mnt/test alpine /bin/ash</pre>
 
 You can also test the configuration mounting the NFS share point directly in the VCH endpoint VM. For information about how to perform this test, see [Install Packages in the Virtual Container Host Endpoint VM](vch_install_packages.md) and [Mount an NFS Share Point in the VCH Endpoint VM](vch_mount_nfsshare.md).
 


### PR DESCRIPTION
Sample docker run command was missing the -v (--volume) parameter on the sample code

VIC Appliance Checklist:
- [X] Up to date with `master` branch
- [ ] Added tests
- [ ] Considered impact to upgrade
- [ ] Tests passing
- [X] Updated documentation
- [ ] Impact assessment checklist

If this is a feature or change to existing functionality, consider areas of impact with the [Impact
Assessment Checklist](https://github.com/vmware/vic-product/blob/master/installer/docs/CHANGE.md)

Fixes #

<!-- If cherry picking
Cherry picks: <commit hash>
From PR: #<original PR to master>
-->
