### PR TITLE
Replace local photon repo to remote photon repo

### DIFF
--- a/installer/build/bootable/repo/photon-local.repo
+++ b/installer/build/bootable/repo/photon-local.repo
@@ -1,6 +1,6 @@
 [photon-2.0]
 name=VMware WDC Photon Linux 2.0(x86_64)
-baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon
+baseurl=https://packages.vmware.com/photon/2.0/photon_release_2.0_x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1
 enabled=1

--- a/installer/build/bootable/repo/photon-updates-local.repo
+++ b/installer/build/bootable/repo/photon-updates-local.repo
@@ -1,6 +1,6 @@
 [photon-updates-2.0]
 name=VMware WDC Photon Linux 2.0(x86_64) Updates
-baseurl=http://wdc-yum-builder-ci.eng.vmware.com/photon-updates
+baseurl=https://packages.vmware.com/photon/2.0/photon_updates_2.0_x86_64/
 gpgkey=file:///etc/pki/rpm-gpg/VMWARE-RPM-GPG-KEY
 gpgcheck=1
 enabled=1


### PR DESCRIPTION
after the remote photon repo was migrated, we do not see some latest rpm package
on the browser, so we do not download these rpm package to local photon repo,
so we have to replace local repo to remote repo.